### PR TITLE
Bump plugin version to 1.0.0.0-beta1

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 1.0.0-alpha2
+  OPENSEARCH_DASHBOARDS_VERSION: 1.0.0-beta1
 jobs:
   tests:
     name: Run unit tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "1.0.0.0",
-  "opensearchDashboardsVersion": "1.0.0",
+  "version": "1.0.0.0-beta1",
+  "opensearchDashboardsVersion": "1.0.0-beta1",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "1.0.0.0",
+  "version": "1.0.0.0-beta1",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "opensearch_version": "1.0.0",
-    "opensearch_name": "anomalyDetectionDashboards"
+    "plugin_version": "1.0.0.0-beta1",
+    "plugin_name": "anomalyDetectionDashboards"
   },
   "scripts": {
     "osd": "node ../../scripts/osd",
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "plugin-helpers": "node ../../scripts/plugin_helpers",
     "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_opensearch_name-$npm_package_config_opensearch_version.zip && mv ./build/$npm_package_config_opensearch_name*.zip ./build/$npm_package_config_opensearch_name-$npm_package_config_opensearch_version.zip",
+    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_name-$npm_package_config_plugin_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_name-$npm_package_config_plugin_version.zip",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "cy:run-with-security": "cypress run --env SECURITY_ENABLED=true",

--- a/release-notes/opensearch-anomaly-detection-dashboards.release-notes-1.0.0.0-beta1.md
+++ b/release-notes/opensearch-anomaly-detection-dashboards.release-notes-1.0.0.0-beta1.md
@@ -17,3 +17,6 @@ Compatible with OpenSearch Dashboards 1.0.0
 * Add DCO info in CONTRIBUTING.md, remove admins from MAINTAINERS.md ([#6](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/6))
 * Add SPDX license header to all files ([#7](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/7))
 * Update NOTICE to reflect the direct software being used ([#8](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/8))
+
+### Maintenance
+* Bump plugin version to 1.0.0.0-beta1 ([#14](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/14))


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Bumps the plugin version to `1.0.0.0-beta1` and OpenSearch Dashboards compatibility to `1.0.0-beta1`.
- All unit + integ tests pass locally
- Installed zip in `1.0.0-beta1` Dashboards binary & sanity tested

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
