### PR TITLE
Change remaining references to historical analysis; other minor wording changes

### DIFF
--- a/public/pages/DetectorConfig/containers/__tests__/DetectorJobs.test.tsx
+++ b/public/pages/DetectorConfig/containers/__tests__/DetectorJobs.test.tsx
@@ -54,7 +54,7 @@ describe('<DetectorJobs /> spec', () => {
     getByText('Real-time detector');
     getByText(DETECTOR_STATE.INIT);
   });
-  test('renders with disabled historical detector', () => {
+  test('renders with disabled historical analysis', () => {
     const { getByText } = render(
       <DetectorJobs
         detector={{

--- a/public/pages/DetectorResults/components/OutOfRangeModal/OutOfRangeModal.tsx
+++ b/public/pages/DetectorResults/components/OutOfRangeModal/OutOfRangeModal.tsx
@@ -57,11 +57,10 @@ export const OutOfRangeModal = (props: OutOfRangeModalProps) => {
         <EuiFlexGroup direction="column">
           <EuiFlexItem grow={false}>
             <EuiText>
-              {`The selected dates are not in the range from when the detector
+              {`Your selected dates are not in the range from when the detector
                 last started streaming data (${convertTimestampToString(
                   props.lastEnabledTime
-                )}). To see historical data, go to
-                historical analysis.`}
+                )}).`}
             </EuiText>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
@@ -65,7 +65,7 @@ export const HistoricalDetectorCallout = (
             <EuiFlexGroup direction="row" gutterSize="xs">
               <EuiLoadingSpinner size="l" style={{ marginRight: '8px' }} />
               <EuiText>
-                <p>Stopping the historical detector</p>
+                <p>Stopping the historical analysis</p>
               </EuiText>
             </EuiFlexGroup>
           </div>
@@ -78,7 +78,7 @@ export const HistoricalDetectorCallout = (
     case DETECTOR_STATE.DISABLED:
       return (
         <EuiCallOut
-          title="The historical detector is stopped"
+          title="The historical analysis is stopped"
           color="primary"
           iconType="alert"
         />
@@ -91,7 +91,7 @@ export const HistoricalDetectorCallout = (
               <EuiFlexGroup direction="row" gutterSize="xs">
                 <EuiLoadingSpinner size="l" style={{ marginRight: '8px' }} />
                 <EuiText>
-                  <p>Initializing the historical detector.</p>
+                  <p>Initializing the historical analysis.</p>
                 </EuiText>
               </EuiFlexGroup>
             </div>
@@ -110,7 +110,7 @@ export const HistoricalDetectorCallout = (
                   style={{ marginRight: '8px', marginTop: '4px' }}
                 />
                 <EuiText>
-                  <p>Running the historical detector</p>
+                  <p>Running the historical analysis</p>
                 </EuiText>
               </EuiFlexGroup>
               {runningProgress ? (
@@ -137,7 +137,7 @@ export const HistoricalDetectorCallout = (
               <EuiSpacer size="s" />
               <EuiFlexItem grow={false} style={{ marginLeft: '22px' }}>
                 <EuiButton fill={false} onClick={() => props.onStopDetector()}>
-                  Stop historical detector
+                  Stop historical analysis
                 </EuiButton>
               </EuiFlexItem>
             </div>
@@ -158,7 +158,7 @@ export const HistoricalDetectorCallout = (
         <EuiCallOut
           title={
             <EuiText>
-              The historical detector has failed unexpectedly. Try restarting
+              The historical analysis has failed unexpectedly. Try restarting
               the detector.
             </EuiText>
           }

--- a/public/pages/HistoricalDetectorResults/components/__tests__/HistoricalDetectorCallout.test.tsx
+++ b/public/pages/HistoricalDetectorResults/components/__tests__/HistoricalDetectorCallout.test.tsx
@@ -40,7 +40,7 @@ describe('<HistoricalDetectorCallout /> spec', () => {
         isStoppingDetector={false}
       />
     );
-    getByText(`Initializing the historical detector.`);
+    getByText(`Initializing the historical analysis.`);
   });
   test('renders component when running and partial progress', () => {
     const { getByText } = render(
@@ -53,8 +53,8 @@ describe('<HistoricalDetectorCallout /> spec', () => {
         isStoppingDetector={false}
       />
     );
-    getByText('Running the historical detector');
-    getByText('Stop historical detector');
+    getByText('Running the historical analysis');
+    getByText('Stop historical analysis');
     getByText('50%');
   });
   test('shows task failure if failed', () => {
@@ -81,7 +81,7 @@ describe('<HistoricalDetectorCallout /> spec', () => {
       />
     );
     getByText(
-      `The historical detector has failed unexpectedly. Try restarting the detector.`
+      `The historical analysis has failed unexpectedly. Try restarting the detector.`
     );
   });
 });

--- a/public/pages/HistoricalDetectorResults/containers/HistoricalDetectorResults.tsx
+++ b/public/pages/HistoricalDetectorResults/containers/HistoricalDetectorResults.tsx
@@ -133,7 +133,7 @@ export function HistoricalDetectorResults(
         .then((response: any) => {
           setTaskId(get(response, 'response._id'));
           core.notifications.toasts.addSuccess(
-            `Successfully started the historical detector`
+            `Successfully started the historical analysis`
           );
         })
         .catch((err: any) => {
@@ -141,7 +141,7 @@ export function HistoricalDetectorResults(
             prettifyErrorMessage(
               getErrorMessage(
                 err,
-                'There was a problem starting the historical detector'
+                'There was a problem starting the historical analysis'
               )
             )
           );
@@ -152,7 +152,7 @@ export function HistoricalDetectorResults(
   };
 
   // We query the task state 5s after making the stop detector call. If the task is still running,
-  // then it is assumed there was an error stopping this task / historical detector.
+  // then it is assumed there was an error stopping this task / historical analysis.
   // TODO: change this from await dispatch() to using .then(), .catch(), etc.
   const onStopDetector = async () => {
     try {
@@ -164,13 +164,13 @@ export function HistoricalDetectorResults(
           throw 'please try again.';
         } else {
           core.notifications.toasts.addSuccess(
-            'Successfully stopped the historical detector'
+            'Successfully stopped the historical analysis'
           );
         }
       });
     } catch (err) {
       core.notifications.toasts.addDanger(
-        `There was a problem stopping the historical detector: ` +
+        `There was a problem stopping the historical analysis: ` +
           prettifyErrorMessage(getErrorMessage(err, ''))
       );
       fetchDetector();

--- a/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -131,7 +131,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
             )
               .then((response: any) => {
                 core.notifications.toasts.addSuccess(
-                  `Successfully started the historical detector`
+                  `Successfully started the historical analysis`
                 );
               })
               .catch((err: any) => {
@@ -139,7 +139,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
                   prettifyErrorMessage(
                     getErrorMessage(
                       err,
-                      'There was a problem starting the historical detector'
+                      'There was a problem starting the historical analysis'
                     )
                   )
                 );

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -333,7 +333,7 @@ export default class AdService {
       const endTime = request.body?.endTime;
       let requestParams = { detectorId: detectorId } as {};
       let requestPath = 'ad.startDetector';
-      // If a start and end time are passed: we want to start a historical detector
+      // If a start and end time are passed: we want to start a historical analysis
       if (isNumber(startTime) && isNumber(endTime)) {
         requestParams = {
           ...requestParams,


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

This PR cleans up some remaining wording changes:
- Replaces all remaining instances of `historical detector` => `historical analysis`
- Tunes wording on the out-of-range modal
- Updates corresponding UT

[List any issues this PR will resolve]

### Check List
  - [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
