### PR TITLE
Bump to version 1.0.0.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "1.0.0.0-rc1",
-  "opensearchDashboardsVersion": "1.0.0-rc1",
+  "version": "1.0.0.0",
+  "opensearchDashboardsVersion": "1.0.0",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "1.0.0.0-rc1",
+  "version": "1.0.0.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "1.0.0.0-rc1",
+    "plugin_version": "1.0.0.0",
     "plugin_name": "anomalyDetectionDashboards",
     "plugin_zip_name": "anomaly-detection-dashboards"
   },


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Bumps the plugin version to `1.0.0.0` by removing the `rc1` version qualifier.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
