### PR TITLE
[SINGLE FLOW] Add historical results tab

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -32,11 +32,12 @@ import {
   EuiIcon,
   EuiLoadingChart,
   EuiStat,
+  EuiButtonGroup,
 } from '@elastic/eui';
 import { get } from 'lodash';
 import moment from 'moment';
 import React, { useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useDelayedLoader } from '../../../hooks/useDelayedLoader';
 import {
   AnomalySummary,
@@ -45,11 +46,15 @@ import {
   Monitor,
   MonitorAlert,
 } from '../../../models/interfaces';
+import { AppState } from '../../../redux/reducers';
 import { searchAlerts } from '../../../redux/reducers/alerting';
 import { darkModeEnabled } from '../../../utils/kibanaUtils';
 import {
   filterWithDateRange,
   prepareDataForChart,
+  getAnomalyDataRangeQuery,
+  getHistoricalAggQuery,
+  parseHistoricalAggregatedAnomalies,
 } from '../../utils/anomalyResultUtils';
 import { AlertsFlyout } from '../components/AlertsFlyout/AlertsFlyout';
 import {
@@ -72,6 +77,14 @@ import {
   INITIAL_ANOMALY_SUMMARY,
 } from '../utils/constants';
 import { HeatmapCell } from './AnomalyHeatmapChart';
+import { ANOMALY_AGG, MIN_END_TIME, MAX_END_TIME } from '../../utils/constants';
+import { MAX_HISTORICAL_AGG_RESULTS } from '../../../utils/constants';
+import { searchResults } from '../../../redux/reducers/anomalyResults';
+import {
+  DAY_IN_MILLI_SECS,
+  WEEK_IN_MILLI_SECS,
+  DETECTOR_STATE,
+} from '../../../../server/utils/constants';
 
 interface AnomalyDetailsChartProps {
   onDateRangeChange(
@@ -115,13 +128,148 @@ export const AnomalyDetailsChart = React.memo(
     });
     const [zoomedAnomalies, setZoomedAnomalies] = useState<any[]>([]);
 
+    const [aggregatedAnomalies, setAggregatedAnomalies] = useState<any[]>([]);
+    const [selectedAggId, setSelectedAggId] = useState<ANOMALY_AGG>(
+      ANOMALY_AGG.RAW
+    );
+    const [disabledAggsMap, setDisabledAggsMap] = useState<
+      { [key in ANOMALY_AGG]: boolean }
+    >({
+      raw: false,
+      day: true,
+      week: true,
+      month: true,
+    });
+
     const DEFAULT_DATE_PICKER_RANGE = {
       start: moment().subtract(7, 'days').valueOf(),
       end: moment().valueOf(),
     };
 
+    const taskId = get(props, 'detector.taskId');
+    const taskState = get(props, 'detector.taskState');
+
+    const isRequestingAnomalyResults = useSelector(
+      (state: AppState) => state.anomalyResults.requesting
+    );
+
+    const getAggregatedAnomalies = async () => {
+      const anomalyDataRangeQuery = getAnomalyDataRangeQuery(
+        zoomRange.startDate,
+        zoomRange.endDate,
+        taskId
+      );
+      dispatch(searchResults(anomalyDataRangeQuery))
+        .then((response: any) => {
+          // Only retrieve buckets that are in the anomaly results range. This is so
+          // we don't show aggregate results for where there is no data at all
+          const dataStartDate = get(
+            response,
+            `response.aggregations.${MIN_END_TIME}.value`
+          );
+          const dataEndDate = get(
+            response,
+            `response.aggregations.${MAX_END_TIME}.value`
+          );
+
+          const historicalAggQuery = getHistoricalAggQuery(
+            dataStartDate,
+            dataEndDate,
+            taskId,
+            selectedAggId
+          );
+          dispatch(searchResults(historicalAggQuery))
+            .then((response: any) => {
+              const aggregatedAnomalies = parseHistoricalAggregatedAnomalies(
+                response,
+                selectedAggId
+              );
+              setAggregatedAnomalies(aggregatedAnomalies);
+            })
+            .catch((e: any) => {
+              console.error(
+                `Error getting aggregated anomaly results for detector ${props.detector?.id}: `,
+                e
+              );
+            });
+        })
+        .catch((e: any) => {
+          console.error(
+            `Error getting aggregated anomaly results for detector ${props.detector?.id}: `,
+            e
+          );
+        });
+    };
+
     useEffect(() => {
-      const anomalies = prepareDataForChart(props.anomalies, zoomRange);
+      setZoomRange(props.dateRange);
+    }, [props.dateRange]);
+
+    // Hook to check if any of the aggregation tabs should be disabled or not.
+    // Currently support up to 10k results, which = 10k day/week/month aggregate results
+    useEffect(() => {
+      if (props.isHistorical) {
+        const anomalyDataRangeQuery = getAnomalyDataRangeQuery(
+          zoomRange.startDate,
+          zoomRange.endDate,
+          taskId
+        );
+        dispatch(searchResults(anomalyDataRangeQuery))
+          .then((response: any) => {
+            const dataStartDate = get(
+              response,
+              `response.aggregations.${MIN_END_TIME}.value`
+            );
+            const dataEndDate = get(
+              response,
+              `response.aggregations.${MAX_END_TIME}.value`
+            );
+
+            // Note that the monthly interval is approximate. 365 / 12 = 30.41 days, rounded up to 31 means
+            // there will be <= 10k monthly-aggregate buckets
+            const numDailyBuckets =
+              (dataEndDate - dataStartDate) / DAY_IN_MILLI_SECS;
+            const numWeeklyBuckets =
+              (dataEndDate - dataStartDate) / WEEK_IN_MILLI_SECS;
+            const numMonthlyBuckets =
+              (dataEndDate - dataStartDate) / (31 * DAY_IN_MILLI_SECS);
+            const newAggId =
+              (numDailyBuckets > MAX_HISTORICAL_AGG_RESULTS &&
+                selectedAggId === ANOMALY_AGG.DAILY) ||
+              (numWeeklyBuckets > MAX_HISTORICAL_AGG_RESULTS &&
+                selectedAggId === ANOMALY_AGG.WEEKLY) ||
+              (numMonthlyBuckets > MAX_HISTORICAL_AGG_RESULTS &&
+                selectedAggId === ANOMALY_AGG.MONTHLY)
+                ? ANOMALY_AGG.RAW
+                : (selectedAggId as ANOMALY_AGG);
+            setSelectedAggId(newAggId);
+            setDisabledAggsMap({
+              raw: false,
+              day: numDailyBuckets > MAX_HISTORICAL_AGG_RESULTS,
+              week: numWeeklyBuckets > MAX_HISTORICAL_AGG_RESULTS,
+              month: numMonthlyBuckets > MAX_HISTORICAL_AGG_RESULTS,
+            });
+          })
+          .catch((e: any) => {
+            console.error(
+              `Error getting aggregated anomaly results for detector ${props.detector?.id}: `,
+              e
+            );
+          });
+      }
+    }, [zoomRange]);
+
+    useEffect(() => {
+      if (selectedAggId !== ANOMALY_AGG.RAW) {
+        getAggregatedAnomalies();
+      }
+    }, [selectedAggId, zoomRange, props.anomalies]);
+
+    useEffect(() => {
+      const anomalies =
+        selectedAggId === ANOMALY_AGG.RAW
+          ? prepareDataForChart(props.anomalies, zoomRange)
+          : aggregatedAnomalies;
       setZoomedAnomalies(anomalies);
       setAnomalySummary(
         !props.bucketizedAnomalies
@@ -133,11 +281,7 @@ export const AnomalyDetailsChart = React.memo(
       setTotalAlerts(
         filterWithDateRange(alerts, zoomRange, 'startTime').length
       );
-    }, [props.anomalies, zoomRange, props.dateRange]);
-
-    useEffect(() => {
-      setZoomRange(props.dateRange);
-    }, [props.dateRange]);
+    }, [props.anomalies, zoomRange, aggregatedAnomalies, selectedAggId]);
 
     const handleZoomRangeChange = (start: number, end: number) => {
       setZoomRange({
@@ -193,8 +337,12 @@ export const AnomalyDetailsChart = React.memo(
       handleZoomRangeChange(startDate, endDate);
     };
 
-    const isLoading = props.isLoading || isLoadingAlerts;
+    const isLoading =
+      props.isLoading || isLoadingAlerts || isRequestingAnomalyResults;
+    const isInitializingHistorical = taskState === DETECTOR_STATE.INIT;
     const showLoader = useDelayedLoader(isLoading);
+    const showAggregateResults =
+      props.isHistorical && selectedAggId !== ANOMALY_AGG.RAW;
 
     return (
       <React.Fragment>
@@ -206,18 +354,17 @@ export const AnomalyDetailsChart = React.memo(
               titleSize="s"
             />
           </EuiFlexItem>
-          <EuiFlexItem>
-            <AnomalyStatWithTooltip
-              isLoading={isLoading}
-              minValue={anomalySummary.minAnomalyGrade}
-              maxValue={anomalySummary.maxAnomalyGrade}
-              description={getAnomalyGradeWording(props.isNotSample)}
-              tooltip="Indicates the extent to which a data point is anomalous. Higher grades indicate more unusual data."
-            />
-          </EuiFlexItem>
-          {
-            // If historical: only show the average grade, and don't show the confidence or last anomaly occurrence stats
-          }
+          {props.isHistorical ? null : (
+            <EuiFlexItem>
+              <AnomalyStatWithTooltip
+                isLoading={isLoading}
+                minValue={anomalySummary.minAnomalyGrade}
+                maxValue={anomalySummary.maxAnomalyGrade}
+                description={getAnomalyGradeWording(props.isNotSample)}
+                tooltip="Indicates the extent to which a data point is anomalous. Higher grades indicate more unusual data."
+              />
+            </EuiFlexItem>
+          )}
           {props.isHistorical ? (
             <EuiFlexItem>
               <EuiStat
@@ -257,7 +404,56 @@ export const AnomalyDetailsChart = React.memo(
               />
             </EuiFlexItem>
           ) : null}
+          {props.isHistorical && !props.isHCDetector ? (
+            <EuiFlexItem
+              grow={false}
+              style={{ width: '450px', marginRight: '4px' }}
+            >
+              <EuiButtonGroup
+                type="single"
+                legend="Aggregation button group"
+                buttonSize="compressed"
+                isFullWidth
+                options={[
+                  {
+                    id: ANOMALY_AGG.RAW,
+                    label: 'Raw',
+                    isDisabled: disabledAggsMap['raw'] || isLoading,
+                  },
+                  {
+                    id: ANOMALY_AGG.DAILY,
+                    label: 'Daily max',
+                    isDisabled:
+                      disabledAggsMap['day'] ||
+                      isLoading ||
+                      isInitializingHistorical,
+                  },
+                  {
+                    id: ANOMALY_AGG.WEEKLY,
+                    label: 'Weekly max',
+                    isDisabled:
+                      disabledAggsMap['week'] ||
+                      isLoading ||
+                      isInitializingHistorical,
+                  },
+                  {
+                    id: ANOMALY_AGG.MONTHLY,
+                    label: 'Monthly max',
+                    isDisabled:
+                      disabledAggsMap['month'] ||
+                      isLoading ||
+                      isInitializingHistorical,
+                  },
+                ]}
+                idSelected={selectedAggId}
+                onChange={(aggId) => {
+                  setSelectedAggId(aggId as ANOMALY_AGG);
+                }}
+              />
+            </EuiFlexItem>
+          ) : null}
         </EuiFlexGroup>
+
         <EuiFlexGroup>
           <EuiFlexItem grow={true}>
             <div
@@ -333,14 +529,23 @@ export const AnomalyDetailsChart = React.memo(
                       marker={<EuiIcon type="bell" />}
                     />
                   ) : null}
-                  <Axis
-                    id="bottom"
-                    position="bottom"
-                    tickFormat={anomalyChartTimeFormatter}
-                  />
+                  {showAggregateResults ? (
+                    <Axis id="bottom" position="bottom" />
+                  ) : (
+                    <Axis
+                      id="bottom"
+                      position="bottom"
+                      tickFormat={anomalyChartTimeFormatter}
+                    />
+                  )}
+
                   <Axis
                     id="left"
-                    title={'Anomaly grade / confidence'}
+                    title={
+                      props.isHistorical
+                        ? 'Anomaly grade'
+                        : 'Anomaly grade / Confidence'
+                    }
                     position="left"
                     domain={{ min: 0, max: 1 }}
                     showGridLines
@@ -361,11 +566,18 @@ export const AnomalyDetailsChart = React.memo(
                   )}
                   <LineSeries
                     id="anomalyGrade"
+                    color={'red'}
                     name={props.anomalyGradeSeriesName}
                     data={zoomedAnomalies}
-                    xScaleType={ScaleType.Time}
+                    xScaleType={
+                      showAggregateResults ? ScaleType.Ordinal : ScaleType.Time
+                    }
                     yScaleType={ScaleType.Linear}
-                    xAccessor={CHART_FIELDS.PLOT_TIME}
+                    xAccessor={
+                      showAggregateResults
+                        ? CHART_FIELDS.AGG_INTERVAL
+                        : CHART_FIELDS.PLOT_TIME
+                    }
                     yAccessors={[CHART_FIELDS.ANOMALY_GRADE]}
                   />
                 </Chart>

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -1,15 +1,4 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
- */
-
-/*
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -59,7 +48,7 @@ import {
 } from '../../../models/interfaces';
 import { AppState } from '../../../redux/reducers';
 import { searchAlerts } from '../../../redux/reducers/alerting';
-import { darkModeEnabled } from '../../../utils/opensearchDashboardsUtils';
+import { darkModeEnabled } from '../../../utils/kibanaUtils';
 import {
   filterWithDateRange,
   prepareDataForChart,

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -1,4 +1,15 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
  * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
@@ -48,7 +59,7 @@ import {
 } from '../../../models/interfaces';
 import { AppState } from '../../../redux/reducers';
 import { searchAlerts } from '../../../redux/reducers/alerting';
-import { darkModeEnabled } from '../../../utils/kibanaUtils';
+import { darkModeEnabled } from '../../../utils/opensearchDashboardsUtils';
 import {
   filterWithDateRange,
   prepareDataForChart,
@@ -266,6 +277,9 @@ export const AnomalyDetailsChart = React.memo(
     }, [selectedAggId, zoomRange, props.anomalies]);
 
     useEffect(() => {
+      // Aggregated anomalies are already formatted differently
+      // in parseHistoricalAggregatedAnomalies(). Only raw anomalies
+      // are formatted with prepareDataForChart().
       const anomalies =
         selectedAggId === ANOMALY_AGG.RAW
           ? prepareDataForChart(props.anomalies, zoomRange)

--- a/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/EmptyHistoricalDetectorResults.tsx
+++ b/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/EmptyHistoricalDetectorResults.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiEmptyPrompt,
+  EuiLink,
+  EuiIcon,
+  EuiButton,
+  EuiOverlayMask,
+} from '@elastic/eui';
+import React, { Fragment, useState } from 'react';
+import { Detector } from '../../../../models/interfaces';
+import { HistoricalRangeModal } from '../HistoricalRangeModal';
+
+interface EmptyHistoricalDetectorResultsProps {
+  detector: Detector;
+  onConfirm(startTime: number, endTime: number): void;
+}
+
+export const EmptyHistoricalDetectorResults = (
+  props: EmptyHistoricalDetectorResultsProps
+) => {
+  const [historicalRangeModalOpen, setHistoricalRangeModalOpen] = useState<
+    boolean
+  >(false);
+  return (
+    <EuiEmptyPrompt
+      title={<h2>You haven't yet set up historical analysis</h2>}
+      body={
+        <Fragment>
+          {historicalRangeModalOpen ? (
+            <EuiOverlayMask>
+              <HistoricalRangeModal
+                detector={props.detector}
+                onClose={() => setHistoricalRangeModalOpen(false)}
+                onConfirm={props.onConfirm}
+                isEdit={false}
+              />
+            </EuiOverlayMask>
+          ) : null}
+          <p>
+            Historical analysis lets you apply anomaly detection models over
+            long historical data windows (weeks or months). You can identify
+            anomaly patterns, seasonality, and trends.{' '}
+            <EuiLink
+              href="https://opendistro.github.io/for-elasticsearch-docs/docs/ad/#step-6-analyze-historical-data"
+              target="_blank"
+            >
+              Learn more &nbsp;
+              <EuiIcon size="s" type="popout" />
+            </EuiLink>{' '}
+          </p>
+        </Fragment>
+      }
+      actions={
+        <EuiButton
+          fill={true}
+          onClick={() => {
+            setHistoricalRangeModalOpen(true);
+          }}
+        >
+          Run historical analysis
+        </EuiButton>
+      }
+    />
+  );
+};

--- a/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/index.ts
+++ b/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { EmptyHistoricalDetectorResults } from './EmptyHistoricalDetectorResults';
+
+export { EmptyHistoricalDetectorResults };

--- a/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
@@ -80,10 +80,7 @@ export const HistoricalDetectorCallout = (
               <EuiFlexGroup direction="row" gutterSize="xs">
                 <EuiLoadingSpinner size="l" style={{ marginRight: '8px' }} />
                 <EuiText>
-                  <p>
-                    Initializing the historical detector. This will only take a
-                    few seconds.
-                  </p>
+                  <p>Initializing the historical detector.</p>
                 </EuiText>
               </EuiFlexGroup>
             </div>

--- a/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiFlexItem,
+  EuiProgress,
+  EuiButton,
+  EuiSpacer,
+} from '@elastic/eui';
+import React from 'react';
+import { Detector } from '../../../../models/interfaces';
+import { DETECTOR_STATE } from '../../../../../server/utils/constants';
+
+interface HistoricalDetectorCalloutProps {
+  detector: Detector;
+  onStopDetector(): void;
+  isStoppingDetector: boolean;
+}
+
+export const HistoricalDetectorCallout = (
+  props: HistoricalDetectorCalloutProps
+) => {
+  if (!props.detector || !props.detector.taskState) {
+    return null;
+  }
+  const runningProgress = props.detector.taskProgress
+    ? Math.round(props.detector.taskProgress * 100)
+    : undefined;
+  const runningProgressPctStr = runningProgress
+    ? runningProgress.toString() + '%'
+    : '';
+
+  if (props.isStoppingDetector) {
+    return (
+      <EuiCallOut
+        title={
+          <div>
+            <EuiFlexGroup direction="row" gutterSize="xs">
+              <EuiLoadingSpinner size="l" style={{ marginRight: '8px' }} />
+              <EuiText>
+                <p>Stopping the historical detector</p>
+              </EuiText>
+            </EuiFlexGroup>
+          </div>
+        }
+        color="primary"
+      />
+    );
+  }
+  switch (props.detector.taskState) {
+    case DETECTOR_STATE.DISABLED:
+      return (
+        <EuiCallOut
+          title="The historical detector is stopped"
+          color="primary"
+          iconType="alert"
+        />
+      );
+    case DETECTOR_STATE.INIT:
+      return (
+        <EuiCallOut
+          title={
+            <div>
+              <EuiFlexGroup direction="row" gutterSize="xs">
+                <EuiLoadingSpinner size="l" style={{ marginRight: '8px' }} />
+                <EuiText>
+                  <p>
+                    Initializing the historical detector. This will only take a
+                    few seconds.
+                  </p>
+                </EuiText>
+              </EuiFlexGroup>
+            </div>
+          }
+          color="primary"
+        />
+      );
+    case DETECTOR_STATE.RUNNING:
+      return (
+        <EuiCallOut
+          title={
+            <div>
+              <EuiFlexGroup direction="row" gutterSize="xs">
+                <EuiLoadingSpinner
+                  size="m"
+                  style={{ marginRight: '8px', marginTop: '4px' }}
+                />
+                <EuiText>
+                  <p>Running the historical detector</p>
+                </EuiText>
+              </EuiFlexGroup>
+              {runningProgress ? (
+                <EuiFlexGroup
+                  direction="row"
+                  gutterSize="xs"
+                  alignItems="center"
+                  style={{ marginTop: '6px', marginLeft: '20px' }}
+                >
+                  <EuiFlexItem>
+                    <EuiText>{runningProgressPctStr}</EuiText>
+                  </EuiFlexItem>
+                  <EuiFlexItem style={{ marginLeft: '-150px' }}>
+                    <EuiProgress
+                      //@ts-ignore
+                      value={runningProgress}
+                      max={100}
+                      color="primary"
+                      size="s"
+                    />
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              ) : null}
+              <EuiSpacer size="s" />
+              <EuiFlexItem grow={false} style={{ marginLeft: '22px' }}>
+                <EuiButton fill={false} onClick={() => props.onStopDetector()}>
+                  Stop historical detector
+                </EuiButton>
+              </EuiFlexItem>
+            </div>
+          }
+          color="primary"
+        />
+      );
+    case DETECTOR_STATE.FAILED:
+      return (
+        <EuiCallOut
+          title={<EuiText>{props.detector.taskError}</EuiText>}
+          iconType="alert"
+          color="danger"
+        ></EuiCallOut>
+      );
+    case DETECTOR_STATE.UNEXPECTED_FAILURE:
+      return (
+        <EuiCallOut
+          title={
+            <EuiText>
+              The historical detector has failed unexpectedly. Try restarting
+              the detector.
+            </EuiText>
+          }
+          iconType="alert"
+          color="danger"
+        ></EuiCallOut>
+      );
+    default:
+      return null;
+  }
+};

--- a/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/index.ts
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { HistoricalDetectorCallout } from './HistoricalDetectorCallout';
+
+export { HistoricalDetectorCallout };

--- a/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
@@ -15,15 +15,11 @@
 
 import React, { useState } from 'react';
 import {
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiModal,
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiModalBody,
-  EuiSpacer,
-  EuiText,
   EuiButtonEmpty,
   EuiButton,
   EuiSuperDatePicker,
@@ -72,7 +68,7 @@ export const HistoricalRangeModal = (props: HistoricalRangeModalProps) => {
             commonlyUsedRanges={HISTORICAL_DATE_RANGE_COMMON_OPTIONS}
             start={startTime}
             end={endTime}
-            onTimeChange={({ start, end, isInvalid, isQuickSelection }) => {
+            onTimeChange={({ start, end }) => {
               setStartTime(start);
               setEndTime(end);
             }}

--- a/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiSpacer,
+  EuiText,
+  EuiButtonEmpty,
+  EuiButton,
+  EuiSuperDatePicker,
+} from '@elastic/eui';
+import { get } from 'lodash';
+import { Detector } from '../../../../models/interfaces';
+import {
+  convertTimestampToString,
+  convertTimestampToNumber,
+} from '../../../../utils/utils';
+import { HISTORICAL_DATE_RANGE_COMMON_OPTIONS } from '../../../DetectorJobs/utils/constants';
+import { FormattedFormRow } from '../../../../components/FormattedFormRow/FormattedFormRow';
+
+interface HistoricalRangeModalProps {
+  detector: Detector;
+  onClose(): void;
+  onConfirm(startTime: number, endTime: number): void;
+  isEdit: boolean;
+}
+
+export const HistoricalRangeModal = (props: HistoricalRangeModalProps) => {
+  const [startTime, setStartTime] = useState<string>(
+    convertTimestampToString(
+      get(props, 'detector.detectionDateRange.startTime', 'now-30d')
+    )
+  );
+  const [endTime, setEndTime] = useState<string>(
+    convertTimestampToString(
+      get(props, 'detector.detectionDateRange.endTime', 'now')
+    )
+  );
+  return (
+    <EuiModal onClose={props.onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {props.isEdit
+            ? 'Modify historical analysis'
+            : 'Set up historical analysis'}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        <FormattedFormRow title="Select a date range">
+          <EuiSuperDatePicker
+            isPaused={true}
+            showUpdateButton={false}
+            commonlyUsedRanges={HISTORICAL_DATE_RANGE_COMMON_OPTIONS}
+            start={startTime}
+            end={endTime}
+            onTimeChange={({ start, end, isInvalid, isQuickSelection }) => {
+              setStartTime(start);
+              setEndTime(end);
+            }}
+          />
+        </FormattedFormRow>
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty data-test-subj="cancelButton" onClick={props.onClose}>
+          Cancel
+        </EuiButtonEmpty>
+
+        <EuiButton
+          data-test-subj="confirmButton"
+          fill
+          onClick={() => {
+            props.onConfirm(
+              //@ts-ignore
+              convertTimestampToNumber(startTime),
+              convertTimestampToNumber(endTime)
+            );
+          }}
+        >
+          Run historical analysis
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/index.ts
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { HistoricalRangeModal } from './HistoricalRangeModal';
+
+export { HistoricalRangeModal };

--- a/public/pages/HistoricalDetectorResults/containers/HistoricalDetectorResults.tsx
+++ b/public/pages/HistoricalDetectorResults/containers/HistoricalDetectorResults.tsx
@@ -19,10 +19,8 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiText,
   EuiTitle,
   EuiLoadingSpinner,
-  EuiIcon,
   EuiButtonEmpty,
   EuiOverlayMask,
   EuiBadge,
@@ -156,14 +154,11 @@ export function HistoricalDetectorResults(
           );
         }
       });
-
-      // if (listener) listener.onSuccess();
     } catch (err) {
       core.notifications.toasts.addDanger(
         `There was a problem stopping the historical detector: ` +
           prettifyErrorMessage(getErrorMessage(err, ''))
       );
-      // if (listener) listener.onException();
       fetchDetector();
     } finally {
       setIsStoppingDetector(false);

--- a/public/pages/HistoricalDetectorResults/containers/HistoricalDetectorResults.tsx
+++ b/public/pages/HistoricalDetectorResults/containers/HistoricalDetectorResults.tsx
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {
+  EuiPage,
+  EuiPageBody,
+  EuiSpacer,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  EuiTitle,
+  EuiLoadingSpinner,
+  EuiIcon,
+  EuiButtonEmpty,
+  EuiOverlayMask,
+  EuiBadge,
+} from '@elastic/eui';
+import { get, isEmpty } from 'lodash';
+import React, { useEffect, Fragment, useState } from 'react';
+import { RouteComponentProps } from 'react-router';
+import { useSelector, useDispatch } from 'react-redux';
+import { darkModeEnabled } from '../../../utils/opensearchDashboardsUtils';
+import { AppState } from '../../../redux/reducers';
+import {
+  getDetector,
+  startHistoricalDetector,
+  stopHistoricalDetector,
+} from '../../../redux/reducers/ad';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
+import { getDetectorStateDetails } from '../../DetectorDetail/utils/helpers';
+import { HistoricalRangeModal } from '../components/HistoricalRangeModal';
+import {
+  HISTORICAL_DETECTOR_RESULT_REFRESH_RATE,
+  HISTORICAL_DETECTOR_STOP_THRESHOLD,
+} from '../utils/constants';
+import { CoreStart } from '../../../../../../src/core/public';
+import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
+import { AnomalyHistory } from '../../DetectorResults/containers/AnomalyHistory';
+import {
+  getHistoricalRangeString,
+  getErrorMessage,
+} from '../../../utils/utils';
+import { prettifyErrorMessage } from '../../../../server/utils/helpers';
+import { EmptyHistoricalDetectorResults } from '../components/EmptyHistoricalDetectorResults';
+import { HistoricalDetectorCallout } from '../components/HistoricalDetectorCallout';
+
+interface HistoricalDetectorResultsProps extends RouteComponentProps {
+  detectorId: string;
+}
+
+export function HistoricalDetectorResults(
+  props: HistoricalDetectorResultsProps
+) {
+  const core = React.useContext(CoreServicesContext) as CoreStart;
+  const isDark = darkModeEnabled();
+  const dispatch = useDispatch();
+  const detectorId: string = get(props, 'match.params.detectorId', '');
+
+  const adState = useSelector((state: AppState) => state.ad);
+  const allDetectors = adState.detectors;
+  const errorGettingDetectors = adState.errorMessage;
+  const detector = allDetectors[detectorId];
+  const [taskId, setTaskId] = useState<string>(get(detector, 'taskId', ''));
+
+  const [isStoppingDetector, setIsStoppingDetector] = useState<boolean>(false);
+
+  const [historicalRangeModalOpen, setHistoricalRangeModalOpen] = useState<
+    boolean
+  >(false);
+
+  const isHCDetector = !isEmpty(get(detector, 'categoryField', []));
+  const historicalEnabled = !isEmpty(get(detector, 'detectionDateRange'));
+
+  const waitForMs = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+  const fetchDetector = async () => {
+    try {
+      await dispatch(getDetector(detectorId));
+    } catch {}
+  };
+
+  // Try to get the detector initially
+  useEffect(() => {
+    if (detectorId) {
+      fetchDetector();
+    }
+  }, []);
+
+  // If detector is initializing or running: keep fetching every 10 seconds to quickly update state/results/percentage bar, etc.
+  useEffect(() => {
+    if (
+      detector?.taskState === DETECTOR_STATE.RUNNING ||
+      detector?.taskState === DETECTOR_STATE.INIT
+    ) {
+      const intervalId = setInterval(
+        fetchDetector,
+        HISTORICAL_DETECTOR_RESULT_REFRESH_RATE
+      );
+      return () => {
+        clearInterval(intervalId);
+      };
+    }
+    setTaskId(get(detector, 'taskId', ''));
+  }, [detector]);
+
+  const startHistoricalTask = async (startTime: number, endTime: number) => {
+    try {
+      dispatch(startHistoricalDetector(props.detectorId, startTime, endTime))
+        .then((response: any) => {
+          setTaskId(get(response, 'response._id'));
+          core.notifications.toasts.addSuccess(
+            `Successfully started the historical detector`
+          );
+        })
+        .catch((err: any) => {
+          core.notifications.toasts.addDanger(
+            prettifyErrorMessage(
+              getErrorMessage(
+                err,
+                'There was a problem starting the historical detector'
+              )
+            )
+          );
+        });
+    } finally {
+      setHistoricalRangeModalOpen(false);
+    }
+  };
+
+  // We query the task state 5s after making the stop detector call. If the task is still running,
+  // then it is assumed there was an error stopping this task / historical detector.
+  // TODO: change this from await dispatch() to using .then(), .catch(), etc.
+  const onStopDetector = async () => {
+    try {
+      setIsStoppingDetector(true);
+      await dispatch(stopHistoricalDetector(detectorId));
+      await waitForMs(HISTORICAL_DETECTOR_STOP_THRESHOLD);
+      dispatch(getDetector(detectorId)).then((response: any) => {
+        if (get(response, 'response.curState') !== DETECTOR_STATE.DISABLED) {
+          throw 'please try again.';
+        } else {
+          core.notifications.toasts.addSuccess(
+            'Successfully stopped the historical detector'
+          );
+        }
+      });
+
+      // if (listener) listener.onSuccess();
+    } catch (err) {
+      core.notifications.toasts.addDanger(
+        `There was a problem stopping the historical detector: ` +
+          prettifyErrorMessage(getErrorMessage(err, ''))
+      );
+      // if (listener) listener.onException();
+      fetchDetector();
+    } finally {
+      setIsStoppingDetector(false);
+    }
+  };
+
+  const callout = (
+    <HistoricalDetectorCallout
+      detector={detector}
+      onStopDetector={onStopDetector}
+      isStoppingDetector={isStoppingDetector}
+    />
+  );
+
+  return (
+    <Fragment>
+      <EuiPage style={{ marginTop: '16px', paddingTop: '0px' }}>
+        <EuiPageBody>
+          <EuiSpacer size="l" />
+          {!isEmpty(detector) && !historicalEnabled ? (
+            <EmptyHistoricalDetectorResults
+              detector={detector}
+              onConfirm={startHistoricalTask}
+            />
+          ) : !isEmpty(detector) ? (
+            <Fragment>
+              {historicalRangeModalOpen ? (
+                <EuiOverlayMask>
+                  <HistoricalRangeModal
+                    detector={detector}
+                    onClose={() => setHistoricalRangeModalOpen(false)}
+                    onConfirm={startHistoricalTask}
+                    isEdit={true}
+                  />
+                </EuiOverlayMask>
+              ) : null}
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <EuiTitle size="m">
+                    <div>
+                      {'Historical analysis'}&nbsp;
+                      {getDetectorStateDetails(
+                        detector,
+                        isHCDetector,
+                        true,
+                        isStoppingDetector
+                      )}
+                    </div>
+                  </EuiTitle>
+                </EuiFlexItem>
+                <EuiFlexGroup direction="row" gutterSize="xs">
+                  <EuiFlexItem grow={false} style={{ marginLeft: '16px' }}>
+                    <EuiBadge
+                      iconType="calendar"
+                      iconSide="left"
+                      color="#D4DAE5"
+                    >
+                      {getHistoricalRangeString(detector)}
+                    </EuiBadge>
+                  </EuiFlexItem>
+                  <EuiFlexItem grow={false} style={{ marginTop: '0px' }}>
+                    <EuiButtonEmpty
+                      iconType="gear"
+                      iconSide="left"
+                      size="xs"
+                      onClick={() => {
+                        setHistoricalRangeModalOpen(true);
+                      }}
+                    >
+                      Modify historical analysis range
+                    </EuiButtonEmpty>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+                {!isEmpty(callout) ? (
+                  <div>
+                    <EuiSpacer size="m" />
+                    <EuiFlexItem
+                      grow={false}
+                      style={{
+                        marginLeft: '12px',
+                        marginRight: '12px',
+                      }}
+                    >
+                      {callout}
+                    </EuiFlexItem>
+                    <EuiSpacer size="xs" />
+                  </div>
+                ) : null}
+                <EuiFlexItem>
+                  {
+                    // Setting the key as the current task ID. If the key changes (new task created),
+                    // React will remount the component, clearing any locally saved state.
+                  }
+                  <AnomalyHistory
+                    key={taskId}
+                    detector={detector}
+                    monitor={undefined}
+                    isFeatureDataMissing={false}
+                    isHistorical={true}
+                    taskId={taskId}
+                    isNotSample={true}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </Fragment>
+          ) : (
+            <EuiLoadingSpinner size="xl" />
+          )}
+        </EuiPageBody>
+      </EuiPage>
+    </Fragment>
+  );
+}

--- a/public/pages/HistoricalDetectorResults/utils/constants.tsx
+++ b/public/pages/HistoricalDetectorResults/utils/constants.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// Current backend implementation: limited to running model on 1000 intervals every 5s.
+// Frontend should refresh at some rate > than this, to auto-refresh and show partial results.
+export const HISTORICAL_DETECTOR_RESULT_REFRESH_RATE = 10000;
+
+// Current backend implementation will handle stopping a historical detector task asynchronously. It is assumed
+// that if the task is not in a stopped state after 5s, then there was a problem stopping.
+export const HISTORICAL_DETECTOR_STOP_THRESHOLD = 5000;

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -29,7 +29,10 @@ import {
   ENTITY_VALUE_PATH_FIELD,
   KEY_FIELD,
   MIN_IN_MILLI_SECS,
+  HOUR_IN_MILLI_SECS,
+  DAY_IN_MILLI_SECS,
   SORT_DIRECTION,
+  WEEK_IN_MILLI_SECS,
 } from '../../../server/utils/constants';
 import { toFixedNumberForAnomaly } from '../../../server/utils/helpers';
 import {
@@ -57,6 +60,10 @@ import {
   TOP_ANOMALY_GRADE_SORT_AGGS,
   TOP_ENTITIES_FIELD,
   TOP_ENTITY_AGGS,
+  ANOMALY_AGG,
+  AGGREGATED_ANOMALIES,
+  MIN_END_TIME,
+  MAX_END_TIME,
 } from './constants';
 import { dateFormatter, minuteDateFormatter } from './helpers';
 
@@ -296,7 +303,7 @@ export const getAnomalySummaryQuery = (
 ) => {
   const termField =
     isHistorical && taskId ? { task_id: taskId } : { detector_id: detectorId };
-  return {
+  const requestBody = {
     size: MAX_ANOMALIES,
     query: {
       bool: {
@@ -391,6 +398,21 @@ export const getAnomalySummaryQuery = (
       includes: RETURNED_AD_RESULT_FIELDS,
     },
   };
+
+  if (!isHistorical) {
+    requestBody.query.bool = {
+      ...requestBody.query.bool,
+      ...{
+        must_not: {
+          exists: {
+            field: 'task_id',
+          },
+        },
+      },
+    };
+  }
+
+  return requestBody;
 };
 
 export const getBucketizedAnomalyResultsQuery = (
@@ -406,7 +428,7 @@ export const getBucketizedAnomalyResultsQuery = (
   const fixedInterval = Math.ceil(
     (endTime - startTime) / (MIN_IN_MILLI_SECS * MAX_DATA_POINTS)
   );
-  return {
+  const requestBody = {
     size: 0,
     query: {
       bool: {
@@ -479,6 +501,21 @@ export const getBucketizedAnomalyResultsQuery = (
       },
     },
   };
+
+  if (!isHistorical) {
+    requestBody.query.bool = {
+      ...requestBody.query.bool,
+      ...{
+        must_not: {
+          exists: {
+            field: 'task_id',
+          },
+        },
+      },
+    };
+  }
+
+  return requestBody;
 };
 
 export const parseBucketizedAnomalyResults = (result: any): Anomalies => {
@@ -943,9 +980,14 @@ export const getTopAnomalousEntitiesQuery = (
   endTime: number,
   detectorId: string,
   size: number,
-  sortType: AnomalyHeatmapSortType
+  sortType: AnomalyHeatmapSortType,
+  isHistorical?: boolean,
+  taskId?: string
 ) => {
-  return {
+  const termField =
+    isHistorical && taskId ? { task_id: taskId } : { detector_id: detectorId };
+
+  const requestBody = {
     size: 0,
     query: {
       bool: {
@@ -966,9 +1008,7 @@ export const getTopAnomalousEntitiesQuery = (
             },
           },
           {
-            term: {
-              detector_id: detectorId,
-            },
+            term: termField,
           },
         ],
       },
@@ -1023,6 +1063,21 @@ export const getTopAnomalousEntitiesQuery = (
       },
     },
   };
+
+  if (!isHistorical) {
+    requestBody.query.bool = {
+      ...requestBody.query.bool,
+      ...{
+        must_not: {
+          exists: {
+            field: 'task_id',
+          },
+        },
+      },
+    };
+  }
+
+  return requestBody;
 };
 
 export const parseTopEntityAnomalySummaryResults = (
@@ -1064,8 +1119,12 @@ export const getEntityAnomalySummariesQuery = (
   detectorId: string,
   size: number,
   categoryField: string,
-  entityValue: string
+  entityValue: string,
+  isHistorical?: boolean,
+  taskId?: string
 ) => {
+  const termField =
+    isHistorical && taskId ? { task_id: taskId } : { detector_id: detectorId };
   const fixedInterval = Math.max(
     Math.ceil((endTime - startTime) / (size * MIN_IN_MILLI_SECS)),
     1
@@ -1076,7 +1135,7 @@ export const getEntityAnomalySummariesQuery = (
   // if startTime is not divisible by fixedInterval, there will be remainder,
   // this can be offset for bucket_key
   const offsetInMillisec = startTime % (fixedInterval * MIN_IN_MILLI_SECS);
-  return {
+  const requestBody = {
     size: 0,
     query: {
       bool: {
@@ -1097,9 +1156,7 @@ export const getEntityAnomalySummariesQuery = (
             },
           },
           {
-            term: {
-              detector_id: detectorId,
-            },
+            term: termField,
           },
           {
             nested: {
@@ -1150,6 +1207,23 @@ export const getEntityAnomalySummariesQuery = (
       },
     },
   };
+
+  // If querying RT results: remove any results that include a task_id, as this indicates
+  // a historical result from a historical task.
+  if (!isHistorical) {
+    requestBody.query.bool = {
+      ...requestBody.query.bool,
+      ...{
+        must_not: {
+          exists: {
+            field: 'task_id',
+          },
+        },
+      },
+    };
+  }
+
+  return requestBody;
 };
 
 export const parseEntityAnomalySummaryResults = (
@@ -1178,4 +1252,165 @@ export const parseEntityAnomalySummaryResults = (
     anomalySummaries: anomalySummaries,
   } as EntityAnomalySummaries;
   return enityAnomalySummaries;
+};
+
+export const getAnomalyDataRangeQuery = (
+  startTime: number,
+  endTime: number,
+  taskId: string
+) => {
+  return {
+    size: 0,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              [AD_DOC_FIELDS.ANOMALY_GRADE]: {
+                gte: 0,
+              },
+            },
+          },
+          {
+            range: {
+              data_end_time: {
+                gte: startTime,
+                lte: endTime,
+              },
+            },
+          },
+          {
+            term: {
+              task_id: taskId,
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      [MIN_END_TIME]: {
+        min: {
+          field: AD_DOC_FIELDS.DATA_END_TIME,
+        },
+      },
+      [MAX_END_TIME]: {
+        max: {
+          field: AD_DOC_FIELDS.DATA_END_TIME,
+        },
+      },
+    },
+  };
+};
+
+export const getHistoricalAggQuery = (
+  startTime: number,
+  endTime: number,
+  taskId: string,
+  anomalyAgg: ANOMALY_AGG
+) => {
+  // Need to calculate timezone offset before bucketing into days/months/weeks.
+  const timezoneAsIANAString = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  return {
+    size: MAX_ANOMALIES,
+    query: {
+      bool: {
+        filter: [
+          {
+            range: {
+              [AD_DOC_FIELDS.ANOMALY_GRADE]: {
+                gt: 0,
+              },
+            },
+          },
+          {
+            range: {
+              data_end_time: {
+                gte: startTime,
+                lte: endTime,
+              },
+            },
+          },
+          {
+            term: {
+              task_id: taskId,
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      [AGGREGATED_ANOMALIES]: {
+        date_histogram: {
+          field: AD_DOC_FIELDS.DATA_END_TIME,
+          calendar_interval: anomalyAgg,
+          time_zone: timezoneAsIANAString,
+          extended_bounds: {
+            min: startTime,
+            max: endTime,
+          },
+        },
+        aggs: {
+          [MAX_ANOMALY_AGGS]: {
+            max: {
+              field: AD_DOC_FIELDS.ANOMALY_GRADE,
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+export const parseHistoricalAggregatedAnomalies = (
+  result: any,
+  anomalyAgg: ANOMALY_AGG
+) => {
+  const resultBuckets = get(
+    result,
+    `response.aggregations.${AGGREGATED_ANOMALIES}.buckets`,
+    []
+  );
+  let anomalies = [] as AnomalyData[];
+  let endTimeOffset = 0;
+  let prefix = '';
+  let dateFormat = '';
+
+  switch (anomalyAgg) {
+    case ANOMALY_AGG.DAILY: {
+      endTimeOffset = DAY_IN_MILLI_SECS;
+      prefix = '';
+      dateFormat = 'MM/DD/YY';
+      break;
+    }
+    case ANOMALY_AGG.WEEKLY: {
+      endTimeOffset = WEEK_IN_MILLI_SECS;
+      prefix = 'Week of ';
+      dateFormat = 'MM/DD/YY';
+      break;
+    }
+    case ANOMALY_AGG.MONTHLY: {
+      // Approximate end time since months don't have even days
+      endTimeOffset = DAY_IN_MILLI_SECS * 30;
+      prefix = '';
+      dateFormat = 'MMM YYYY';
+    }
+  }
+  const plotTimeOffset = endTimeOffset / 2;
+
+  resultBuckets.forEach((bucket: any) => {
+    const timestamp = get(bucket, 'key');
+    let maxGrade = get(bucket, `${MAX_ANOMALY_AGGS}.value`);
+    anomalies.push({
+      anomalyGrade: maxGrade !== null ? maxGrade : 0,
+      //@ts-ignore
+      confidence: undefined,
+      startTime: timestamp,
+      endTime: timestamp + endTimeOffset,
+      plotTime: timestamp + plotTimeOffset,
+      aggInterval: prefix + moment(timestamp).format(dateFormat),
+    });
+  });
+
+  return anomalies;
 };

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -86,5 +86,15 @@ export const MAX_ANOMALY_AGGS = 'max_anomaly_aggs';
 export const COUNT_ANOMALY_AGGS = 'count_anomaly_aggs';
 export const MAX_ANOMALY_SORT_AGGS = 'max_anomaly_sort_aggs';
 export const ENTITY_DATE_BUCKET_ANOMALY_AGGS = 'entity_date_bucket_anomaly';
+export const AGGREGATED_ANOMALIES = 'aggregated_anomalies';
+export const MIN_END_TIME = 'min_end_time';
+export const MAX_END_TIME = 'max_end_time';
 
 export const SINGLE_DETECTOR_NOT_FOUND_MSG = `Can't find detector with id`;
+
+export enum ANOMALY_AGG {
+  RAW = 'raw',
+  DAILY = 'day',
+  WEEKLY = 'week',
+  MONTHLY = 'month',
+}

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -27,7 +27,7 @@ export const BREADCRUMBS = Object.freeze({
   SAMPLE_DETECTORS: { text: 'Sample detectors', href: '#/sample-detectors' },
   CREATE_DETECTOR: { text: 'Create detector' },
   EDIT_DETECTOR: { text: 'Edit detector' },
-  DASHBOARD: { text: 'Dashboard', href: '#/' },
+  DASHBOARD: { text: 'Dashboard', href: '#/dashboard' },
   EDIT_MODEL_CONFIGURATION: { text: 'Edit model configuration' },
   HISTORICAL_DETECTORS: {
     text: 'Historical detectors',
@@ -49,6 +49,8 @@ export const APP_PATH = {
   CREATE_HISTORICAL_DETECTOR: '/create-historical-detector/',
   EDIT_HISTORICAL_DETECTOR: '/historical-detectors/:detectorId/edit',
   HISTORICAL_DETECTOR_DETAIL: '/historical-detectors/:detectorId/details',
+  CREATE_DETECTOR_STEPS: '/create-detector-steps',
+  OVERVIEW: '/overview',
 };
 
 export const KIBANA_PATH = {
@@ -69,6 +71,9 @@ export const MAX_DETECTORS = 1000;
 
 export const MAX_ANOMALIES = 10000;
 
+export const MAX_HISTORICAL_AGG_RESULTS = 10000;
+
+// TODO: get this value from index settings since it is dynamic
 export const MAX_FEATURE_NUM = 5;
 
 export const MAX_FEATURE_NAME_SIZE = 64;

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -33,6 +33,12 @@ export const SEC_IN_MILLI_SECS = 1000;
 
 export const MIN_IN_MILLI_SECS = 60 * SEC_IN_MILLI_SECS;
 
+export const HOUR_IN_MILLI_SECS = 60 * MIN_IN_MILLI_SECS;
+
+export const DAY_IN_MILLI_SECS = 24 * HOUR_IN_MILLI_SECS;
+
+export const WEEK_IN_MILLI_SECS = 7 * DAY_IN_MILLI_SECS;
+
 export enum CLUSTER {
   ADMIN = 'admin',
   AES_AD = 'aes_ad',
@@ -48,12 +54,15 @@ export enum AD_DOC_FIELDS {
   DATA_START_TIME = 'data_start_time',
   DATA_END_TIME = 'data_end_time',
   DETECTOR_ID = 'detector_id',
+  TASK_ID = 'task_id',
   DETECTOR_NAME = 'name',
   PLOT_TIME = 'plot_time',
   ANOMALY_GRADE = 'anomaly_grade',
   ERROR = 'error',
   INDICES = 'indices',
 }
+
+export const MAX_DETECTORS = 1000;
 
 export const MAX_MONITORS = 1000;
 
@@ -87,3 +96,6 @@ export const KEY_FIELD = 'key';
 
 export const STACK_TRACE_PATTERN = '.java:';
 export const ES_EXCEPTION_PREFIX = 'org.elasticsearch.ElasticsearchException: ';
+
+export const REALTIME_TASK_TYPE_PREFIX = 'REALTIME';
+export const HISTORICAL_TASK_TYPE_PREFIX = 'HISTORICAL';


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

**This PR is 5 of 9 related to the new single flow changes. We will merge all changes into the single-flow-development branch first, and finally merge into main.**

**Please ignore test-related code for now, this is currently being refactored and updated, will be addressed in a later PR**

This PR adds the historical tab on the detector details page. Specifically, the changes include:
- Adding support to start and stop a historical task, and view the historical anomaly results and feature results
- An empty state for when no historical tasks have been created prior
- Modals to create and modify the historical detector date range
- Showing partial historical results as the task is running - will automatically refresh every 10s (same as existing historical detector details page)
- Daily/weekly/monthly aggregations on the anomaly results chart to quickly summarize the data if a long data range is selected. The `AnomalyDetailsChart` was refactored to support this functionality. Note it is only applicable in the historical context. Also note that a maximum of 10k agg results is supported (retrieving 10k buckets). If selecting an aggregation would result in > 10k buckets, the button to select that aggregation is disabled.
- Change the default anomaly grade line color to `red` in the historical context

Screenshots:
![Screen Shot 2021-05-03 at 8 45 26 AM](https://user-images.githubusercontent.com/62119629/116903124-d771eb00-abf0-11eb-890e-7efdf7808381.png)
![Screen Shot 2021-05-03 at 8 45 43 AM](https://user-images.githubusercontent.com/62119629/116903146-de006280-abf0-11eb-82a2-0fbc17ecb313.png)
![Screen Shot 2021-05-03 at 8 46 12 AM](https://user-images.githubusercontent.com/62119629/116903167-e6589d80-abf0-11eb-9e49-f5877521925a.png)
![Screen Shot 2021-05-03 at 8 46 56 AM](https://user-images.githubusercontent.com/62119629/116903646-844c6800-abf1-11eb-8a2b-318bc939cd6b.png)
![Screen Shot 2021-05-03 at 8 47 11 AM](https://user-images.githubusercontent.com/62119629/116903660-8a424900-abf1-11eb-865f-cab2a742a8e6.png)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
