### PR TITLE
Bump plugin version to 1.1.0.0

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,7 +5,7 @@ on:
       - v*
 
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 7.10.2
+  OPENSEARCH_DASHBOARDS_VERSION: 1.1.0
 jobs:
   Build-and-upload:
     name: Build and upload artifacts

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -7,11 +7,11 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomaly-detection-dashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
-  DOCKER_TAG: 1.0.0-rc1
+  DOCKER_TAG: 1.1.0
 jobs:
   test-with-security:
     name: Run e2e tests with security

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
 jobs:
   tests:
     name: Run unit tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "1.0.0.0",
-  "opensearchDashboardsVersion": "1.0.0",
+  "version": "1.1.0.0",
+  "opensearchDashboardsVersion": "1.1.0",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "1.0.0.0",
+  "version": "1.1.0.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "1.0.0.0",
+    "plugin_version": "1.1.0.0",
     "plugin_name": "anomalyDetectionDashboards",
     "plugin_zip_name": "anomaly-detection-dashboards"
   },


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Bumps plugin version to `1.1.0.0`, and related dependencies to `1.1.0`.

Testing:
Ran the unit and integration tests locally & successfully. Note that the integration test GitHub workflows will fail for now due to the `1.1.0`-tagged docker images not existing yet. I've attached the locally-ran output in a comment below.

I also did a sanity test that core functionality is working. Set up a 1.1 cluster with the latest AD backend changes based on `main` branch (last commit: [here](https://github.com/opensearch-project/anomaly-detection/commit/bedc5b620384163abe272e913705fa23cfd3b3a3)).


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
