### PR TITLE
Clean up copyright wording

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,2 +1,2 @@
 OpenSearch Anomaly Detection Dashboards
-Copyright 2021 OpenSearch Contributors
+Copyright OpenSearch Contributors

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.

--- a/public/pages/Overview/components/CreateWorkflowStepDetails.tsx
+++ b/public/pages/Overview/components/CreateWorkflowStepDetails.tsx
@@ -1,16 +1,12 @@
 /*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
  */
 
 import {

--- a/public/pages/Overview/components/CreateWorkflowStepSeparator.tsx
+++ b/public/pages/Overview/components/CreateWorkflowStepSeparator.tsx
@@ -1,17 +1,14 @@
 /*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
  */
+
 import { EuiFlexItem } from '@elastic/eui';
 import React from 'react';
 


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Cleans up copyright wording on README and NOTICE. Did a full audit to make sure all files have the SPDX header, and fixed 2 files that exclusively had the old header. The 2 files were created after the SPDX license was added, so the old Amazon header wasn't necessary.

### Issues Resolved

#67

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
