### PR TITLE
 Change single size description and fix related places

### DIFF
--- a/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
+++ b/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
@@ -95,7 +95,7 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
                 <EuiFlexItem grow={false}>
                   <EuiFieldNumber
                     id="shingleSize"
-                    placeholder="Window size"
+                    placeholder="Shingle size"
                     data-test-subj="shingleSize"
                     {...field}
                   />

--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -256,7 +256,7 @@ export function ConfigureModel(props: ConfigureModelProps) {
                     <EuiText>
                       Set the index fields that you want to find anomalies for
                       by defining the model features. You can also set other
-                      model parameters such as category field and window size
+                      model parameters such as category field and shingle size
                       for more granular views. After you set the model features
                       and other optional parameters, you can preview your
                       anomalies from a sample feature output.{' '}

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
         <div
           class="euiText euiText--medium"
         >
-          Set the index fields that you want to find anomalies for by defining the model features. You can also set other model parameters such as category field and window size for more granular views. After you set the model features and other optional parameters, you can preview your anomalies from a sample feature output.
+          Set the index fields that you want to find anomalies for by defining the model features. You can also set other model parameters such as category field and shingle size for more granular views. After you set the model features and other optional parameters, you can preview your anomalies from a sample feature output.
            
           <a
             class="euiLink euiLink--primary"
@@ -929,7 +929,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
         <div
           class="euiText euiText--medium"
         >
-          Set the index fields that you want to find anomalies for by defining the model features. You can also set other model parameters such as category field and window size for more granular views. After you set the model features and other optional parameters, you can preview your anomalies from a sample feature output.
+          Set the index fields that you want to find anomalies for by defining the model features. You can also set other model parameters such as category field and shingle size for more granular views. After you set the model features and other optional parameters, you can preview your anomalies from a sample feature output.
            
           <a
             class="euiLink euiLink--primary"

--- a/public/pages/DetectorConfig/components/AdditionalSettings/AdditionalSettings.tsx
+++ b/public/pages/DetectorConfig/components/AdditionalSettings/AdditionalSettings.tsx
@@ -41,12 +41,12 @@ export function AdditionalSettings(props: AdditionalSettingsProps) {
       categoryField: isEmpty(get(props, 'categoryField', []))
         ? '-'
         : convertToCategoryFieldString(props.categoryField, ', '),
-      windowSize: props.shingleSize,
+      shingleSize: props.shingleSize,
     },
   ];
   const tableColumns = [
     { name: 'Categorical fields', field: 'categoryField' },
-    { name: 'Window size', field: 'windowSize' },
+    { name: 'Shingle size', field: 'shingleSize' },
   ];
   return (
     <ContentPanel title="Additional settings" titleSize="s">

--- a/public/pages/DetectorConfig/containers/Features.tsx
+++ b/public/pages/DetectorConfig/containers/Features.tsx
@@ -197,7 +197,7 @@ export const Features = (props: FeaturesProps) => {
 
   const setParamsText = `Set the index fields that you want to find anomalies for by defining
                            the model features. You can also set other model parameters such as
-                           window size.`;
+                           shingle size.`;
 
   const previewText = `After you set the model features and other optional parameters, you can
                          preview your anomalies from a sample feature output.`;

--- a/public/pages/ReviewAndCreate/components/AdditionalSettings/AdditionalSettings.tsx
+++ b/public/pages/ReviewAndCreate/components/AdditionalSettings/AdditionalSettings.tsx
@@ -37,12 +37,12 @@ export function AdditionalSettings(props: AdditionalSettingsProps) {
   const tableItems = [
     {
       categoryField: get(props, 'categoryField.0', '-'),
-      windowSize: props.shingleSize,
+      shingleSize: props.shingleSize,
     },
   ];
   const tableColumns = [
     { name: 'Category field', field: 'categoryField' },
-    { name: 'Window size', field: 'windowSize' },
+    { name: 'Shingle size', field: 'shingleSize' },
   ];
   return (
     <EuiBasicTable

--- a/public/pages/ReviewAndCreate/components/__tests__/AdditionalSettings.test.tsx
+++ b/public/pages/ReviewAndCreate/components/__tests__/AdditionalSettings.test.tsx
@@ -43,7 +43,7 @@ describe('<AdditionalSettings /> spec', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
     getAllByText('Category field');
-    getAllByText('Window size');
+    getAllByText('Shingle size');
     getByText('-');
     getByText('8');
   });
@@ -62,7 +62,7 @@ describe('<AdditionalSettings /> spec', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
     getAllByText('Category field');
-    getAllByText('Window size');
+    getAllByText('Shingle size');
     getByText('test_field');
     getByText('8');
   });

--- a/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/AdditionalSettings.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/AdditionalSettings.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<AdditionalSettings /> spec renders the component with high cardinality
             </th>
             <th
               class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_windowSize_1"
+              data-test-subj="tableHeaderCell_shingleSize_1"
               role="columnheader"
               scope="col"
             >
@@ -58,9 +58,9 @@ exports[`<AdditionalSettings /> spec renders the component with high cardinality
               >
                 <span
                   class="euiTableCellContent__text"
-                  title="Window size"
+                  title="Shingle size"
                 >
-                  Window size
+                  Shingle size
                 </span>
               </div>
             </th>
@@ -94,7 +94,7 @@ exports[`<AdditionalSettings /> spec renders the component with high cardinality
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
               >
-                Window size
+                Shingle size
               </div>
               <div
                 class="euiTableCellContent"
@@ -163,7 +163,7 @@ exports[`<AdditionalSettings /> spec renders the component with high cardinality
             </th>
             <th
               class="euiTableHeaderCell"
-              data-test-subj="tableHeaderCell_windowSize_1"
+              data-test-subj="tableHeaderCell_shingleSize_1"
               role="columnheader"
               scope="col"
             >
@@ -172,9 +172,9 @@ exports[`<AdditionalSettings /> spec renders the component with high cardinality
               >
                 <span
                   class="euiTableCellContent__text"
-                  title="Window size"
+                  title="Shingle size"
                 >
-                  Window size
+                  Shingle size
                 </span>
               </div>
             </th>
@@ -208,7 +208,7 @@ exports[`<AdditionalSettings /> spec renders the component with high cardinality
               <div
                 class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
               >
-                Window size
+                Shingle size
               </div>
               <div
                 class="euiTableCellContent"

--- a/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
@@ -433,7 +433,7 @@ exports[`<ReviewAndCreate /> spec renders the component 1`] = `
                       </th>
                       <th
                         class="euiTableHeaderCell"
-                        data-test-subj="tableHeaderCell_windowSize_1"
+                        data-test-subj="tableHeaderCell_shingleSize_1"
                         role="columnheader"
                         scope="col"
                       >
@@ -442,9 +442,9 @@ exports[`<ReviewAndCreate /> spec renders the component 1`] = `
                         >
                           <span
                             class="euiTableCellContent__text"
-                            title="Window size"
+                            title="Shingle size"
                           >
-                            Window size
+                            Shingle size
                           </span>
                         </div>
                       </th>
@@ -478,7 +478,7 @@ exports[`<ReviewAndCreate /> spec renders the component 1`] = `
                         <div
                           class="euiTableRowCell__mobileHeader euiTableRowCell--hideForDesktop"
                         >
-                          Window size
+                          Shingle size
                         </div>
                         <div
                           class="euiTableCellContent"

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -146,18 +146,18 @@ export const calculateTimeWindowsWithMaxDataPoints = (
 ): DateRange[] => {
   const resultSampleWindows = [] as DateRange[];
   const rangeInMilliSec = dateRange.endDate - dateRange.startDate;
-  const windowSizeinMilliSec = Math.max(
+  const shingleSizeinMilliSec = Math.max(
     Math.ceil(rangeInMilliSec / maxDataPoints),
     MIN_IN_MILLI_SECS
   );
   for (
     let currentTime = dateRange.startDate;
     currentTime < dateRange.endDate;
-    currentTime += windowSizeinMilliSec
+    currentTime += shingleSizeinMilliSec
   ) {
     resultSampleWindows.push({
       startDate: currentTime,
-      endDate: Math.min(currentTime + windowSizeinMilliSec, dateRange.endDate),
+      endDate: Math.min(currentTime + shingleSizeinMilliSec, dateRange.endDate),
     } as DateRange);
   }
   return resultSampleWindows;


### PR DESCRIPTION
### Description

This PR changed the shingle size description.  Specifically,

1) I replaced window size with shingle size as we used shingle in various places of  https://opensearch.org/docs/monitoring-plugins/ad/index/, public API, and our code.  To be consistent, I changed to shingle.
2) We discourage the use of shingle size 1.  AD with 1 value is not well defined, attribution is not useful (100% always) and expected value is not well defined. The recommendation makes the result more useful to the customer.
3) Updated the range of shingle size.
4) Changed to have one default shingle size 8.  Don't differentiate HCAD and single-stream detectors.

Testing done:
1. unit and e2e tests pass.
2. Manually checked the changed text showed correctly.

Before:
![shingleSize_before](https://user-images.githubusercontent.com/5303417/130870091-f6cd1f60-bcf2-48a7-9d01-55d3b0337ab2.png)

After:
![shingleSize_after](https://user-images.githubusercontent.com/5303417/130870113-9834b242-d944-4185-8b4d-11387f38b633.png)

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
