### PR TITLE
WIP: Update API paths from _opendistro to _opensearch

### DIFF
--- a/.cypress/fixtures/delete_detector_response.json
+++ b/.cypress/fixtures/delete_detector_response.json
@@ -1,5 +1,5 @@
 {
-  "_index": ".opendistro-anomaly-detectors",
+  "_index": ".opensearch-anomaly-detectors",
   "_type": "_doc",
   "_id": "ulgqpXEBqtadYz9j2MHG",
   "_version": 2,

--- a/.cypress/fixtures/no_detector_index_response.json
+++ b/.cypress/fixtures/no_detector_index_response.json
@@ -1,4 +1,4 @@
 {
   "ok": false,
-  "error": "[index_not_found_exception] no such index [.opendistro-anomaly-detectors], with { resource.type=\"index_or_alias\" & resource.id=\".opendistro-anomaly-detectors\" & index_uuid=\"_na_\" & index=\".opendistro-anomaly-detectors\" }"
+  "error": "[index_not_found_exception] no such index [.opensearch-anomaly-detectors], with { resource.type=\"index_or_alias\" & resource.id=\".opensearch-anomaly-detectors\" & index_uuid=\"_na_\" & index=\".opensearch-anomaly-detectors\" }"
 }

--- a/public/redux/reducers/__tests__/utils.ts
+++ b/public/redux/reducers/__tests__/utils.ts
@@ -136,7 +136,7 @@ export const getRandomMonitor = (
     inputs: [
       {
         search: {
-          indices: ['.opendistro-anomaly-results*'],
+          indices: ['.opensearch-anomaly-results*'],
           query: {
             size: 1,
             query: {

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -72,9 +72,9 @@ export const ALERTING_PLUGIN_NAME = 'alerting';
 
 export const OPENSEARCH_DASHBOARDS_NAME = 'dashboards';
 
-export const ANOMALY_DETECTORS_INDEX = '.opendistro-anomaly-detectors';
+export const ANOMALY_DETECTORS_INDEX = '.opensearch-anomaly-detectors';
 
-export const ANOMALY_RESULT_INDEX = '.opendistro-anomaly-results';
+export const ANOMALY_RESULT_INDEX = '.opensearch-anomaly-results';
 
 export const MAX_DETECTORS = 1000;
 

--- a/server/routes/alerting.ts
+++ b/server/routes/alerting.ts
@@ -70,7 +70,7 @@ export default class AlertingService {
                   {
                     term: {
                       'monitor.inputs.search.indices.keyword': {
-                        value: '.opendistro-anomaly-results*',
+                        value: '.opensearch-anomaly-results*',
                       },
                     },
                   },

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -26,8 +26,8 @@
 
 import { ADApis, DefaultHeaders } from '../models/interfaces';
 
-export const AD_API_ROUTE_PREFIX = '/_opendistro/_anomaly_detection';
-export const ALERTING_API_ROUTE_PREFIX = '/_opendistro/_alerting';
+export const AD_API_ROUTE_PREFIX = '/_opensearch/_anomaly_detection';
+export const ALERTING_API_ROUTE_PREFIX = '/_opensearch/_alerting';
 
 export const API: ADApis = {
   DETECTOR_BASE: `${AD_API_ROUTE_PREFIX}/detectors`,


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Draft PR for migrating the plugin API compatibility from `_opendistro`-prefixed APIs to the newly-named `_opensearch`-prefixed APIs, for both anomaly detection and alerting OpenSearch plugins.

### Check List

- [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
