### PR TITLE
Fix bug of HC historical results not showing top 20/30

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -230,13 +230,22 @@ export const AnomalyHeatmapChart = React.memo(
     };
 
     // Custom hook to refresh all of the heatmap data when running a historical task
+    //
+    // TODO: this hook is actually getting updated more often than just when there
+    // is a change to the props.detectorTaskProgress. This is due to a remounting
+    // issue that is triggering this after every AnomaliesChart re-render. More details here:
+    // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/90
     useEffect(() => {
       if (props.isHistorical) {
         const updateHeatmapPlotData = getAnomaliesHeatmapData(
           props.anomalies,
           props.dateRange,
           sortByFieldValue,
-          get(COMBINED_OPTIONS.options[0], 'value')
+          get(
+            currentViewOptions[0],
+            'value',
+            get(COMBINED_OPTIONS.options[0], 'value')
+          )
         );
         setOriginalHeatmapData(updateHeatmapPlotData);
         setHeatmapData(updateHeatmapPlotData);


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Fixes the bug of the filters for "Top 20" / "Top 30" not updating correctly when selected for historical high-cardinality charts. The fix is to update the hook to use any existing filter state, rather than defaulting to "Top 10" and overriding any existing state.

Note that if the hook was working as expected, this original bug wouldn't exist, since it would only be triggered when changes to the `props.detectorTaskProgress` happen (when the historical task is running). But, it is actually being triggered when any filter selection is made. It was then found that the entire `AnomalyHeatmapChart` component is getting re-mounted whenever these filter changes are occurring, hence triggering this hook every time a re-mount happens.

Expected behavior:
User selects "Top 20" -> `props.onDisplayOptionChanged` is called -> `AnomalyHeatmapChart` component re-renders with updated set of anomalies and entity data -> renders top 20 entity results

What's happening currently:
User selects "Top 20" -> `props.onDisplayOptionChanged` is called -> `AnomalyHeatmapChart` is re-mounted (so all hooks will be triggered) -> the hook on `props.detectorTaskProgress` is triggered -> resetting the selected option to "Top 10" -> only showing top 10 entity results

I created #90 to track this, and will handle separately.

### Issues Resolved

[List any issues this PR will resolve]

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
