### PR TITLE
Add broken link check workflow

### DIFF
--- a/.github/workflows/link-check-workflow.yml
+++ b/.github/workflows/link-check-workflow.yml
@@ -1,0 +1,23 @@
+name: Link Checker
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  linkchecker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: lychee Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Fail if there were link errors
+        run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.github/workflows/link-check-workflow.yml
+++ b/.github/workflows/link-check-workflow.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429 --exclude "localhost"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+          args: --accept=200,403,429 --exclude=localhost "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/link-check-workflow.yml
+++ b/.github/workflows/link-check-workflow.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429 --exclude *localhost*  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+          args: --accept=200,403,429 --exclude "*localhost*"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/link-check-workflow.yml
+++ b/.github/workflows/link-check-workflow.yml
@@ -15,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429 --exclude "*localhost*"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+          args: --accept=200,403,429 --exclude "localhost"  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/.github/workflows/link-check-workflow.yml
+++ b/.github/workflows/link-check-workflow.yml
@@ -1,13 +1,12 @@
 name: Link Checker
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   linkchecker:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -16,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
+          args: --accept=200,403,429 --exclude *localhost*  "**/*.html" "**/*.md" "**/*.txt" "**/*.json"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Unit tests](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/workflows/Unit%20tests%20workflow/badge.svg)](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/actions?query=workflow%3A%22Unit+tests+workflow%22)
 [![Integration tests](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/workflows/E2E%20tests%20workflow/badge.svg)](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/actions?query=workflow%3A%22E2E+tests+workflow%22)
 [![codecov](https://codecov.io/gh/opensearch-project/anomaly-detection-dashboards-plugin/branch/main/graph/badge.svg)](https://codecov.io/gh/opensearch-project/anomaly-detection-dashboards-plugin)
-[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://docs-beta.opensearch.org/docs/ad/)
+[![Documentation](https://img.shields.io/badge/doc-reference-blue)](https://docs-beta.opensearch.org/monitoring-plugins/ad/index/)
 [![Forum](https://img.shields.io/badge/chat-on%20forums-blue)](https://discuss.opendistrocommunity.dev/c/Use-this-category-for-all-questions-around-machine-learning-plugins)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
@@ -22,7 +22,7 @@ You should use the plugin with the same version of the [OpenSearch Alerting Dash
 
 ## Documentation
 
-Please see our [documentation](https://docs-beta.opensearch.org/docs/ad).
+Please see our [documentation](https://docs-beta.opensearch.org/monitoring-plugins/ad/index/).
 
 ## Setup
 

--- a/public/pages/AnomalyCharts/components/AlertsFlyout/__tests__/__snapshots__/AlertsFlyout.test.tsx.snap
+++ b/public/pages/AnomalyCharts/components/AlertsFlyout/__tests__/__snapshots__/AlertsFlyout.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with monitor 1`] 
                       Anomaly detector alerts are powered by the
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://docs-beta.opensearch.org/docs/alerting"
+                        href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//alerting"
                         rel="noreferrer"
                       >
                          
@@ -98,7 +98,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with monitor 1`] 
                       Alerting in your navigation panel,
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://docs-beta.opensearch.org/docs/opensearch/install/plugins/#alerting"
+                        href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//opensearch/install/plugins/#alerting"
                         rel="noreferrer"
                       >
                          
@@ -217,7 +217,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with monitor 1`] 
               <a
                 class="euiButton euiButton--primary"
                 data-test-subj="setUpAlerts"
-                href="https://docs-beta.opensearch.org/docs/alerting"
+                href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//alerting"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -363,7 +363,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with undefined mo
                       Anomaly detector alerts are powered by the
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://docs-beta.opensearch.org/docs/alerting"
+                        href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//alerting"
                         rel="noreferrer"
                       >
                          
@@ -388,7 +388,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with undefined mo
                       Alerting in your navigation panel,
                       <a
                         class="euiLink euiLink--primary"
-                        href="https://docs-beta.opensearch.org/docs/opensearch/install/plugins/#alerting"
+                        href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//opensearch/install/plugins/#alerting"
                         rel="noreferrer"
                       >
                          
@@ -507,7 +507,7 @@ exports[`<AlertsFlyout /> spec Alerts Flyout renders component with undefined mo
               <a
                 class="euiButton euiButton--primary"
                 data-test-subj="setUpAlerts"
-                href="https://docs-beta.opensearch.org/docs/alerting"
+                href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//alerting"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/public/pages/CreateHistoricalDetector/components/Configuration/__tests__/__snapshots__/Configuration.test.tsx.snap
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/__tests__/__snapshots__/Configuration.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`<Configuration /> spec renders the component in create mode with existi
                    
                   <a
                     class="euiLink euiLink--primary"
-                    href="https://docs-beta.opensearch.org/docs/ad"
+                    href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
@@ -703,7 +703,7 @@ exports[`<Configuration /> spec renders the component in edit mode without exist
                    
                   <a
                     class="euiLink euiLink--primary"
-                    href="https://docs-beta.opensearch.org/docs/ad"
+                    href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                     rel="noopener noreferrer"
                     target="_blank"
                   >

--- a/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/__snapshots__/Features.test.tsx.snap
+++ b/public/pages/CreateHistoricalDetector/components/Configuration/components/__tests__/__snapshots__/Features.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<Features /> spec renders the component with no given features 1`] = `
                
               <a
                 class="euiLink euiLink--primary"
-                href="https://docs-beta.opensearch.org/docs/ad"
+                href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                 rel="noopener noreferrer"
                 target="_blank"
               >
@@ -145,7 +145,7 @@ exports[`<Features /> spec renders the component with one feature 1`] = `
                
               <a
                 class="euiLink euiLink--primary"
-                href="https://docs-beta.opensearch.org/docs/ad"
+                href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/public/pages/CreateHistoricalDetector/containers/__tests__/__snapshots__/CreateHistoricalDetector.test.tsx.snap
+++ b/public/pages/CreateHistoricalDetector/containers/__tests__/__snapshots__/CreateHistoricalDetector.test.tsx.snap
@@ -813,7 +813,7 @@ exports[`<CreateHistoricalDetector /> spec create historical detector renders th
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://docs-beta.opensearch.org/docs/ad"
+                      href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -2271,7 +2271,7 @@ exports[`<CreateHistoricalDetector /> spec edit historical detector renders the 
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://docs-beta.opensearch.org/docs/ad"
+                      href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                       rel="noopener noreferrer"
                       target="_blank"
                     >

--- a/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
+++ b/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<EmptyDetector /> spec Empty results renders component with empty messa
          
         <a
           class="euiLink euiLink--primary"
-          href="https://docs-beta.opensearch.org/docs/ad"
+          href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
           rel="noopener noreferrer"
           target="_blank"
         >

--- a/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/EditFeatures/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<CategoryField /> spec hides callout if component is loading 1`] = `
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://docs-beta.opensearch.org/docs/ad"
+                      href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -177,7 +177,7 @@ exports[`<CategoryField /> spec renders the component when disabled 1`] = `
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://docs-beta.opensearch.org/docs/ad"
+                      href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -297,7 +297,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://docs-beta.opensearch.org/docs/ad"
+                      href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
@@ -517,7 +517,7 @@ exports[`<CategoryField /> spec shows callout when there are no available catego
                      
                     <a
                       class="euiLink euiLink--primary"
-                      href="https://docs-beta.opensearch.org/docs/ad"
+                      href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                       rel="noopener noreferrer"
                       target="_blank"
                     >

--- a/public/pages/SampleData/components/SampleDataCallout/__tests__/__snapshots__/SampleDataCallout.test.tsx.snap
+++ b/public/pages/SampleData/components/SampleDataCallout/__tests__/__snapshots__/SampleDataCallout.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<SampleDataCallout /> spec Data not loaded renders component 1`] = `
        
       <a
         class="euiLink euiLink--primary"
-        href="https://docs-beta.opensearch.org/docs/ad"
+        href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
+++ b/public/pages/createDetector/containers/__tests__/__snapshots__/CreateDetector.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<CreateDetector /> spec create detector renders the component 1`] = `
                
               <a
                 class="euiLink euiLink--primary"
-                href="https://docs-beta.opensearch.org/docs/ad"
+                href="https://docs-beta.opensearch.org/monitoring-plugins/ad/index//ad"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -76,7 +76,8 @@ export const ANOMALY_DETECTORS_INDEX = '.opendistro-anomaly-detectors';
 
 export const ANOMALY_RESULT_INDEX = '.opendistro-anomaly-results';
 
-export const BASE_DOCS_LINK = 'https://docs-beta.opensearch.org/docs';
+export const BASE_DOCS_LINK =
+  'https://docs-beta.opensearch.org/monitoring-plugins/ad/index/';
 
 export const MAX_DETECTORS = 1000;
 


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Adds a broken link checker workflow. Runs on pushes & pull requests to `main`. Based off of the `opensearch-plugins` [PR](https://github.com/opensearch-project/opensearch-plugins/pull/54).

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
