### PR TITLE
[BACKPORT] [1.1] Fix bug of HC historical results not showing top 20/30 (#91)

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -230,13 +230,22 @@ export const AnomalyHeatmapChart = React.memo(
     };
 
     // Custom hook to refresh all of the heatmap data when running a historical task
+    //
+    // TODO: this hook is actually getting updated more often than just when there
+    // is a change to the props.detectorTaskProgress. This is due to a remounting
+    // issue that is triggering this after every AnomaliesChart re-render. More details here:
+    // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/90
     useEffect(() => {
       if (props.isHistorical) {
         const updateHeatmapPlotData = getAnomaliesHeatmapData(
           props.anomalies,
           props.dateRange,
           sortByFieldValue,
-          get(COMBINED_OPTIONS.options[0], 'value')
+          get(
+            currentViewOptions[0],
+            'value',
+            get(COMBINED_OPTIONS.options[0], 'value')
+          )
         );
         setOriginalHeatmapData(updateHeatmapPlotData);
         setHeatmapData(updateHeatmapPlotData);


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Backporting #91 to `1.1` branch.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
