### PR TITLE
Rename default zip to anomaly-detection-dashboards

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -8,7 +8,7 @@ on:
       - main
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.0'
-  AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomalyDetectionDashboards
+  AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomaly-detection-dashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
   DOCKER_TAG: 1.0.0-rc1

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -45,7 +45,7 @@ Ultimately, your directory structure should look like this:
 
 To build the plugin's distributable zip simply run `yarn build`.
 
-Example output: `./build/anomalyDetectionDashboards-1.0.0.0.zip`
+Example output: `./build/anomaly-detection-dashboards-1.0.0.0.zip`
 
 ### Run
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "config": {
     "plugin_version": "1.0.0.0-rc1",
-    "plugin_name": "anomalyDetectionDashboards"
+    "plugin_name": "anomalyDetectionDashboards",
+    "plugin_zip_name": "anomaly-detection-dashboards"
   },
   "scripts": {
     "osd": "node ../../scripts/osd",
@@ -13,7 +14,7 @@
     "lint": "node ../../scripts/eslint .",
     "plugin-helpers": "node ../../scripts/plugin_helpers",
     "test:jest": "../../node_modules/.bin/jest --config ./test/jest.config.js",
-    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_name-$npm_package_config_plugin_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_name-$npm_package_config_plugin_version.zip",
+    "build": "yarn plugin-helpers build && echo Renaming artifact to $npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip && mv ./build/$npm_package_config_plugin_name*.zip ./build/$npm_package_config_plugin_zip_name-$npm_package_config_plugin_version.zip",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "cy:run-with-security": "cypress run --env SECURITY_ENABLED=true",


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Renames default zip from the camelCased `anomalyDetectionDashboards` to the kebab-cased `anomaly-detection-dashboards`.

Only affects zip - not plugin name (as seen in the url) or plugin ID.

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
