### PR TITLE
Reset plugin version to 1.0.0.0, fix UT workflow

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
-          token: ${{ secrets.OPENSEARCH_DASHBOARDS_OSS_ACCESS }}
           path: OpenSearch-Dashboards
       - name: Get node and yarn versions
         id: versions_step

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 7.10.2
 jobs:

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 7.10.2
+  OPENSEARCH_DASHBOARDS_VERSION: main
 jobs:
   tests:
     name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/anomalyDetectionDashboards-1.13.0.0.zip`
+Example output: `./build/anomalyDetectionDashboards-1.0.0.0.zip`
 
 ## Run
 

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "1.13.0.0",
-  "opensearchDashboardsVersion": "7.10.2",
+  "version": "1.0.0.0",
+  "opensearchDashboardsVersion": "1.0.0",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "1.13.0.0",
+  "version": "1.0.0.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "opensearch_version": "1.13.0.0",
+    "opensearch_version": "1.0.0",
     "opensearch_name": "anomalyDetectionDashboards"
   },
   "scripts": {


### PR DESCRIPTION
### Description

Fixes the unit test workflow so it can successfully run against opened PRs in addition to merges to the main branch.
Updates the plugin version and OpenSearch Dashboards compatibility to 1.0.0.0 and 1.0.0, respectively.

Once OpenSearch Dashboards has versioned branches, the `main` can revert back to a version (e.g., `7.10.2` branch).

Passing workflow: see [here](https://github.com/ohltyler/anomaly-detection-dashboards-plugin-1/actions/runs/768905398)

### Issues Resolved

Partially resolves the overall workflow updates (#2)
Resolves #4 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
