### PR TITLE
Change single size description

### DIFF
--- a/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
+++ b/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
@@ -77,13 +77,15 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
         <Field name="shingleSize" validate={validatePositiveInteger}>
           {({ field, form }: FieldProps) => (
             <FormattedFormRow
-              title="Window size"
+              title="Shingle size"
               hint={[
-                `Set the number of intervals to consider in a detection 
-                window for your model. We recommend using a window size 
-                between 1 and 16. If you expect missing values or if you 
-                want the anomalies exclusively based on the current interval, 
-                choose 1.`,
+                `Set the number of intervals to consider in a detection
+                window for your model. The anomaly detector expects the
+                shingle size to be in the range of 1 and 60. The default
+                shingle size is 8. We recommend that you don’t choose 1
+                unless you have two or more features. Smaller values might
+                increase recall but also false positives. Larger values
+                might be useful for ignoring noise in a signal.`,
               ]}
               hintLink={`${BASE_DOCS_LINK}/ad`}
               isInvalid={isInvalid(field.name, form)}


### PR DESCRIPTION
### Description

This PR changed the shingle size description.  Specifically,

1) I replaced window size with shingle size as we used shingle in various places of  https://opensearch.org/docs/monitoring-plugins/ad/index/, public API, and our code.  To be consistent, I changed to shingle.
2) We discourage the use of shingle size 1.  AD with 1 value is not well defined, attribution is not useful (100% always) and expected value is not well defined. The recommendation makes the result more useful to the customer.
3) Updated the range of shingle size.
4) Changed to have one default shingle size 8.  Don't differentiate HCAD and single-stream detectors.

Testing done:
1. unit and e2e tests pass.
2. Manually checked the changed text showed correctly.

Before:
![shingleSize_before](https://user-images.githubusercontent.com/5303417/130870091-f6cd1f60-bcf2-48a7-9d01-55d3b0337ab2.png)

After:
![shingleSize_after](https://user-images.githubusercontent.com/5303417/130870113-9834b242-d944-4185-8b4d-11387f38b633.png)

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
