### PR TITLE
Update API call endpoints from _opendistro to _plugins

### DIFF
--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -26,8 +26,8 @@
 
 import { ADApis, DefaultHeaders } from '../models/interfaces';
 
-export const AD_API_ROUTE_PREFIX = '/_opendistro/_anomaly_detection';
-export const ALERTING_API_ROUTE_PREFIX = '/_opendistro/_alerting';
+export const AD_API_ROUTE_PREFIX = '/_plugins/_anomaly_detection';
+export const ALERTING_API_ROUTE_PREFIX = '/_plugins/_alerting';
 
 export const API: ADApis = {
   DETECTOR_BASE: `${AD_API_ROUTE_PREFIX}/detectors`,


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Updates the API calls to use the new `_plugins/` endpoint prefix in favor of the legacy `_opendistro/*` endpoint prefix.

Current list of anomaly detection API calls being updated: [here](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/server/cluster/ad/adPlugin.ts)
Current list of alerting API calls being updated: [here](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/server/cluster/ad/alertingPlugin.ts)

Have tested all anomaly detection calls made.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
