### PR TITLE
Bug fixes for single flow feature

### DIFF
--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -180,6 +180,14 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
     }
   }, [detector]);
 
+  // If the detector state was changed after opening the stop detector modal,
+  // re-check if any jobs are running, and close the modal if it's not needed anymore
+  useEffect(() => {
+    if (!isRTJobRunning && !isHistoricalJobRunning) {
+      hideStopDetectorModal();
+    }
+  }, [detector]);
+
   const handleSwitchToConfigurationTab = useCallback(() => {
     setDetectorDetailModel({
       ...detectorDetailModel,

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -50,6 +50,7 @@ import {
   startDetector,
   stopDetector,
   getDetector,
+  stopHistoricalDetector,
 } from '../../../redux/reducers/ad';
 import { getErrorMessage, Listener } from '../../../utils/utils';
 import { darkModeEnabled } from '../../../utils/opensearchDashboardsUtils';
@@ -66,6 +67,7 @@ import {
   NO_PERMISSIONS_KEY_WORD,
   prettifyErrorMessage,
 } from '../../../../server/utils/helpers';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
 
 export interface DetectorRouterProps {
   detectorId?: string;
@@ -120,6 +122,20 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   const { monitor, fetchMonitorError, isLoadingMonitor } = useFetchMonitorInfo(
     detectorId
   );
+  // String to set in the modal if the realtime detector and/or historical analysis
+  // are running when the user tries to edit the detector details or model config
+  const isRTJobRunning = get(detector, 'enabled');
+  const isHistoricalJobRunning =
+    get(detector, 'taskState') === DETECTOR_STATE.RUNNING ||
+    get(detector, 'taskState') === DETECTOR_STATE.INIT;
+  const runningJobsAsString =
+    isRTJobRunning && isHistoricalJobRunning
+      ? 'detector and historical analysis'
+      : isRTJobRunning
+      ? 'detector'
+      : isHistoricalJobRunning
+      ? 'historical analysis'
+      : '';
 
   //TODO: test dark mode once detector configuration and AD result page merged
   const isDark = darkModeEnabled();
@@ -245,15 +261,23 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
 
   const handleStopAdJob = async (detectorId: string, listener?: Listener) => {
     try {
-      await dispatch(stopDetector(detectorId));
+      if (isRTJobRunning) {
+        await dispatch(stopDetector(detectorId));
+      }
+      if (isHistoricalJobRunning) {
+        await dispatch(stopHistoricalDetector(detectorId));
+      }
       core.notifications.toasts.addSuccess(
-        'Successfully stopped the detector job'
+        `Successfully stopped the ${runningJobsAsString}`
       );
       if (listener) listener.onSuccess();
     } catch (err) {
       core.notifications.toasts.addDanger(
         prettifyErrorMessage(
-          getErrorMessage(err, 'There was a problem stopping the detector job')
+          getErrorMessage(
+            err,
+            `There was a problem stopping the ${runningJobsAsString}`
+          )
         )
       );
       if (listener) listener.onException();
@@ -277,7 +301,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   }, []);
 
   const handleEditDetector = () => {
-    detector.enabled
+    isRTJobRunning || isHistoricalJobRunning
       ? setDetectorDetailModel({
           ...detectorDetailModel,
           showStopDetectorModalFor: 'detector',
@@ -286,7 +310,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   };
 
   const handleEditFeature = () => {
-    detector.enabled
+    isRTJobRunning || isHistoricalJobRunning
       ? setDetectorDetailModel({
           ...detectorDetailModel,
           showStopDetectorModalFor: 'features',
@@ -301,15 +325,14 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
     <MonitorCallout monitorId={monitor.id} monitorName={monitor.name} />
   ) : null;
 
-  const deleteDetectorCallout = detector.enabled ? (
-    <EuiCallOut
-      title="The detector is running. Are you sure you want to proceed?"
-      color="warning"
-      iconType="alert"
-    ></EuiCallOut>
-  ) : null;
-
-  const isHCDetector = !isEmpty(get(detector, 'categoryField', []));
+  const deleteDetectorCallout =
+    isRTJobRunning || isHistoricalJobRunning ? (
+      <EuiCallOut
+        title={`The ${runningJobsAsString} is running. Are you sure you want to proceed?`}
+        color="warning"
+        iconType="alert"
+      ></EuiCallOut>
+    ) : null;
 
   return (
     <React.Fragment>
@@ -454,8 +477,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
         <EuiOverlayMask>
           <ConfirmModal
             title="Stop detector to proceed?"
-            description="You must stop the detector to change its 
-                      configuration. After you reconfigure the detector, be sure to restart it."
+            description={`You must stop the ${runningJobsAsString} to change its configuration. After you reconfigure the detector, be sure to restart it.`}
             callout={monitorCallout}
             confirmButtonText="Stop and proceed to edit"
             confirmButtonColor="primary"

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -575,6 +575,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                   detector={props.detector}
                   monitor={props.monitor}
                   isHCDetector={isHCDetector}
+                  isHistorical={props.isHistorical}
                   selectedHeatmapCell={selectedHeatmapCell}
                 />,
                 <EuiSpacer size="m" />,


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

This PR fixes 2 bugs found when testing out the single flow feature:
1. Historical analysis task not being taken into consideration when editing the detector settings or model config. The fix: add checks for if the historical task is running or not before editing, and add verbose messaging around that. Added a custom hook which will automatically close the modal if the detector task states have been changed after opening the modal (e.g., the historical analysis was `RUNNING` when initially opened, but was changed to `FINISHED` soon after).
2. 'The detector was stopped' messaging showing up when selecting a heatmap cell for a historical high-cardinality detector, during a timeframe where the corresponding real-time task was not running. The fix: propagate the `isHistorical` prop to the relevant components, which will hide these annotations if the chart is being rendered in a historical context.

Testing:
- Tested all 4 scenarios of detector tasks running (just realtime, just historical, both realtime & historical, neither realtime or historical), when clicking on the edit features or edit detector buttons to confirm the wording is correct, and the relevant tasks are stopped.

Screenshots of an example where both realtime and historical jobs were running:

Updated wording in modal:
![Screen Shot 2021-08-27 at 11 56 42 AM](https://user-images.githubusercontent.com/62119629/131176055-5764ad2f-abc7-452a-a7d9-c4a3f5baf3b6.png)

Updated wording in toast:
![Screen Shot 2021-08-27 at 11 57 14 AM](https://user-images.githubusercontent.com/62119629/131176066-9d23a521-e1b2-4da5-8324-63d98ee2c8cc.png)


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
