### PR TITLE
Clear HC charts when the date range changes

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -462,6 +462,9 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         startDate: startDate,
         endDate: endDate,
       });
+      if (isHCDetector) {
+        setSelectedHeatmapCell(undefined);
+      }
     },
     []
   );


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Currently, if a user selects a heatmap cell, the (1) anomaly chart, (2) anomaly table, and (3) feature chart are populated below. When the user changes any of the heatmap chart filters (top 10 / top 20 / top 30, sort by # occurrences / sort by severity, etc.), the data in these 3 components are cleared, since new cells will be generated, and the previously-selected one may not be available anymore.

However, changing the date range will not clear the state, even though it is also directly affecting the heatmap chart, and could lead to confusing UI if the results aren't cleared. This PR fixes that by clearing data when the date range is changed.

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
