### PR TITLE
Change workflows to run against 1.x branch

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -7,8 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 1.0.0-beta1
-  OPENSEARCH_VERSION: 1.0.0-beta1
+  OPENSEARCH_DASHBOARDS_VERSION: 1.x
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomalyDetectionDashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
@@ -65,7 +64,6 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
           plugin_version=$(node -pe "require('./package.json').version")
-          echo opensearch version: $OPENSEARCH_VERSION
           echo plugin version: $plugin_version
           echo plugin name: $AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME
           if docker pull $OPENSEARCH_DOCKER_IMAGE:latest
@@ -108,7 +106,6 @@ jobs:
     steps:
       - name: Pull and Run Docker
         run: |
-          echo opensearch version: $OPENSEARCH_VERSION
           if docker pull $OPENSEARCH_DOCKER_IMAGE:latest
           then
             echo "FROM $OPENSEARCH_DOCKER_IMAGE:latest" >> Dockerfile

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 1.0.0-beta1
+  OPENSEARCH_DASHBOARDS_VERSION: 1.x
 jobs:
   tests:
     name: Run unit tests


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Updates the test workflows to run against the `1.x` branch. Removes unnecessary env variable in the CI workflow.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
