### PR TITLE
Add callouts and make category fields readonly after creation

### DIFF
--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -106,6 +106,24 @@ export function CategoryField(props: CategoryFieldProps) {
         ></EuiCallOut>
       ) : null}
       {noCategoryFields ? <EuiSpacer size="m" /> : null}
+      {props.isEdit ? (
+        <EuiCallOut
+          data-test-subj="noCategoryFieldsCallout"
+          title="<Placeholder for text when editing>"
+          color="primary"
+          iconType="iInCircle"
+          size="s"
+        ></EuiCallOut>
+      ) : (
+        <EuiCallOut
+          data-test-subj="noCategoryFieldsCallout"
+          title="<Placeholder for text when creating>"
+          color="warning"
+          iconType="alert"
+          size="s"
+        ></EuiCallOut>
+      )}
+      <EuiSpacer size="m" />
       <Field
         name="categoryField"
         validate={enabled ? validateCategoryField : null}
@@ -117,7 +135,7 @@ export function CategoryField(props: CategoryFieldProps) {
                 id={'categoryFieldCheckbox'}
                 label="Enable categorical fields"
                 checked={enabled}
-                disabled={noCategoryFields}
+                disabled={noCategoryFields || props.isEdit}
                 onChange={() => {
                   if (!enabled) {
                     props.setIsHCDetector(true);
@@ -167,6 +185,7 @@ export function CategoryField(props: CategoryFieldProps) {
                     }
                     singleSelection={false}
                     isClearable={true}
+                    isDisabled={props.isEdit}
                   />
                 </EuiFormRow>
               </EuiFlexItem>

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -108,7 +108,7 @@ export function CategoryField(props: CategoryFieldProps) {
       {noCategoryFields ? <EuiSpacer size="m" /> : null}
       {props.isEdit ? (
         <EuiCallOut
-          data-test-subj="noCategoryFieldsCallout"
+          data-test-subj="categoryFieldReadOnlyCallout"
           title="<Placeholder for text when editing>"
           color="primary"
           iconType="iInCircle"
@@ -116,7 +116,7 @@ export function CategoryField(props: CategoryFieldProps) {
         ></EuiCallOut>
       ) : (
         <EuiCallOut
-          data-test-subj="noCategoryFieldsCallout"
+          data-test-subj="cannotEditCategoryFieldCallout"
           title="<Placeholder for text when creating>"
           color="warning"
           iconType="alert"

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -109,21 +109,13 @@ export function CategoryField(props: CategoryFieldProps) {
       {props.isEdit ? (
         <EuiCallOut
           data-test-subj="categoryFieldReadOnlyCallout"
-          title="<Placeholder for text when editing>"
+          title="Category fields cannot be changed once the detector is created"
           color="primary"
           iconType="iInCircle"
           size="s"
         ></EuiCallOut>
-      ) : (
-        <EuiCallOut
-          data-test-subj="cannotEditCategoryFieldCallout"
-          title="<Placeholder for text when creating>"
-          color="warning"
-          iconType="alert"
-          size="s"
-        ></EuiCallOut>
-      )}
-      <EuiSpacer size="m" />
+      ) : null}
+      {props.isEdit ? <EuiSpacer size="m" /> : null}
       <Field
         name="categoryField"
         validate={enabled ? validateCategoryField : null}
@@ -148,6 +140,17 @@ export function CategoryField(props: CategoryFieldProps) {
                 }}
               />
             </EuiFlexItem>
+            {enabled && !props.isEdit ? (
+              <EuiFlexItem>
+                <EuiCallOut
+                  data-test-subj="cannotEditCategoryFieldCallout"
+                  title="Category fields cannot be changed once the detector is created. Please ensure that you select the fields necessary for your case."
+                  color="warning"
+                  iconType="alert"
+                  size="s"
+                ></EuiCallOut>
+              </EuiFlexItem>
+            ) : null}
             {enabled && !noCategoryFields ? (
               <EuiFlexItem>
                 <EuiFormRow

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
@@ -261,7 +261,7 @@ describe('<CategoryField /> spec', () => {
     expect(queryByText('b')).toBeNull();
     expect(queryByText('c')).toBeNull();
   });
-  test('shows warning callout if creating', () => {
+  test('shows warning callout if creating & category field enabled', () => {
     const { queryByTestId } = render(
       <Fragment>
         <Formik
@@ -293,7 +293,39 @@ describe('<CategoryField /> spec', () => {
     );
     expect(queryByTestId('cannotEditCategoryFieldCallout')).not.toBeNull();
   });
-  test('shows info callout if editing', () => {
+  test('hides warning callout if creating & category field disabled', () => {
+    const { queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isEdit={false}
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                formikProps={{
+                  values: {
+                    categoryFieldEnabled: true,
+                  },
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(queryByTestId('cannotEditCategoryFieldCallout')).not.toBeNull();
+  });
+  test('shows info callout and hides warning callout if editing', () => {
     const { queryByTestId } = render(
       <Fragment>
         <Formik
@@ -324,5 +356,6 @@ describe('<CategoryField /> spec', () => {
       </Fragment>
     );
     expect(queryByTestId('categoryFieldReadOnlyCallout')).not.toBeNull();
+    expect(queryByTestId('cannotEditCategoryFieldCallout')).toBeNull();
   });
 });

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
@@ -25,7 +25,7 @@
  */
 
 import React, { Fragment } from 'react';
-import { render, fireEvent, getByRole } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { Form, Formik } from 'formik';
 import { CategoryField } from '../CategoryField';
 
@@ -110,7 +110,7 @@ describe('<CategoryField /> spec', () => {
     getByText('b');
   });
   test('shows callout when there are no available category fields', () => {
-    const { container, queryByText, queryByTestId } = render(
+    const { queryByText, queryByTestId } = render(
       <Fragment>
         <Formik
           initialValues={{
@@ -139,13 +139,12 @@ describe('<CategoryField /> spec', () => {
         </Formik>
       </Fragment>
     );
-    expect(container).toMatchSnapshot();
     expect(queryByTestId('noCategoryFieldsCallout')).not.toBeNull();
     expect(queryByTestId('categoryFieldComboBox')).toBeNull();
     expect(queryByText('Enable categorical fields')).not.toBeNull();
   });
   test('hides callout if component is loading', () => {
-    const { container, queryByText, queryByTestId } = render(
+    const { queryByText, queryByTestId } = render(
       <Fragment>
         <Formik
           initialValues={{
@@ -174,7 +173,6 @@ describe('<CategoryField /> spec', () => {
         </Formik>
       </Fragment>
     );
-    expect(container).toMatchSnapshot();
     expect(queryByTestId('noCategoryFieldsCallout')).toBeNull();
     expect(queryByText('Enable categorical fields')).not.toBeNull();
   });
@@ -226,5 +224,105 @@ describe('<CategoryField /> spec', () => {
     expect(queryByText('a')).not.toBeNull();
     expect(queryByText('b')).not.toBeNull();
     expect(queryByText('c')).toBeNull();
+  });
+  test(`fields are readonly if editing`, () => {
+    const { getByTestId, queryByText } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isEdit={true}
+                isHCDetector={true}
+                categoryFieldOptions={['a', 'b', 'c']}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                formikProps={{
+                  values: {
+                    categoryFieldEnabled: true,
+                  },
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    // try to open combo box. options should not show since the box is readonly
+    fireEvent.click(getByTestId('comboBoxToggleListButton'));
+    expect(queryByText('a')).toBeNull();
+    expect(queryByText('b')).toBeNull();
+    expect(queryByText('c')).toBeNull();
+  });
+  test('shows warning callout if creating', () => {
+    const { queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isEdit={false}
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                formikProps={{
+                  values: {
+                    categoryFieldEnabled: true,
+                  },
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(queryByTestId('cannotEditCategoryFieldCallout')).not.toBeNull();
+  });
+  test('shows info callout if editing', () => {
+    const { queryByTestId } = render(
+      <Fragment>
+        <Formik
+          initialValues={{
+            categoryField: [],
+          }}
+          onSubmit={() => {}}
+        >
+          <Fragment>
+            <Form>
+              <CategoryField
+                isEdit={true}
+                isHCDetector={true}
+                categoryFieldOptions={[]}
+                setIsHCDetector={(isHCDetector: boolean) => {
+                  return;
+                }}
+                isLoading={false}
+                formikProps={{
+                  values: {
+                    categoryFieldEnabled: true,
+                  },
+                }}
+              />
+            </Form>
+          </Fragment>
+        </Formik>
+      </Fragment>
+    );
+    expect(queryByTestId('categoryFieldReadOnlyCallout')).not.toBeNull();
   });
 });

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/CategoryField.test.tsx
@@ -314,7 +314,7 @@ describe('<CategoryField /> spec', () => {
                 isLoading={false}
                 formikProps={{
                   values: {
-                    categoryFieldEnabled: true,
+                    categoryFieldEnabled: false,
                   },
                 }}
               />
@@ -323,7 +323,7 @@ describe('<CategoryField /> spec', () => {
         </Formik>
       </Fragment>
     );
-    expect(queryByTestId('cannotEditCategoryFieldCallout')).not.toBeNull();
+    expect(queryByTestId('cannotEditCategoryFieldCallout')).toBeNull();
   });
   test('shows info callout and hides warning callout if editing', () => {
     const { queryByTestId } = render(

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -85,33 +85,6 @@ exports[`<CategoryField /> spec renders the component when disabled 1`] = `
           style="padding: 10px 0px;"
         >
           <div
-            class="euiCallOut euiCallOut--warning euiCallOut--small"
-            data-test-subj="cannotEditCategoryFieldCallout"
-          >
-            <div
-              class="euiCallOutHeader"
-            >
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              />
-              <span
-                class="euiCallOutHeader__title"
-              >
-                &lt;Placeholder for text when creating&gt;
-              </span>
-            </div>
-          </div>
-          <div
-            class="euiSpacer euiSpacer--m"
-          />
-          <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
           >
             <div
@@ -233,38 +206,6 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
           style="padding: 10px 0px;"
         >
           <div
-            class="euiCallOut euiCallOut--warning euiCallOut--small"
-            data-test-subj="cannotEditCategoryFieldCallout"
-          >
-            <div
-              class="euiCallOutHeader"
-            >
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--medium euiCallOutHeader__icon"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7.59 10.059L7.35 5.18h1.3L8.4 10.06h-.81zm.394 1.901a.61.61 0 01-.448-.186.606.606 0 01-.186-.444c0-.174.062-.323.186-.446a.614.614 0 01.448-.184c.169 0 .315.06.44.182.124.122.186.27.186.448a.6.6 0 01-.189.446.607.607 0 01-.437.184zM2 14a1 1 0 01-.878-1.479l6-11a1 1 0 011.756 0l6 11A1 1 0 0114 14H2zm0-1h12L8 2 2 13z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-              <span
-                class="euiCallOutHeader__title"
-              >
-                &lt;Placeholder for text when creating&gt;
-              </span>
-            </div>
-          </div>
-          <div
-            class="euiSpacer euiSpacer--m"
-          />
-          <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
           >
             <div
@@ -288,6 +229,34 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                 >
                   Enable categorical fields
                 </label>
+              </div>
+            </div>
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiCallOut euiCallOut--warning euiCallOut--small"
+                data-test-subj="cannotEditCategoryFieldCallout"
+              >
+                <div
+                  class="euiCallOutHeader"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  />
+                  <span
+                    class="euiCallOutHeader__title"
+                  >
+                    Category fields cannot be changed once the detector is created. Please ensure that you select the fields necessary for your case.
+                  </span>
+                </div>
               </div>
             </div>
             <div

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -1,131 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<CategoryField /> spec hides callout if component is loading 1`] = `
-<div>
-  <form
-    action="#"
-  >
-    <div
-      class="euiPanel euiPanel--paddingMedium"
-      style="padding: 20px;"
-    >
-      <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style="padding: 0px;"
-      >
-        <div
-          class="euiFlexItem"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            >
-              <h2
-                class="euiTitle euiTitle--small"
-                id="categoryFieldTitle"
-              >
-                Categorical fields 
-              </h2>
-            </div>
-          </div>
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem content-panel-subTitle"
-              style="line-height: normal; max-width: 75%;"
-            >
-              <div
-                class="euiText euiText--medium content-panel-subTitle"
-                style="line-height: normal;"
-              >
-                Split a single time series into multiple time series based on categorical fields. You can select up to 2.
-                 
-                <a
-                  class="euiLink euiLink--primary"
-                  href="https://opensearch.org/docs/monitoring-plugins/ad"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            />
-          </div>
-        </div>
-      </div>
-      <div>
-        <hr
-          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-        />
-        <div
-          style="padding: 10px 0px;"
-        >
-          <div
-            class="euiSpacer euiSpacer--m"
-          />
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiCheckbox"
-              >
-                <input
-                  checked=""
-                  class="euiCheckbox__input"
-                  disabled=""
-                  id="categoryFieldCheckbox"
-                  type="checkbox"
-                />
-                <div
-                  class="euiCheckbox__square"
-                />
-                <label
-                  class="euiCheckbox__label"
-                  for="categoryFieldCheckbox"
-                >
-                  Enable categorical fields
-                </label>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </form>
-</div>
-`;
-
 exports[`<CategoryField /> spec renders the component when disabled 1`] = `
 <div>
   <form
@@ -210,6 +84,33 @@ exports[`<CategoryField /> spec renders the component when disabled 1`] = `
         <div
           style="padding: 10px 0px;"
         >
+          <div
+            class="euiCallOut euiCallOut--warning euiCallOut--small"
+            data-test-subj="cannotEditCategoryFieldCallout"
+          >
+            <div
+              class="euiCallOutHeader"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiCallOutHeader__title"
+              >
+                &lt;Placeholder for text when creating&gt;
+              </span>
+            </div>
+          </div>
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
           >
@@ -332,6 +233,38 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
           style="padding: 10px 0px;"
         >
           <div
+            class="euiCallOut euiCallOut--warning euiCallOut--small"
+            data-test-subj="cannotEditCategoryFieldCallout"
+          >
+            <div
+              class="euiCallOutHeader"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiCallOutHeader__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7.59 10.059L7.35 5.18h1.3L8.4 10.06h-.81zm.394 1.901a.61.61 0 01-.448-.186.606.606 0 01-.186-.444c0-.174.062-.323.186-.446a.614.614 0 01.448-.184c.169 0 .315.06.44.182.124.122.186.27.186.448a.6.6 0 01-.189.446.607.607 0 01-.437.184zM2 14a1 1 0 01-.878-1.479l6-11a1 1 0 011.756 0l6 11A1 1 0 0114 14H2zm0-1h12L8 2 2 13z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+              <span
+                class="euiCallOutHeader__title"
+              >
+                &lt;Placeholder for text when creating&gt;
+              </span>
+            </div>
+          </div>
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
           >
             <div
@@ -450,156 +383,6 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                     You can only apply the categorical fields to the 'ip' and 'keyword' OpenSearch data types.
                   </div>
                 </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </form>
-</div>
-`;
-
-exports[`<CategoryField /> spec shows callout when there are no available category fields 1`] = `
-<div>
-  <form
-    action="#"
-  >
-    <div
-      class="euiPanel euiPanel--paddingMedium"
-      style="padding: 20px;"
-    >
-      <div
-        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-        style="padding: 0px;"
-      >
-        <div
-          class="euiFlexItem"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            >
-              <h2
-                class="euiTitle euiTitle--small"
-                id="categoryFieldTitle"
-              >
-                Categorical fields 
-              </h2>
-            </div>
-          </div>
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem content-panel-subTitle"
-              style="line-height: normal; max-width: 75%;"
-            >
-              <div
-                class="euiText euiText--medium content-panel-subTitle"
-                style="line-height: normal;"
-              >
-                Split a single time series into multiple time series based on categorical fields. You can select up to 2.
-                 
-                <a
-                  class="euiLink euiLink--primary"
-                  href="https://opensearch.org/docs/monitoring-plugins/ad"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="euiFlexItem euiFlexItem--flexGrowZero"
-        >
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            />
-          </div>
-        </div>
-      </div>
-      <div>
-        <hr
-          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-        />
-        <div
-          style="padding: 10px 0px;"
-        >
-          <div
-            class="euiCallOut euiCallOut--warning euiCallOut--small"
-            data-test-subj="noCategoryFieldsCallout"
-          >
-            <div
-              class="euiCallOutHeader"
-            >
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              />
-              <span
-                class="euiCallOutHeader__title"
-              >
-                There are no available category fields for the selected index
-              </span>
-            </div>
-          </div>
-          <div
-            class="euiSpacer euiSpacer--m"
-          />
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiCheckbox"
-              >
-                <input
-                  checked=""
-                  class="euiCheckbox__input"
-                  disabled=""
-                  id="categoryFieldCheckbox"
-                  type="checkbox"
-                />
-                <div
-                  class="euiCheckbox__square"
-                />
-                <label
-                  class="euiCheckbox__label"
-                  for="categoryFieldCheckbox"
-                >
-                  Enable categorical fields
-                </label>
               </div>
             </div>
           </div>

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -670,33 +670,6 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
             class="euiSpacer euiSpacer--m"
           />
           <div
-            class="euiCallOut euiCallOut--warning euiCallOut--small"
-            data-test-subj="cannotEditCategoryFieldCallout"
-          >
-            <div
-              class="euiCallOutHeader"
-            >
-              <svg
-                aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
-                focusable="false"
-                height="16"
-                role="img"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              />
-              <span
-                class="euiCallOutHeader__title"
-              >
-                &lt;Placeholder for text when creating&gt;
-              </span>
-            </div>
-          </div>
-          <div
-            class="euiSpacer euiSpacer--m"
-          />
-          <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
           >
             <div
@@ -1656,7 +1629,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
               <span
                 class="euiCallOutHeader__title"
               >
-                &lt;Placeholder for text when editing&gt;
+                Category fields cannot be changed once the detector is created
               </span>
             </div>
           </div>

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -670,6 +670,33 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
             class="euiSpacer euiSpacer--m"
           />
           <div
+            class="euiCallOut euiCallOut--warning euiCallOut--small"
+            data-test-subj="cannotEditCategoryFieldCallout"
+          >
+            <div
+              class="euiCallOutHeader"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiCallOutHeader__title"
+              >
+                &lt;Placeholder for text when creating&gt;
+              </span>
+            </div>
+          </div>
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
           >
             <div
@@ -1603,6 +1630,33 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
                 class="euiCallOutHeader__title"
               >
                 There are no available category fields for the selected index
+              </span>
+            </div>
+          </div>
+          <div
+            class="euiSpacer euiSpacer--m"
+          />
+          <div
+            class="euiCallOut euiCallOut--primary euiCallOut--small"
+            data-test-subj="categoryFieldReadOnlyCallout"
+          >
+            <div
+              class="euiCallOutHeader"
+            >
+              <svg
+                aria-hidden="true"
+                class="euiIcon euiIcon--medium euiIcon-isLoading euiCallOutHeader__icon"
+                focusable="false"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              />
+              <span
+                class="euiCallOutHeader__title"
+              >
+                &lt;Placeholder for text when editing&gt;
               </span>
             </div>
           </div>


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

This PR blocks users from editing the selected category fields after initial detector creation. The reason for this change is because the anomaly results and charts can get in weird states if the detector cardinality type is changed, and lead to showing confusing and/or misleading data to the users (e.g., making a single-category high-cardinality detector into a non-high-cardinality detector will show multiple results with the same timestamp for each entity).

Changes include:
- Adding callouts to the model config page describing the changes. In the creation flow, show a warning callout once the user initially enables the category field checkbox. In the edit flow, show an info callout describing why the category field selections (enabled or disabled, selected fields) are readonly.
- Making the checkbox and combo box readonly when editing the model config

Testing:
- Sanity tested the functionality for the create & edit flows
- Updated and added unit tests

Screenshots:

Warning callout in creation flow:

![Screen Shot 2021-08-31 at 9 56 03 AM](https://user-images.githubusercontent.com/62119629/131545702-e41b49d5-297b-418d-9eb5-ab817b6209f5.png)

Info callout in edit flow:

![Screen Shot 2021-08-31 at 9 55 33 AM](https://user-images.githubusercontent.com/62119629/131545712-6a36d00d-caf9-4792-a6b1-dab8742c2c9a.png)

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
