### PR TITLE
Tune wording on category field callouts

### DIFF
--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -109,7 +109,7 @@ export function CategoryField(props: CategoryFieldProps) {
       {props.isEdit ? (
         <EuiCallOut
           data-test-subj="categoryFieldReadOnlyCallout"
-          title="Category fields cannot be changed once the detector is created"
+          title="You can't change the category fields after you create the detector."
           color="primary"
           iconType="iInCircle"
           size="s"
@@ -144,7 +144,7 @@ export function CategoryField(props: CategoryFieldProps) {
               <EuiFlexItem>
                 <EuiCallOut
                   data-test-subj="cannotEditCategoryFieldCallout"
-                  title="Category fields cannot be changed once the detector is created. Please ensure that you select the fields necessary for your case."
+                  title="You can't change the category fields after you create the detector. Make sure that you only select the fields necessary for your use case."
                   color="warning"
                   iconType="alert"
                   size="s"

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -254,7 +254,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                   <span
                     class="euiCallOutHeader__title"
                   >
-                    Category fields cannot be changed once the detector is created. Please ensure that you select the fields necessary for your case.
+                    You can't change the category fields after you create the detector. Make sure that you only select the fields necessary for your use case.
                   </span>
                 </div>
               </div>

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -1629,7 +1629,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
               <span
                 class="euiCallOutHeader__title"
               >
-                Category fields cannot be changed once the detector is created
+                You can't change the category fields after you create the detector.
               </span>
             </div>
           </div>


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

The wording has been tuned for the new category field callouts. This PR addresses that.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
