### PR TITLE
[BACKPORT] [1.x] Backport remaining PRs to 1.x

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,7 +5,7 @@ on:
       - v*
 
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 7.10.2
+  OPENSEARCH_DASHBOARDS_VERSION: 1.1.0
 jobs:
   Build-and-upload:
     name: Build and upload artifacts

--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -7,11 +7,11 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
   AD_OPENSEARCH_DASHBOARDS_PLUGIN_NAME: anomaly-detection-dashboards
   OPENSEARCH_DOCKER_IMAGE: opensearchstaging/opensearch
   DASHBOARDS_DOCKER_IMAGE: opensearchstaging/opensearch-dashboards
-  DOCKER_TAG: 1.0.0-rc1
+  DOCKER_TAG: 1.1.0
 jobs:
   test-with-security:
     name: Run e2e tests with security

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '1.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '1.x'
 jobs:
   tests:
     name: Run unit tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "1.0.0.0",
-  "opensearchDashboardsVersion": "1.0.0",
+  "version": "1.1.0.0",
+  "opensearchDashboardsVersion": "1.1.0",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "1.0.0.0",
+  "version": "1.1.0.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "1.0.0.0",
+    "plugin_version": "1.1.0.0",
     "plugin_name": "anomalyDetectionDashboards",
     "plugin_zip_name": "anomaly-detection-dashboards"
   },

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -109,7 +109,7 @@ export function CategoryField(props: CategoryFieldProps) {
       {props.isEdit ? (
         <EuiCallOut
           data-test-subj="categoryFieldReadOnlyCallout"
-          title="Category fields cannot be changed once the detector is created"
+          title="You can't change the category fields after you create the detector."
           color="primary"
           iconType="iInCircle"
           size="s"
@@ -144,7 +144,7 @@ export function CategoryField(props: CategoryFieldProps) {
               <EuiFlexItem>
                 <EuiCallOut
                   data-test-subj="cannotEditCategoryFieldCallout"
-                  title="Category fields cannot be changed once the detector is created. Please ensure that you select the fields necessary for your case."
+                  title="You can't change the category fields after you create the detector. Make sure that you only select the fields necessary for your use case."
                   color="warning"
                   iconType="alert"
                   size="s"

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -254,7 +254,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                   <span
                     class="euiCallOutHeader__title"
                   >
-                    Category fields cannot be changed once the detector is created. Please ensure that you select the fields necessary for your case.
+                    You can't change the category fields after you create the detector. Make sure that you only select the fields necessary for your use case.
                   </span>
                 </div>
               </div>

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -1629,7 +1629,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
               <span
                 class="euiCallOutHeader__title"
               >
-                Category fields cannot be changed once the detector is created
+                You can't change the category fields after you create the detector.
               </span>
             </div>
           </div>

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -462,6 +462,9 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         startDate: startDate,
         endDate: endDate,
       });
+      if (isHCDetector) {
+        setSelectedHeatmapCell(undefined);
+      }
     },
     []
   );


### PR DESCRIPTION
### Description

Backports the last 3 PRs into `1.x` branch. Now includes all necessary changes for cutting a `1.1` branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
