### PR TITLE
Run CI against 1.0.0-rc1 docker images

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -11,8 +11,7 @@ env:
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomalyDetectionDashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
-  OPENSEARCH_DOCKER_TAG: 1.0.0-rc1
-  DASHBOARDS_DOCKER_TAG: 1.0.0-rc1
+  DOCKER_TAG: 1.0.0-rc1
 jobs:
   test-with-security:
     name: Run e2e tests with security
@@ -68,11 +67,11 @@ jobs:
           plugin_version=$(node -pe "require('./package.json').version")
           echo plugin version: $plugin_version
           echo plugin name: $AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME
-          if docker pull $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG
+          if docker pull $OPENSEARCH_DOCKER_IMAGE:$DOCKER_TAG
           then
             ## Populate the Dockerfiles
-            echo "FROM $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG" >> Dockerfile-AD-OpenSearch
-            echo "FROM $DASHBOARDS_DOCKER_IMAGE:$DASHBOARDS_DOCKER_TAG" >> Dockerfile-AD-OpenSearch-Dashboards
+            echo "FROM $OPENSEARCH_DOCKER_IMAGE:$DOCKER_TAG" >> Dockerfile-AD-OpenSearch
+            echo "FROM $DASHBOARDS_DOCKER_IMAGE:$DOCKER_TAG" >> Dockerfile-AD-OpenSearch-Dashboards
             echo "COPY build/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME-$plugin_version.zip ." >> Dockerfile-AD-OpenSearch-Dashboards
             ## Uninstall existing AD artifact and install new one
             echo "RUN if [ -d /usr/share/opensearch-dashboards/plugins/anomaly-detection-dashboards ]; then /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove anomaly-detection-dashboards; fi" >> Dockerfile-AD-OpenSearch-Dashboards
@@ -108,9 +107,9 @@ jobs:
     steps:
       - name: Pull and Run Docker
         run: |
-          if docker pull $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG
+          if docker pull $OPENSEARCH_DOCKER_IMAGE:$DOCKER_TAG
           then
-            echo "FROM $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG" >> Dockerfile
+            echo "FROM $OPENSEARCH_DOCKER_IMAGE:$DOCKER_TAG" >> Dockerfile
             ## The OpenSearch rest test client uses http by default.
             ## Need to disable the security plugin to call the rest api over http.
             ## Also need to remove any remaining security settings specified in opensearch.yml

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -11,6 +11,8 @@ env:
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomalyDetectionDashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
+  OPENSEARCH_DOCKER_TAG: 1.0.0-rc1
+  DASHBOARDS_DOCKER_TAG: 1.0.0-rc1
 jobs:
   test-with-security:
     name: Run e2e tests with security
@@ -66,14 +68,14 @@ jobs:
           plugin_version=$(node -pe "require('./package.json').version")
           echo plugin version: $plugin_version
           echo plugin name: $AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME
-          if docker pull $OPENSEARCH_DOCKER_IMAGE:latest
+          if docker pull $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG
           then
             ## Populate the Dockerfiles
-            echo "FROM $OPENSEARCH_DOCKER_IMAGE:latest" >> Dockerfile-AD-OpenSearch
-            echo "FROM $DASHBOARDS_DOCKER_IMAGE:latest" >> Dockerfile-AD-OpenSearch-Dashboards
+            echo "FROM $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG" >> Dockerfile-AD-OpenSearch
+            echo "FROM $DASHBOARDS_DOCKER_IMAGE:$DASHBOARDS_DOCKER_TAG" >> Dockerfile-AD-OpenSearch-Dashboards
             echo "COPY build/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME-$plugin_version.zip ." >> Dockerfile-AD-OpenSearch-Dashboards
             ## Uninstall existing AD artifact and install new one
-            echo "RUN if [ -d /usr/share/opensearch-dashboards/plugins/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME ]; then /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove $AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME; fi" >> Dockerfile-AD-OpenSearch-Dashboards
+            echo "RUN if [ -d /usr/share/opensearch-dashboards/plugins/anomaly-detection-dashboards ]; then /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove anomaly-detection-dashboards; fi" >> Dockerfile-AD-OpenSearch-Dashboards
             echo "RUN bin/opensearch-dashboards-plugin install file:///usr/share/opensearch-dashboards/$AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME-$plugin_version.zip;" >> Dockerfile-AD-OpenSearch-Dashboards
 
             ## Create the tagged images
@@ -106,9 +108,9 @@ jobs:
     steps:
       - name: Pull and Run Docker
         run: |
-          if docker pull $OPENSEARCH_DOCKER_IMAGE:latest
+          if docker pull $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG
           then
-            echo "FROM $OPENSEARCH_DOCKER_IMAGE:latest" >> Dockerfile
+            echo "FROM $OPENSEARCH_DOCKER_IMAGE:$OPENSEARCH_DOCKER_TAG" >> Dockerfile
             ## The OpenSearch rest test client uses http by default.
             ## Need to disable the security plugin to call the rest api over http.
             ## Also need to remove any remaining security settings specified in opensearch.yml


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Changes the CI to run against the `1.0.0-rc1` staging docker images.

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
