### PR TITLE
Update sample data naming conventions

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -72,10 +72,7 @@ import {
   FEATURE_DATA_CHECK_WINDOW_OFFSET,
 } from '../../utils/anomalyResultUtils';
 import { getDetectorResults } from '../../../redux/reducers/anomalyResults';
-import {
-  detectorIsSample,
-  getAssociatedIndex,
-} from '../../SampleData/utils/helpers';
+import { detectorIsSample } from '../../SampleData/utils/helpers';
 import { SampleIndexDetailsCallout } from '../../SampleData/components/SampleIndexDetailsCallout/SampleIndexDetailsCallout';
 import { CoreStart } from '../../../../../../src/core/public';
 import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
@@ -133,7 +130,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
   useEffect(() => {
     if (detector && detectorIsSample(detector)) {
       setIsSampleDetector(true);
-      setSampleIndexName(getAssociatedIndex(detector));
+      setSampleIndexName(detector.indices[0]);
     } else {
       setIsSampleDetector(false);
     }

--- a/public/pages/SampleData/components/SampleDetailsFlyout/SampleDetailsFlyout.tsx
+++ b/public/pages/SampleData/components/SampleDetailsFlyout/SampleDetailsFlyout.tsx
@@ -39,12 +39,14 @@ import {
   getFieldsAndTypesGrid,
   getFeaturesAndAggsAndFieldsGrid,
 } from '../../utils/helpers';
+import { Detector } from '../../../../models/interfaces';
 import { SAMPLE_DATA } from '../../utils/constants';
 import { EuiHorizontalRule } from '@elastic/eui';
 
 interface SampleDetailsFlyoutProps {
   title: string;
   sampleData: SAMPLE_DATA;
+  detector: Detector | undefined;
   interval: number;
   onClose(): void;
 }
@@ -98,7 +100,11 @@ export const SampleDetailsFlyout = (props: SampleDetailsFlyoutProps) => {
         >
           <EuiText style={{ lineHeight: 2.0 }}>
             <b>Name: </b>
-            <i>{props.sampleData.detectorName}</i>
+            <i>
+              {props.detector
+                ? props.detector.name
+                : props.sampleData.detectorName}
+            </i>
             <br></br>
             <b>Detection interval: </b>
             Every {detectorInterval} minutes
@@ -125,7 +131,11 @@ export const SampleDetailsFlyout = (props: SampleDetailsFlyoutProps) => {
         >
           <EuiText style={{ lineHeight: 2.0 }}>
             <b>Name: </b>
-            <i>{props.sampleData.indexName}</i>
+            <i>
+              {props.detector
+                ? props.detector.indices[0]
+                : props.sampleData.indexName}
+            </i>
             <br></br>
             <b>Log frequency: </b>Every {props.interval} minute(s)
             <br></br>

--- a/public/pages/SampleData/containers/SampleData/SampleData.tsx
+++ b/public/pages/SampleData/containers/SampleData/SampleData.tsx
@@ -53,8 +53,8 @@ import {
 } from '../../utils/constants';
 import {
   containsSampleIndex,
-  containsSampleDetector,
   getDetectorId,
+  getSampleDetector,
 } from '../../utils/helpers';
 import { SampleDataBox } from '../../components/SampleDataBox/SampleDataBox';
 import { SampleDetailsFlyout } from '../../components/SampleDetailsFlyout/SampleDetailsFlyout';
@@ -217,10 +217,10 @@ export const SampleData = () => {
               );
             }}
             isLoadingData={isLoadingHttpData}
-            isDataLoaded={containsSampleDetector(
-              allDetectors,
-              SAMPLE_TYPE.HTTP_RESPONSES
-            )}
+            isDataLoaded={
+              getSampleDetector(allDetectors, SAMPLE_TYPE.HTTP_RESPONSES) !==
+              undefined
+            }
             detectorId={getDetectorId(
               allDetectors,
               sampleHttpResponses.detectorName,
@@ -248,10 +248,10 @@ export const SampleData = () => {
               );
             }}
             isLoadingData={isLoadingEcommerceData}
-            isDataLoaded={containsSampleDetector(
-              allDetectors,
-              SAMPLE_TYPE.ECOMMERCE
-            )}
+            isDataLoaded={
+              getSampleDetector(allDetectors, SAMPLE_TYPE.ECOMMERCE) !==
+              undefined
+            }
             detectorId={getDetectorId(
               allDetectors,
               sampleEcommerce.detectorName,
@@ -279,10 +279,10 @@ export const SampleData = () => {
               );
             }}
             isLoadingData={isLoadingHostHealthData}
-            isDataLoaded={containsSampleDetector(
-              allDetectors,
-              SAMPLE_TYPE.HOST_HEALTH
-            )}
+            isDataLoaded={
+              getSampleDetector(allDetectors, SAMPLE_TYPE.HOST_HEALTH) !==
+              undefined
+            }
             detectorId={getDetectorId(
               allDetectors,
               sampleHostHealth.detectorName,
@@ -296,6 +296,7 @@ export const SampleData = () => {
         <SampleDetailsFlyout
           title="Monitor HTTP responses"
           sampleData={sampleHttpResponses}
+          detector={getSampleDetector(allDetectors, SAMPLE_TYPE.HTTP_RESPONSES)}
           interval={1}
           onClose={() => setShowHttpResponseDetailsFlyout(false)}
         />
@@ -304,6 +305,7 @@ export const SampleData = () => {
         <SampleDetailsFlyout
           title="Monitor eCommerce orders"
           sampleData={sampleEcommerce}
+          detector={getSampleDetector(allDetectors, SAMPLE_TYPE.ECOMMERCE)}
           interval={1}
           onClose={() => setShowEcommerceDetailsFlyout(false)}
         />
@@ -312,6 +314,7 @@ export const SampleData = () => {
         <SampleDetailsFlyout
           title="Monitor host health"
           sampleData={sampleHostHealth}
+          detector={getSampleDetector(allDetectors, SAMPLE_TYPE.HOST_HEALTH)}
           interval={1}
           onClose={() => setShowHostHealthDetailsFlyout(false)}
         />

--- a/public/pages/SampleData/containers/SampleData/SampleData.tsx
+++ b/public/pages/SampleData/containers/SampleData/SampleData.tsx
@@ -223,7 +223,8 @@ export const SampleData = () => {
             )}
             detectorId={getDetectorId(
               allDetectors,
-              sampleHttpResponses.detectorName
+              sampleHttpResponses.detectorName,
+              sampleHttpResponses.legacyDetectorName
             )}
           />
         </EuiFlexItem>
@@ -253,7 +254,8 @@ export const SampleData = () => {
             )}
             detectorId={getDetectorId(
               allDetectors,
-              sampleEcommerce.detectorName
+              sampleEcommerce.detectorName,
+              sampleEcommerce.legacyDetectorName
             )}
           />
         </EuiFlexItem>
@@ -283,7 +285,8 @@ export const SampleData = () => {
             )}
             detectorId={getDetectorId(
               allDetectors,
-              sampleHostHealth.detectorName
+              sampleHostHealth.detectorName,
+              sampleHostHealth.legacyDetectorName
             )}
           />
         </EuiFlexItem>

--- a/public/pages/SampleData/utils/constants.tsx
+++ b/public/pages/SampleData/utils/constants.tsx
@@ -39,7 +39,9 @@ export const indexSettings = {
 
 export interface SAMPLE_DATA {
   indexName: string;
+  legacyIndexName: string;
   detectorName: string;
+  legacyDetectorName: string;
   description: string;
   icon: any;
   fieldMappings: {};
@@ -50,8 +52,11 @@ export interface SAMPLE_DATA {
 /*
  *** SAMPLE HTTP RESPONSES CONSTANTS ***
  */
-const httpResponsesIndexName = 'opendistro-sample-http-responses';
-const httpResponsesDetectorName = 'opendistro-sample-http-responses-detector';
+const httpResponsesIndexName = 'sample-http-responses';
+const legacyHttpResponsesIndexName = 'opendistro-sample-http-responses';
+const httpResponsesDetectorName = 'sample-http-responses-detector';
+const legacyHttpResponsesDetectorName =
+  'opendistro-sample-http-responses-detector';
 const httpFieldMappings = {
   timestamp: {
     type: 'date',
@@ -77,7 +82,9 @@ const httpFieldMappings = {
 };
 export const sampleHttpResponses = {
   indexName: httpResponsesIndexName,
+  legacyIndexName: legacyHttpResponsesIndexName,
   detectorName: httpResponsesDetectorName,
+  legacyDetectorName: legacyHttpResponsesDetectorName,
   description:
     'Detect high numbers of error response codes in an index containing HTTP response data.',
   icon: <EuiIcon type="visLine" size="l" />,
@@ -144,8 +151,10 @@ export const sampleHttpResponses = {
 /*
  *** ECOMMERCE CONSTANTS ***
  */
-const ecommerceIndexName = 'opendistro-sample-ecommerce';
-const ecommerceDetectorName = 'opendistro-sample-ecommerce-detector';
+const ecommerceIndexName = 'sample-ecommerce';
+const legacyEcommerceIndexName = 'opendistro-sample-ecommerce';
+const ecommerceDetectorName = 'sample-ecommerce-detector';
+const legacyEcommerceDetectorName = 'opendistro-sample-ecommerce-detector';
 const ecommerceFieldMappings = {
   timestamp: {
     type: 'date',
@@ -165,7 +174,9 @@ const ecommerceFieldMappings = {
 };
 export const sampleEcommerce = {
   indexName: ecommerceIndexName,
+  legacyIndexName: legacyEcommerceIndexName,
   detectorName: ecommerceDetectorName,
+  legacyDetectorName: legacyEcommerceDetectorName,
   description:
     'Detect any unusual increase or decrease of orders in an index containing online order data.',
   icon: <EuiIcon type="package" size="l" />,
@@ -261,8 +272,10 @@ export const sampleEcommerce = {
 /*
  *** HOST HEALTH CONSTANTS ***
  */
-const hostHealthIndexName = 'opendistro-sample-host-health';
-const hostHealthDetectorName = 'opendistro-sample-host-health-detector';
+const hostHealthIndexName = 'sample-host-health';
+const legacyHostHealthIndexName = 'opendistro-sample-host-health';
+const hostHealthDetectorName = 'sample-host-health-detector';
+const legacyHostHealthDetectorName = 'opendistro-sample-host-health-detector';
 const hostHealthFieldMappings = {
   timestamp: {
     type: 'date',
@@ -276,7 +289,9 @@ const hostHealthFieldMappings = {
 };
 export const sampleHostHealth = {
   indexName: hostHealthIndexName,
+  legacyIndexName: legacyHostHealthIndexName,
   detectorName: hostHealthDetectorName,
+  legacyDetectorName: legacyHostHealthDetectorName,
   description:
     'Detect increases in CPU and memory utilization in an index containing various health metrics from a host.',
   icon: <EuiIcon type="visGauge" size="l" />,

--- a/public/pages/SampleData/utils/helpers.tsx
+++ b/public/pages/SampleData/utils/helpers.tsx
@@ -25,7 +25,7 @@
  */
 
 import React from 'react';
-import { isEmpty } from 'lodash';
+import { isEmpty, get } from 'lodash';
 import { EuiDataGrid } from '@elastic/eui';
 import { CatIndex } from '../../../../server/models/types';
 import { Detector, DetectorListItem } from '../../../models/interfaces';
@@ -72,7 +72,7 @@ export const containsSampleIndex = (
   return indexNames.includes(indexName) || indexNames.includes(legacyIndexName);
 };
 
-export const containsSampleDetector = (
+export const getSampleDetector = (
   detectors: DetectorListItem[],
   sampleType: SAMPLE_TYPE
 ) => {
@@ -96,10 +96,14 @@ export const containsSampleDetector = (
     }
   }
   // Checking for legacy sample detectors
-  const detectorNames = detectors.map((detector) => detector.name);
-  return (
-    detectorNames.includes(detectorName) ||
-    detectorNames.includes(legacyDetectorName)
+  return get(
+    detectors.filter(
+      (detector) =>
+        detector.name.includes(detectorName) ||
+        detector.name.includes(legacyDetectorName)
+    ),
+    '0',
+    undefined
   );
 };
 

--- a/public/pages/SampleData/utils/helpers.tsx
+++ b/public/pages/SampleData/utils/helpers.tsx
@@ -49,21 +49,27 @@ export const containsSampleIndex = (
   sampleType: SAMPLE_TYPE
 ) => {
   let indexName = '';
+  let legacyIndexName = '';
   switch (sampleType) {
     case SAMPLE_TYPE.HTTP_RESPONSES: {
       indexName = sampleHttpResponses.indexName;
+      legacyIndexName = sampleHttpResponses.legacyIndexName;
       break;
     }
     case SAMPLE_TYPE.ECOMMERCE: {
       indexName = sampleEcommerce.indexName;
+      legacyIndexName = sampleEcommerce.legacyIndexName;
       break;
     }
     case SAMPLE_TYPE.HOST_HEALTH: {
       indexName = sampleHostHealth.indexName;
+      legacyIndexName = sampleHostHealth.legacyIndexName;
       break;
     }
   }
-  return indices.map((index) => index.index).includes(indexName);
+  // Checking for legacy sample indices
+  const indexNames = indices.map((index) => index.index);
+  return indexNames.includes(indexName) || indexNames.includes(legacyIndexName);
 };
 
 export const containsSampleDetector = (
@@ -71,55 +77,54 @@ export const containsSampleDetector = (
   sampleType: SAMPLE_TYPE
 ) => {
   let detectorName = '';
+  let legacyDetectorName = '';
   switch (sampleType) {
     case SAMPLE_TYPE.HTTP_RESPONSES: {
       detectorName = sampleHttpResponses.detectorName;
+      legacyDetectorName = sampleHttpResponses.legacyDetectorName;
       break;
     }
     case SAMPLE_TYPE.ECOMMERCE: {
       detectorName = sampleEcommerce.detectorName;
+      legacyDetectorName = sampleEcommerce.legacyDetectorName;
       break;
     }
     case SAMPLE_TYPE.HOST_HEALTH: {
       detectorName = sampleHostHealth.detectorName;
+      legacyDetectorName = sampleHostHealth.legacyDetectorName;
       break;
     }
   }
-  return detectors.map((detector) => detector.name).includes(detectorName);
+  // Checking for legacy sample detectors
+  const detectorNames = detectors.map((detector) => detector.name);
+  return (
+    detectorNames.includes(detectorName) ||
+    detectorNames.includes(legacyDetectorName)
+  );
 };
 
 export const detectorIsSample = (detector: Detector) => {
   return (
     detector.name === sampleHttpResponses.detectorName ||
+    detector.name === sampleHttpResponses.legacyDetectorName ||
     detector.name === sampleEcommerce.detectorName ||
-    detector.name === sampleHostHealth.detectorName
+    detector.name === sampleEcommerce.legacyDetectorName ||
+    detector.name === sampleHostHealth.detectorName ||
+    detector.name === sampleHostHealth.legacyDetectorName
   );
-};
-
-export const getAssociatedIndex = (detector: Detector) => {
-  if (detector.name === sampleHttpResponses.detectorName) {
-    return sampleHttpResponses.indexName;
-  }
-  if (detector.name === sampleEcommerce.detectorName) {
-    return sampleEcommerce.indexName;
-  }
-  if (detector.name === sampleHostHealth.detectorName) {
-    return sampleHostHealth.indexName;
-  }
-  console.error(
-    'Error getting associated sample index for detector ',
-    detector.name
-  );
-  return '';
 };
 
 export const getDetectorId = (
   detectors: DetectorListItem[],
-  detectorName: string
+  detectorName: string,
+  legacyDetectorName: string
 ) => {
   let detectorId = '';
   detectors.some((detector) => {
-    if (detector.name === detectorName) {
+    if (
+      detector.name === detectorName ||
+      detector.name === legacyDetectorName
+    ) {
       detectorId = detector.id;
       return true;
     }

--- a/public/pages/utils/constants.ts
+++ b/public/pages/utils/constants.ts
@@ -81,14 +81,14 @@ export const GET_ALL_DETECTORS_QUERY_PARAMS = {
 
 export const GET_SAMPLE_DETECTORS_QUERY_PARAMS = {
   from: 0,
-  search: 'opendistro-sample',
+  search: 'sample',
   indices: '',
   size: MAX_DETECTORS,
   sortDirection: SORT_DIRECTION.ASC,
   sortField: 'name',
 };
 
-export const GET_SAMPLE_INDICES_QUERY = 'opendistro-sample-*';
+export const GET_SAMPLE_INDICES_QUERY = '*sample-*';
 
 export const TOP_ENTITIES_FIELD = 'top_entities';
 export const TOP_ENTITY_AGGS = 'top_entity_aggs';

--- a/server/routes/sampleData.ts
+++ b/server/routes/sampleData.ts
@@ -73,7 +73,7 @@ export default class SampleDataService {
             __dirname,
             '../sampleData/rawData/httpResponses.json.gz'
           );
-          indexName = 'opendistro-sample-http-responses';
+          indexName = 'sample-http-responses';
           break;
         }
         case SAMPLE_TYPE.ECOMMERCE: {
@@ -81,7 +81,7 @@ export default class SampleDataService {
             __dirname,
             '../sampleData/rawData/ecommerce.json.gz'
           );
-          indexName = 'opendistro-sample-ecommerce';
+          indexName = 'sample-ecommerce';
           break;
         }
         case SAMPLE_TYPE.HOST_HEALTH: {
@@ -89,7 +89,7 @@ export default class SampleDataService {
             __dirname,
             '../sampleData/rawData/hostHealth.json.gz'
           );
-          indexName = 'opendistro-sample-host-health';
+          indexName = 'sample-host-health';
           break;
         }
       }


### PR DESCRIPTION
### Description
Current sample detectors and indices include the legacy `opendistro-` prefix. This PR removes that prefix.

Example: 
eCommerce detector change: `opendistro-sample-ecommerce-detector` => `sample-ecommerce-detector`
eCommerce index change: `opendistro-sample-ecommerce` => `sample-ecommerce`

In addition:
- Handled backwards compatibility by ensuring legacy detectors created are still recognized as created on the sample detectors page
- Changed the sample details flyout to pull the detector & index names from an existing detector if possible. That way, new and legacy detectors will both be properly reflected
- Added legacy checks to helper fns and query parameters to search for both new and legacy created detectors and indices
- Confirmed newly named detectors/indices function the same as before

Screenshots:

Legacy + new sample detectors coexisting:
![Screen Shot 2021-05-12 at 1 24 19 PM](https://user-images.githubusercontent.com/62119629/118039743-887d3180-b325-11eb-91e7-5f9524a4bb4d.png)
![Screen Shot 2021-05-12 at 1 24 35 PM](https://user-images.githubusercontent.com/62119629/118039748-8a46f500-b325-11eb-93d2-b5acfc429d69.png)

Details flyout (legacy):
![Screen Shot 2021-05-12 at 1 25 02 PM](https://user-images.githubusercontent.com/62119629/118039803-9632b700-b325-11eb-9f40-f61549829a0f.png)

Details flyout (new):
![Screen Shot 2021-05-12 at 1 25 16 PM](https://user-images.githubusercontent.com/62119629/118039829-9af76b00-b325-11eb-879a-30c99eeb049c.png)

### Issues Resolved
Resolves #3

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
