### PR TITLE
Enable zooming in HC entity charts

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -494,28 +494,24 @@ export const AnomalyDetailsChart = React.memo(
                     //TODO: research more why only set this old property will work.
                     showLegendDisplayValue={false}
                     legendPosition={Position.Right}
-                    onBrushEnd={
-                      props.isHCDetector
-                        ? undefined
-                        : (brushArea: XYBrushArea) => {
-                            const start = get(
-                              brushArea,
-                              'x.0',
-                              DEFAULT_DATE_PICKER_RANGE.start
-                            );
-                            const end = get(
-                              brushArea,
-                              'x.1',
-                              DEFAULT_DATE_PICKER_RANGE.start
-                            );
-                            !props.bucketizedAnomalies
-                              ? handleZoomRangeChange(start, end)
-                              : handleDateRangeChange(start, end);
-                            if (props.onDatePickerRangeChange) {
-                              props.onDatePickerRangeChange(start, end);
-                            }
-                          }
-                    }
+                    onBrushEnd={(brushArea: XYBrushArea) => {
+                      const start = get(
+                        brushArea,
+                        'x.0',
+                        DEFAULT_DATE_PICKER_RANGE.start
+                      );
+                      const end = get(
+                        brushArea,
+                        'x.1',
+                        DEFAULT_DATE_PICKER_RANGE.start
+                      );
+                      !props.bucketizedAnomalies
+                        ? handleZoomRangeChange(start, end)
+                        : handleDateRangeChange(start, end);
+                      if (props.onDatePickerRangeChange) {
+                        props.onDatePickerRangeChange(start, end);
+                      }
+                    }}
                     theme={ANOMALY_CHART_THEME}
                   />
                   {(props.isHCDetector && !props.selectedHeatmapCell) ||

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -49,7 +49,6 @@ import {
   filterWithHeatmapFilter,
   entityListsMatch,
 } from '../../utils/anomalyResultUtils';
-import { getDateRangeWithSelectedHeatmapCell } from '../utils/anomalyChartUtils';
 import { Entity } from '../../../../server/models/interfaces';
 
 interface FeatureBreakDownProps {
@@ -97,9 +96,8 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
             !isEmpty(dataEntityList) &&
             entityListsMatch(dataEntityList, cellEntityList) &&
             get(currentAnomalyData, 'plotTime', 0) >=
-              props.selectedHeatmapCell.dateRange.startDate &&
-            get(currentAnomalyData, 'plotTime', 0) <=
-              props.selectedHeatmapCell.dateRange.endDate
+              props.dateRange.startDate &&
+            get(currentAnomalyData, 'plotTime', 0) <= props.dateRange.endDate
           ) {
             filteredFeatureData.push(originalFeatureData[i]);
           }
@@ -169,11 +167,7 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
               )}
               annotations={getAnnotationData()}
               isLoading={props.isLoading}
-              dateRange={getDateRangeWithSelectedHeatmapCell(
-                props.dateRange,
-                props.isHCDetector,
-                props.selectedHeatmapCell
-              )}
+              dateRange={props.dateRange}
               featureType={
                 get(
                   props,

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -306,6 +306,10 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   useEffect(() => {
     if (selectedHeatmapCell) {
       fetchEntityAnomalyData(selectedHeatmapCell);
+      handleZoomChange(
+        selectedHeatmapCell.dateRange.startDate,
+        selectedHeatmapCell.dateRange.endDate
+      );
     } else {
       setAtomicAnomalyResults(hcDetectorAnomalyResults);
     }
@@ -634,6 +638,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                     )}
                     isHCDetector={isHCDetector}
                     isHistorical={props.isHistorical}
+                    selectedHeatmapCell={selectedHeatmapCell}
                   />
                 )}
               </EuiPanel>

--- a/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResultsTable.tsx
@@ -43,11 +43,13 @@ import { DetectorResultsQueryParams } from 'server/models/types';
 import { AnomalyData } from '../../../models/interfaces';
 import { getTitleWithCount } from '../../../utils/utils';
 import { convertToCategoryFieldAndEntityString } from '../../utils/anomalyResultUtils';
+import { HeatmapCell } from '../../AnomalyCharts/containers/AnomalyHeatmapChart';
 
 interface AnomalyResultsTableProps {
   anomalies: AnomalyData[];
   isHCDetector?: boolean;
   isHistorical?: boolean;
+  selectedHeatmapCell?: HeatmapCell | undefined;
 }
 
 interface ListState {
@@ -67,9 +69,13 @@ export function AnomalyResultsTable(props: AnomalyResultsTableProps) {
     },
   });
   const [targetAnomalies, setTargetAnomalies] = useState<any[]>([] as any[]);
-  const totalAnomalies = props.anomalies
-    ? props.anomalies.filter((anomaly) => anomaly.anomalyGrade > 0)
-    : [];
+
+  // Only return anomalies if they exist. If high-cardinality: only show when a heatmap cell is selected
+  const totalAnomalies =
+    props.anomalies &&
+    ((props.isHCDetector && props.selectedHeatmapCell) || !props.isHCDetector)
+      ? props.anomalies.filter((anomaly) => anomaly.anomalyGrade > 0)
+      : [];
 
   const sortFieldCompare = (field: string, sortDirection: SORT_DIRECTION) => {
     return (a: any, b: any) => {
@@ -82,9 +88,12 @@ export function AnomalyResultsTable(props: AnomalyResultsTableProps) {
   };
 
   useEffect(() => {
-    let anomalies = props.anomalies
-      ? props.anomalies.filter((anomaly) => anomaly.anomalyGrade > 0)
-      : [];
+    // Only return anomalies if they exist. If high-cardinality: only show when a heatmap cell is selected
+    let anomalies =
+      props.anomalies &&
+      ((props.isHCDetector && props.selectedHeatmapCell) || !props.isHCDetector)
+        ? props.anomalies.filter((anomaly) => anomaly.anomalyGrade > 0)
+        : [];
 
     if (props.isHCDetector) {
       anomalies = anomalies.map((anomaly) => {


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

This PR adds zooming capabilities to the anomaly chart when selecting a heatmap cell for high-cardinality detectors.

Changes include:
- `AnomaliesDetailChart`: Allowing zooming for high-cardinality detectors
- `FeatureBreakDown`: Setting the date range based on the passed-in date range (which is `zoomRange`) instead of the heatmap cell. This is so we can narrow the range if the user zooms, rather than leaving it at the heatmap cell's static range.
- `AnomalyHistory`: setting the `zoomRange` when a heatmap cell is selected or de-selected, to refresh any stored data in the components. This is needed since `FeatureBreakDown` now relies on the `zoomRange` to get the date range. 
- `AnomalyResultsTable`: Only populate with anomalies when applicable. The two applicable cases are (1) non high-cardinality detectors and (2) high-cardinality detectors when a heatmap cell is selected. This had to be changed due to the `zoomRange` allowing more results to be shown, so more filtering was needed.

Testing:
Confirmed the zooming works, and updates the corresponding table and feature breakdown accordingly.
Confirmed that selecting different heatmap cells or de-selecting heatmap cells will clear the zoom range.
Confirmed it works for historical and real-time.
Confirmed it doesn't break the components for non-high-cardinality detectors.

### Issues Resolved

#75

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
