### PR TITLE
Update workflows to run against 1.0 branch

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 1.x
+  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomalyDetectionDashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
@@ -121,7 +121,7 @@ jobs:
       - name: Run Docker Image
         run: |
           docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" opensearch-ad:test
-          sleep 90
+          sleep 180
           curl -XGET http://localhost:9200/_cat/plugins
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 1.x
+  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
 jobs:
   tests:
     name: Run unit tests


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Now that OpenSearch Dashboards has been frozen for `1.0`, build and test against this version.

Also increases the timeout in the CI workflow (without security) which was causing occasional failures in the github runners.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
