### PR TITLE
Fix CI workflows; change to run against PR

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -3,16 +3,21 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 7.10.2
-  OPENSEARCH_VERSION: 1.13.1
+  OPENSEARCH_DASHBOARDS_VERSION: 1.0.0-beta1
+  OPENSEARCH_VERSION: 1.0.0-beta1
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomalyDetectionDashboards
+  OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
+  DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
 jobs:
   test-with-security:
     name: Run e2e tests with security
     strategy:
       matrix:
-        os: [ubuntu-16.04] # use ubuntu-16.04 as required by cypress: https://github.com/marketplace/actions/cypress-io#important
+        os: [ubuntu-latest]
         java: [14]
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,7 +26,6 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
-          token: ${{ secrets.OPENSEARCH_DASHBOARDS_OSS_ACCESS }}
           path: OpenSearch-Dashboards
 
       - name: Get node and yarn versions
@@ -60,23 +64,22 @@ jobs:
       - name: Create tagged images for OpenSearch and OpenSearch Dashboards
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
-          opensearch_version=$OPENSEARCH_VERSION
           plugin_version=$(node -pe "require('./package.json').version")
-          echo opensearch version: $opensearch_version
+          echo opensearch version: $OPENSEARCH_VERSION
           echo plugin version: $plugin_version
           echo plugin name: $AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME
-          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$opensearch_version
+          if docker pull $OPENSEARCH_DOCKER_IMAGE:latest
           then
             ## Populate the Dockerfiles
-            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$opensearch_version" >> Dockerfile-AD-OpenSearch-Dashboards
-            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch-kibana:$opensearch_version" >> Dockerfile-AD-OpenSearch-Dashboards
+            echo "FROM $OPENSEARCH_DOCKER_IMAGE:latest" >> Dockerfile-AD-OpenSearch
+            echo "FROM $DASHBOARDS_DOCKER_IMAGE:latest" >> Dockerfile-AD-OpenSearch-Dashboards
             echo "COPY build/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME-$plugin_version.zip ." >> Dockerfile-AD-OpenSearch-Dashboards
             ## Uninstall existing AD artifact and install new one
             echo "RUN if [ -d /usr/share/opensearch-dashboards/plugins/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME ]; then /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove $AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME; fi" >> Dockerfile-AD-OpenSearch-Dashboards
-            echo "RUN bin/opensearch-dashboards-plugin install file:///usr/share/OpenSearch-Dashboards/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME-$plugin_version.zip;" >> Dockerfile-AD-OpenSearch-Dashboards
+            echo "RUN bin/opensearch-dashboards-plugin install file:///usr/share/opensearch-dashboards/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME-$plugin_version.zip;" >> Dockerfile-AD-OpenSearch-Dashboards
 
             ## Create the tagged images
-            docker build -f ./Dockerfile-AD -t opensearch-ad:test .
+            docker build -f ./Dockerfile-AD-OpenSearch -t opensearch-ad:test .
             docker build -f ./Dockerfile-AD-OpenSearch-Dashboards -t opensearch-ad-dashboards:test .
           fi
           docker images
@@ -99,20 +102,23 @@ jobs:
     name: Run e2e tests without security
     strategy:
       matrix:
-        os: [ubuntu-16.04] # use ubuntu-16.04 as required by cypress: https://github.com/marketplace/actions/cypress-io#important
+        os: [ubuntu-latest]
         java: [14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Pull and Run Docker
         run: |
-          opensearch_version=$OPENSEARCH_VERSION
-          echo opensearch version: $opensearch_version
-          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$opensearch_version
+          echo opensearch version: $OPENSEARCH_VERSION
+          if docker pull $OPENSEARCH_DOCKER_IMAGE:latest
           then
-            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$opensearch_version" >> Dockerfile
+            echo "FROM $OPENSEARCH_DOCKER_IMAGE:latest" >> Dockerfile
             ## The OpenSearch rest test client uses http by default.
             ## Need to disable the security plugin to call the rest api over http.
-            echo "RUN if [ -d /usr/share/OpenSearch/plugins/opensearch-security ]; then /usr/share/OpenSearch/bin/OpenSearch-plugin remove opensearch-security; fi" >> Dockerfile
+            ## Also need to remove any remaining security settings specified in opensearch.yml
+            echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-security ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security; fi" >> Dockerfile
+            echo "RUN sed -n -i '1,/Start OpenSearch Security Demo Configuration/p;/End OpenSearch Security Demo Configuration/,\$p'" >> Dockerfile
+            truncate -s -1 Dockerfile
+            echo -n " /usr/share/opensearch/config/opensearch.yml" >> Dockerfile
             docker build -t opensearch-ad:test .
           fi
       - name: Run Docker Image
@@ -125,7 +131,6 @@ jobs:
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
-          token: ${{ secrets.OPENSEARCH_DASHBOARDS_OSS_ACCESS }}
           path: OpenSearch-Dashboards
       - name: Get node and yarn versions
         id: versions_step

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "cy:run-with-security": "cypress run --env SECURITY_ENABLED=true",
-    "test:e2e": "CHOKIDAR_USEPOLLING=1 CYPRESS_responseTimeout=180000 WAIT_ON_TIMEOUT=900000 start-server-and-test 'cd ../../ && yarn start --no-base-path --oss && cd plugins/anomaly-detection-opensearch-dashboards-plugin' http-get://localhost:5601/app/anomaly-detection-opensearch-dashboards-plugin 'echo sleeping to wait for server to get ready && sleep 360 && yarn cy:run'"
+    "test:e2e": "CHOKIDAR_USEPOLLING=1 CYPRESS_responseTimeout=180000 WAIT_ON_TIMEOUT=900000 start-server-and-test 'cd ../../ && yarn start --no-base-path && cd plugins/anomaly-detection-opensearch-dashboards-plugin' http-get://localhost:5601/app/anomaly-detection-opensearch-dashboards-plugin 'echo sleeping to wait for server to get ready && sleep 360 && yarn cy:run'"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,css,md}": [


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Fixes the CI workflow to run against the OpenSearch staging docker images with the `latest` tag. Also updates the workflow to run against PRs and not just on merges to main.

NOTE: this is still checking out the `1.0.0-beta1` tag for the core repos. This workflow (as well as the other repos) will be changed once there is a dedicated branch or consistent way for plugins to build and test against the latest versions of the core repos.

### Issues Resolved

Resolves #2

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
