### PR TITLE
Support multi-category filtering of results

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -215,3 +215,16 @@ export type DetectionDateRange = {
   startTime: number;
   endTime: number;
 };
+
+export type EntityOption = {
+  label: string;
+};
+
+// Primarily used in the heatmap chart when a subset of category fields are selected.
+// We store all child category fields as keys, and all selected child entities as
+// an array of EntityOptions per field.
+// Ex: given child category field IP and entities [1.2.3.4, 5.6.7.8] would be stored as
+// { [IP]: [ { label: 1.2.3.4 }, { label: 5.6.7.8 } ] }
+export type EntityOptionsMap = {
+  [categoryField: string]: EntityOption[];
+};

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -83,6 +83,7 @@ interface FeatureChartProps {
   detectorEnabledTime?: number;
   rawFeatureData: FeatureAggregationData[][];
   entityData: EntityData[][];
+  isHCDetector?: boolean;
 }
 
 export const FeatureChart = (props: FeatureChartProps) => {
@@ -174,6 +175,8 @@ export const FeatureChart = (props: FeatureChartProps) => {
     props.dateRange
   ) as FeatureAggregationData[][];
 
+  const multipleTimeSeries = get(featureData, 'length', 0) > 1;
+
   return (
     <ContentPanel
       title={
@@ -200,7 +203,7 @@ export const FeatureChart = (props: FeatureChartProps) => {
           opacity: showLoader ? 0.2 : 1,
         }}
       >
-        <Chart>
+        <Chart key={`${featureData}`}>
           <Settings
             showLegend
             showLegendExtra={false}
@@ -258,9 +261,11 @@ export const FeatureChart = (props: FeatureChartProps) => {
           }
           {featureData.map(
             (featureTimeSeries: FeatureAggregationData[], index) => {
-              const multipleTimeSeries = get(props, 'entityData.length', 0) > 1;
-              const seriesKey = multipleTimeSeries
-                ? convertToEntityString(props.entityData[index], ', ')
+              const seriesKey = props.isHCDetector
+                ? `${props.featureDataSeriesName} (${convertToEntityString(
+                    props.entityData[index],
+                    ', '
+                  )})`
                 : props.featureDataSeriesName;
               return (
                 <LineSeries

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -203,6 +203,11 @@ export const FeatureChart = (props: FeatureChartProps) => {
           opacity: showLoader ? 0.2 : 1,
         }}
       >
+        {/**
+         * Charts may show stale data even after feature data is changed.
+         * By setting the key prop here, the chart will re-mount whenever the
+         * feature data has changed.
+         */}
         <Chart key={`${featureData}`}>
           <Settings
             showLegend

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -46,20 +46,28 @@ import {
   DateRange,
   FEATURE_TYPE,
   Schedule,
+  EntityData,
 } from '../../../../models/interfaces';
 import { darkModeEnabled } from '../../../../utils/opensearchDashboardsUtils';
 import {
   prepareDataForChart,
   getFeatureMissingDataAnnotations,
   filterWithDateRange,
+  flattenData,
+  convertToEntityString,
 } from '../../../utils/anomalyResultUtils';
 import { CodeModal } from '../../../DetectorConfig/components/CodeModal/CodeModal';
-import { CHART_FIELDS, FEATURE_CHART_THEME } from '../../utils/constants';
-import { isEmpty } from 'lodash';
+import {
+  CHART_FIELDS,
+  CHART_COLORS,
+  FEATURE_CHART_THEME,
+} from '../../utils/constants';
+import { get, isEmpty } from 'lodash';
+import { ENTITY_COLORS } from '../../../DetectorResults/utils/constants';
 
 interface FeatureChartProps {
   feature: FeatureAttributes;
-  featureData: FeatureAggregationData[];
+  featureData: FeatureAggregationData[][];
   annotations: any[];
   isLoading: boolean;
   dateRange: DateRange;
@@ -73,7 +81,8 @@ interface FeatureChartProps {
   detectorInterval: Schedule;
   showFeatureMissingDataPointAnnotation?: boolean;
   detectorEnabledTime?: number;
-  rawFeatureData: FeatureAggregationData[];
+  rawFeatureData: FeatureAggregationData[][];
+  entityData: EntityData[][];
 }
 
 export const FeatureChart = (props: FeatureChartProps) => {
@@ -128,8 +137,6 @@ export const FeatureChart = (props: FeatureChartProps) => {
     </EuiText>
   );
 
-  const featureData = prepareDataForChart(props.featureData, props.dateRange);
-
   // return undefined if featureMissingDataPointAnnotationStartDate is missing
   // OR it is even behind the specified date range
   const getFeatureMissingAnnotationDateRange = (
@@ -161,6 +168,12 @@ export const FeatureChart = (props: FeatureChartProps) => {
       'coordinates.x0'
     );
   };
+
+  const featureData = prepareDataForChart(
+    props.featureData,
+    props.dateRange
+  ) as FeatureAggregationData[][];
+
   return (
     <ContentPanel
       title={
@@ -217,8 +230,8 @@ export const FeatureChart = (props: FeatureChartProps) => {
                   domainType={AnnotationDomainTypes.XDomain}
                   dataValues={getFeatureMissingDataAnnotations(
                     props.showFeatureMissingDataPointAnnotation
-                      ? props.rawFeatureData
-                      : props.featureData,
+                      ? flattenData(props.rawFeatureData)
+                      : flattenData(props.featureData),
                     props.detectorInterval.interval,
                     getFeatureMissingAnnotationDateRange(
                       props.dateRange,
@@ -240,15 +253,33 @@ export const FeatureChart = (props: FeatureChartProps) => {
             showGridLines
           />
           <Axis id="bottom" position="bottom" tickFormat={timeFormatter} />
-          <LineSeries
-            id="featureData"
-            name={props.featureDataSeriesName}
-            xScaleType={ScaleType.Time}
-            yScaleType={ScaleType.Linear}
-            xAccessor={CHART_FIELDS.PLOT_TIME}
-            yAccessors={[CHART_FIELDS.DATA]}
-            data={featureData}
-          />
+          {
+            // Add each set of feature data as a separate time series
+          }
+          {featureData.map(
+            (featureTimeSeries: FeatureAggregationData[], index) => {
+              const multipleTimeSeries = get(props, 'entityData.length', 0) > 1;
+              const seriesKey = multipleTimeSeries
+                ? convertToEntityString(props.entityData[index], ', ')
+                : props.featureDataSeriesName;
+              return (
+                <LineSeries
+                  id={seriesKey}
+                  name={seriesKey}
+                  color={
+                    multipleTimeSeries
+                      ? ENTITY_COLORS[index]
+                      : CHART_COLORS.FEATURE_DATA_COLOR
+                  }
+                  xScaleType={ScaleType.Time}
+                  yScaleType={ScaleType.Linear}
+                  xAccessor={CHART_FIELDS.PLOT_TIME}
+                  yAccessors={[CHART_FIELDS.DATA]}
+                  data={featureTimeSeries}
+                />
+              );
+            }
+          )}
         </Chart>
         {showCustomExpression ? (
           <CodeModal

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -96,6 +96,8 @@ export interface AnomaliesChartProps {
   anomaliesResult: Anomalies | undefined;
   heatmapDisplayOption?: HeatmapDisplayOption;
   entityAnomalySummaries?: EntityAnomalySummaries[];
+  selectedCategoryFields?: any[];
+  handleCategoryFieldsChange(selectedOptions: any[]): void;
 }
 
 export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
@@ -277,6 +279,10 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                         categoryField={orderBy(props.detectorCategoryField, [
                           (categoryField) => categoryField.toLowerCase(),
                         ])}
+                        selectedCategoryFields={props.selectedCategoryFields}
+                        handleCategoryFieldsChange={
+                          props.handleCategoryFieldsChange
+                        }
                       />,
                       props.isNotSample !== true
                         ? [

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -41,6 +41,7 @@ import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 import { useDelayedLoader } from '../../../hooks/useDelayedLoader';
 import {
   Anomalies,
+  AnomalyData,
   DateRange,
   Detector,
   Monitor,
@@ -93,7 +94,7 @@ export interface AnomaliesChartProps {
   selectedHeatmapCell?: HeatmapCell;
   newDetector?: Detector;
   zoomRange?: DateRange;
-  anomaliesResult: Anomalies | undefined;
+  anomalyAndFeatureResults: Anomalies[] | undefined;
   heatmapDisplayOption?: HeatmapDisplayOption;
   entityAnomalySummaries?: EntityAnomalySummaries[];
   selectedCategoryFields?: any[];
@@ -110,7 +111,13 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
       : 'now',
   });
 
-  const anomalies = get(props.anomaliesResult, 'anomalies', []);
+  // for each time series of results, get the anomalies, ignoring feature data
+  let anomalyResults = [] as AnomalyData[][];
+  get(props, 'anomalyAndFeatureResults', []).forEach(
+    (anomalyAndFeatureResult: Anomalies) => {
+      anomalyResults.push(anomalyAndFeatureResult.anomalies);
+    }
+  );
 
   const handleDateRangeChange = (startDate: number, endDate: number) => {
     props.onDateRangeChange(startDate, endDate);
@@ -255,7 +262,11 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                         )}
                         isHistorical={props.isHistorical}
                         dateRange={props.dateRange}
-                        anomalies={anomalies}
+                        // Raw anomalies only passed here for building the plot data for sample
+                        // results, so we will only pass a single time series here,
+                        // since we don't currently support sub-aggregation and multi-time-series
+                        // for sample data charts. See comments in AnomalyHeatmapChart for details
+                        anomalies={get(anomalyResults, 0, [])}
                         isLoading={props.isLoading}
                         showAlerts={props.showAlerts}
                         monitor={props.monitor}
@@ -320,9 +331,9 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                               dateRange={props.dateRange}
                               onDateRangeChange={props.onDateRangeChange}
                               onZoomRangeChange={props.onZoomRangeChange}
-                              anomalies={anomalies}
+                              anomalies={anomalyResults}
                               bucketizedAnomalies={false}
-                              anomalySummary={INITIAL_ANOMALY_SUMMARY}
+                              anomalySummary={props.anomalySummary}
                               isLoading={props.isLoading}
                               anomalyGradeSeriesName={getAnomalyGradeWording(
                                 props.isNotSample
@@ -345,9 +356,11 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                               //@ts-ignore
                               detector={props.newDetector}
                               //@ts-ignore
-                              anomaliesResult={props.anomaliesResult}
+                              anomalyAndFeatureResults={
+                                props.anomalyAndFeatureResults
+                              }
                               annotations={generateAnomalyAnnotations(
-                                get(props.anomaliesResult, 'anomalies', [])
+                                anomalyResults
                               )}
                               isLoading={props.isLoading}
                               //@ts-ignore
@@ -374,7 +387,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
               dateRange={props.dateRange}
               onDateRangeChange={handleDateRangeChange}
               onZoomRangeChange={props.onZoomRangeChange}
-              anomalies={anomalies}
+              anomalies={anomalyResults}
               bucketizedAnomalies={props.bucketizedAnomalies}
               anomalySummary={props.anomalySummary}
               isLoading={props.isLoading}

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -140,7 +140,11 @@ export const AnomalyDetailsChart = React.memo(
       props.anomalies
     );
 
-    const [aggregatedAnomalies, setAggregatedAnomalies] = useState<any[]>([]);
+    // Aggregated anomalies will always be a single time series (AnomalyData[]).
+    // We don't support multiple time series of aggregated anomalies.
+    const [aggregatedAnomalies, setAggregatedAnomalies] = useState<
+      AnomalyData[]
+    >([]);
     const [selectedAggId, setSelectedAggId] = useState<ANOMALY_AGG>(
       ANOMALY_AGG.RAW
     );
@@ -204,7 +208,7 @@ export const AnomalyDetailsChart = React.memo(
                 response,
                 selectedAggId
               );
-              setAggregatedAnomalies([aggregatedAnomalies]);
+              setAggregatedAnomalies(aggregatedAnomalies);
             })
             .catch((e: any) => {
               console.error(
@@ -288,11 +292,11 @@ export const AnomalyDetailsChart = React.memo(
     useEffect(() => {
       // Aggregated anomalies are already formatted differently
       // in parseHistoricalAggregatedAnomalies(). Only raw anomalies
-      // are formatted with prepareDataForChart().
+      // need to be formatted with prepareDataForChart().
       const anomalies =
         selectedAggId === ANOMALY_AGG.RAW
-          ? prepareDataForChart(props.anomalies, zoomRange)
-          : aggregatedAnomalies;
+          ? (prepareDataForChart(props.anomalies, zoomRange) as AnomalyData[][])
+          : [aggregatedAnomalies];
       setZoomedAnomalies(anomalies);
       setTotalAlerts(
         filterWithDateRange(alerts, zoomRange, 'startTime').length

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -557,11 +557,11 @@ export const AnomalyDetailsChart = React.memo(
                     showGridLines
                   />
                   {
-                    // If historical: don't show the confidence line chart
+                    // If historical or multiple selected time series: don't show the confidence line chart
                   }
-                  {zoomedAnomalies.forEach(
+                  {zoomedAnomalies.map(
                     (anomalySeries: AnomalyData[], index) => {
-                      if (props.isHistorical) {
+                      if (props.isHistorical || multipleTimeSeries) {
                         return null;
                       } else {
                         const seriesKey = props.isHCDetector
@@ -576,11 +576,7 @@ export const AnomalyDetailsChart = React.memo(
                           <LineSeries
                             id={seriesKey}
                             name={seriesKey}
-                            color={
-                              multipleTimeSeries
-                                ? ENTITY_COLORS[index]
-                                : CHART_COLORS.ANOMALY_GRADE_COLOR
-                            }
+                            color={CHART_COLORS.CONFIDENCE_COLOR}
                             xScaleType={ScaleType.Time}
                             yScaleType={ScaleType.Linear}
                             xAccessor={CHART_FIELDS.PLOT_TIME}
@@ -599,7 +595,7 @@ export const AnomalyDetailsChart = React.memo(
                           } (${convertToEntityString(
                             get(anomalySeries, '1.entity', []),
                             ', '
-                          )}`
+                          )})`
                         : props.anomalyGradeSeriesName;
 
                       return (

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -295,8 +295,6 @@ export const AnomalyDetailsChart = React.memo(
           : aggregatedAnomalies;
       setZoomedAnomalies(anomalies);
       setTotalAlerts(
-        // TODO: handle alerts to only show if the selected time series is selected,
-        // like in the multi-category filtering case where it may not be
         filterWithDateRange(alerts, zoomRange, 'startTime').length
       );
     }, [props.anomalies, zoomRange, aggregatedAnomalies, selectedAggId]);

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -567,8 +567,9 @@ export const AnomalyDetailsChart = React.memo(
                         const seriesKey = props.isHCDetector
                           ? `${
                               props.confidenceSeriesName
+                              // Extracting entity list from anomaly data
                             } (${convertToEntityString(
-                              get(anomalySeries, '1.entity', []),
+                              get(anomalySeries, '0.entity', []),
                               ', '
                             )}`
                           : props.confidenceSeriesName;
@@ -592,8 +593,9 @@ export const AnomalyDetailsChart = React.memo(
                       const seriesKey = props.isHCDetector
                         ? `${
                             props.anomalyGradeSeriesName
+                            // Extracting entity list from anomaly data
                           } (${convertToEntityString(
-                            get(anomalySeries, '1.entity', []),
+                            get(anomalySeries, '0.entity', []),
                             ', '
                           )})`
                         : props.anomalyGradeSeriesName;

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -64,7 +64,7 @@ import {
 } from '../../../../server/models/interfaces';
 import { HEATMAP_CHART_Y_AXIS_WIDTH } from '../utils/constants';
 import {
-  convertToEntityList,
+  convertHeatmapCellEntityStringToEntityList,
   convertToCategoryFieldString,
 } from '../../utils/anomalyResultUtils';
 
@@ -275,7 +275,7 @@ export const AnomalyHeatmapChart = React.memo(
 
     const handleHeatmapClick = (event: Plotly.PlotMouseEvent) => {
       const selectedCellIndices = get(event, 'points[0].pointIndex', []);
-      const selectedEntityString = get(event, 'points[0].y', '');
+      const selectedEntityString = get(event, 'points[0].customdata', '');
       if (!isEmpty(selectedCellIndices)) {
         let anomalyCount = get(event, 'points[0].text', 0);
         if (
@@ -320,10 +320,8 @@ export const AnomalyHeatmapChart = React.memo(
               startDate: selectedStartDate,
               endDate: selectedEndDate,
             },
-            entityList: convertToEntityList(
-              selectedEntityString,
-              get(props, 'categoryField', []),
-              ENTITY_LIST_DELIMITER
+            entityList: convertHeatmapCellEntityStringToEntityList(
+              selectedEntityString
             ),
           } as HeatmapCell);
         }

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -44,14 +44,14 @@ import { useDelayedLoader } from '../../../hooks/useDelayedLoader';
 import { Monitor, DateRange } from '../../../models/interfaces';
 import { AlertsFlyout } from '../components/AlertsFlyout/AlertsFlyout';
 import {
-  getAnomaliesHeatmapData,
+  getSampleAnomaliesHeatmapData,
   getSelectedHeatmapCellPlotData,
   updateHeatmapPlotData,
   HEATMAP_X_AXIS_DATE_FORMAT,
   AnomalyHeatmapSortType,
   sortHeatmapPlotData,
   filterHeatmapPlotDataByY,
-  getEntitytAnomaliesHeatmapData,
+  getEntityAnomaliesHeatmapData,
   getCategoryFieldOptions,
 } from '../utils/anomalyChartUtils';
 import {
@@ -63,7 +63,10 @@ import {
   Entity,
 } from '../../../../server/models/interfaces';
 import { HEATMAP_CHART_Y_AXIS_WIDTH } from '../utils/constants';
-import { convertToEntityList } from '../../utils/anomalyResultUtils';
+import {
+  convertToEntityList,
+  convertToCategoryFieldString,
+} from '../../utils/anomalyResultUtils';
 
 interface AnomalyHeatmapChartProps {
   detectorId: string;
@@ -173,16 +176,22 @@ export const AnomalyHeatmapChart = React.memo(
       };
     };
 
+    // We store and update heatmap data in 2 ways, depending on if it's in a sample scenario or not.
+    // If sample data, we get heatmap data from the raw sample anomalies themselves.
+    // If non-sample data, we get heatmap data from the anomaly summaries via props.
+    // The summaries come from aggregate query results directly against the result data; this isn't possible
+    // in the sample data scenario, where we can only retrieve sampled raw data and no aggregate buckets/summaries,
+    // hence needing to handle that in post-processing via getSampleAnomaliesHeatmapData
     const [originalHeatmapData, setOriginalHeatmapData] = useState(
       props.isNotSample
-        ? // use anomaly summary data in case of realtime result
-          getEntitytAnomaliesHeatmapData(
+        ? // use anomaly summary data in case of realtime or historical result
+          getEntityAnomaliesHeatmapData(
             props.dateRange,
-            props.entityAnomalySummaries,
-            props.heatmapDisplayOption?.entityOption.value
+            get(props, 'entityAnomalySummaries', []),
+            get(props, 'heatmapDisplayOption.entityOption.value', 0)
           )
-        : // use anomalies data in case of sample result
-          getAnomaliesHeatmapData(
+        : // use raw anomalies data in case of sample result
+          getSampleAnomaliesHeatmapData(
             props.anomalies,
             props.dateRange,
             AnomalyHeatmapSortType.SEVERITY,
@@ -198,7 +207,11 @@ export const AnomalyHeatmapChart = React.memo(
       AnomalyHeatmapSortType
     >(
       props.isNotSample
-        ? props.heatmapDisplayOption?.sortType
+        ? get(
+            props,
+            'heatmapDisplayOption.sortType',
+            SORT_BY_FIELD_OPTIONS[0].value
+          )
         : SORT_BY_FIELD_OPTIONS[0].value
     );
 
@@ -237,16 +250,22 @@ export const AnomalyHeatmapChart = React.memo(
     // https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/90
     useEffect(() => {
       if (props.isHistorical) {
-        const updateHeatmapPlotData = getAnomaliesHeatmapData(
-          props.anomalies,
-          props.dateRange,
-          sortByFieldValue,
-          get(
-            currentViewOptions[0],
-            'value',
-            get(COMBINED_OPTIONS.options[0], 'value')
-          )
-        );
+        const updateHeatmapPlotData = props.isNotSample
+          ? getEntityAnomaliesHeatmapData(
+              props.dateRange,
+              get(props, 'entityAnomalySummaries', []),
+              get(props, 'heatmapDisplayOption.entityOption.value', 0)
+            )
+          : getSampleAnomaliesHeatmapData(
+              props.anomalies,
+              props.dateRange,
+              sortByFieldValue,
+              get(
+                currentViewOptions[0],
+                'value',
+                get(COMBINED_OPTIONS.options[0], 'value')
+              )
+            );
         setOriginalHeatmapData(updateHeatmapPlotData);
         setHeatmapData(updateHeatmapPlotData);
         setNumEntities(updateHeatmapPlotData[0].y.length);
@@ -334,12 +353,18 @@ export const AnomalyHeatmapChart = React.memo(
           });
         } else {
           const displayTopEntityNum = get(COMBINED_OPTIONS.options[0], 'value');
-          const updateHeatmapPlotData = getAnomaliesHeatmapData(
-            props.anomalies,
-            props.dateRange,
-            sortByFieldValue,
-            displayTopEntityNum
-          );
+          const updateHeatmapPlotData = props.isNotSample
+            ? getEntityAnomaliesHeatmapData(
+                props.dateRange,
+                get(props, 'entityAnomalySummaries', []),
+                displayTopEntityNum
+              )
+            : getSampleAnomaliesHeatmapData(
+                props.anomalies,
+                props.dateRange,
+                sortByFieldValue,
+                displayTopEntityNum
+              );
           setOriginalHeatmapData(updateHeatmapPlotData);
           setHeatmapData(updateHeatmapPlotData);
           setNumEntities(updateHeatmapPlotData[0].y.length);
@@ -365,12 +390,18 @@ export const AnomalyHeatmapChart = React.memo(
             });
           } else {
             const displayTopEntityNum = get(option, 'value');
-            const updateHeatmapPlotData = getAnomaliesHeatmapData(
-              props.anomalies,
-              props.dateRange,
-              sortByFieldValue,
-              displayTopEntityNum
-            );
+            const updateHeatmapPlotData = props.isNotSample
+              ? getEntityAnomaliesHeatmapData(
+                  props.dateRange,
+                  get(props, 'entityAnomalySummaries', []),
+                  displayTopEntityNum
+                )
+              : getSampleAnomaliesHeatmapData(
+                  props.anomalies,
+                  props.dateRange,
+                  sortByFieldValue,
+                  displayTopEntityNum
+                );
 
             setOriginalHeatmapData(updateHeatmapPlotData);
             setHeatmapData(updateHeatmapPlotData);
@@ -467,18 +498,37 @@ export const AnomalyHeatmapChart = React.memo(
                         <h4>View by:</h4>
                       </EuiText>
                     </EuiFlexItem>
-                    <EuiFlexItem style={{ minWidth: 300 }}>
-                      <EuiComboBox
-                        placeholder="Select categorical fields"
-                        options={getCategoryFieldOptions(
-                          get(props, 'categoryField', [])
-                        )}
-                        selectedOptions={props.selectedCategoryFields}
-                        onChange={(selectedOptions) =>
-                          props.handleCategoryFieldsChange(selectedOptions)
-                        }
-                      />
-                    </EuiFlexItem>
+
+                    {/**
+                     * We don't support multi-category filtering on sample data currently.
+                     * Because of this, we remove the category field combo box for the sample charts, and
+                     * simply show the list of selected category fields in string format.
+                     */}
+                    {props.isNotSample ? (
+                      <EuiFlexItem style={{ minWidth: 300 }}>
+                        <EuiComboBox
+                          placeholder="Select categorical fields"
+                          options={getCategoryFieldOptions(
+                            get(props, 'categoryField', [])
+                          )}
+                          selectedOptions={props.selectedCategoryFields}
+                          onChange={(selectedOptions) =>
+                            props.handleCategoryFieldsChange(selectedOptions)
+                          }
+                        />
+                      </EuiFlexItem>
+                    ) : (
+                      <EuiFlexItem style={{ marginBottom: '0px' }}>
+                        <EuiText>
+                          <h4>
+                            {convertToCategoryFieldString(
+                              get(props, 'categoryField', [] as string[]),
+                              ','
+                            )}
+                          </h4>
+                        </EuiText>
+                      </EuiFlexItem>
+                    )}
                     <EuiFlexItem style={{ minWidth: 300 }}>
                       <EuiComboBox
                         placeholder="Select options"

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -126,7 +126,7 @@ export const AnomalyHeatmapChart = React.memo(
         inputDisplay: 'By severity',
       },
       {
-        value: AnomalyHeatmapSortType.OCCURRENCES,
+        value: AnomalyHeatmapSortType.OCCURRENCE,
         inputDisplay: 'By occurrence',
       },
     ];

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -52,6 +52,7 @@ import {
   sortHeatmapPlotData,
   filterHeatmapPlotDataByY,
   getEntitytAnomaliesHeatmapData,
+  getCategoryFieldOptions,
 } from '../utils/anomalyChartUtils';
 import {
   MIN_IN_MILLI_SECS,
@@ -62,10 +63,7 @@ import {
   Entity,
 } from '../../../../server/models/interfaces';
 import { HEATMAP_CHART_Y_AXIS_WIDTH } from '../utils/constants';
-import {
-  convertToEntityList,
-  convertToCategoryFieldString,
-} from '../../utils/anomalyResultUtils';
+import { convertToEntityList } from '../../utils/anomalyResultUtils';
 
 interface AnomalyHeatmapChartProps {
   detectorId: string;
@@ -84,6 +82,8 @@ interface AnomalyHeatmapChartProps {
   entityAnomalySummaries?: EntityAnomalySummaries[];
   isNotSample?: boolean;
   categoryField?: string[];
+  selectedCategoryFields?: any[];
+  handleCategoryFieldsChange(selectedOptions: any[]): void;
 }
 
 export interface HeatmapCell {
@@ -460,22 +460,25 @@ export const AnomalyHeatmapChart = React.memo(
                 justifyContent="spaceBetween"
                 style={{ padding: '12px', marginBottom: '6px' }}
               >
-                <EuiFlexItem style={{ marginBottom: '0px' }}>
-                  <EuiText>
-                    <h4>
-                      View by:&nbsp;
-                      <b>
-                        {convertToCategoryFieldString(
-                          get(props, 'categoryField', []) as string[],
-                          ', '
-                        )}
-                      </b>
-                    </h4>
-                  </EuiText>
-                </EuiFlexItem>
-
                 <EuiFlexItem grow={false}>
                   <EuiFlexGroup gutterSize="s" alignItems="center">
+                    <EuiFlexItem style={{ marginBottom: '0px' }} grow={false}>
+                      <EuiText>
+                        <h4>View by:</h4>
+                      </EuiText>
+                    </EuiFlexItem>
+                    <EuiFlexItem style={{ minWidth: 300 }}>
+                      <EuiComboBox
+                        placeholder="Select categorical fields"
+                        options={getCategoryFieldOptions(
+                          get(props, 'categoryField', [])
+                        )}
+                        selectedOptions={props.selectedCategoryFields}
+                        onChange={(selectedOptions) =>
+                          props.handleCategoryFieldsChange(selectedOptions)
+                        }
+                      />
+                    </EuiFlexItem>
                     <EuiFlexItem style={{ minWidth: 300 }}>
                       <EuiComboBox
                         placeholder="Select options"

--- a/public/pages/AnomalyCharts/containers/AnomalyOccurrenceChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyOccurrenceChart.tsx
@@ -27,7 +27,12 @@
 import React from 'react';
 import { EuiBadge } from '@elastic/eui';
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
-import { Monitor, Detector, DateRange } from '../../../models/interfaces';
+import {
+  Monitor,
+  Detector,
+  DateRange,
+  AnomalyData,
+} from '../../../models/interfaces';
 import { AnomalyDetailsChart } from './AnomalyDetailsChart';
 import { HeatmapCell } from './AnomalyHeatmapChart';
 import { getDateRangeWithSelectedHeatmapCell } from '../utils/anomalyChartUtils';
@@ -40,7 +45,7 @@ interface AnomalyOccurrenceChartProps {
   ): void;
   onZoomRangeChange(startDate: number, endDate: number): void;
   title: string | React.ReactNode;
-  anomalies: any[];
+  anomalies: AnomalyData[][];
   bucketizedAnomalies: boolean;
   anomalySummary: any;
   dateRange: DateRange;

--- a/public/pages/AnomalyCharts/containers/AnomalyOccurrenceChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyOccurrenceChart.tsx
@@ -30,11 +30,7 @@ import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 import { Monitor, Detector, DateRange } from '../../../models/interfaces';
 import { AnomalyDetailsChart } from './AnomalyDetailsChart';
 import { HeatmapCell } from './AnomalyHeatmapChart';
-import { filterWithHeatmapFilter } from '../../utils/anomalyResultUtils';
-import {
-  getAnomalySummary,
-  getDateRangeWithSelectedHeatmapCell,
-} from '../utils/anomalyChartUtils';
+import { getDateRangeWithSelectedHeatmapCell } from '../utils/anomalyChartUtils';
 
 interface AnomalyOccurrenceChartProps {
   onDateRangeChange(
@@ -63,31 +59,14 @@ interface AnomalyOccurrenceChartProps {
 export const AnomalyOccurrenceChart = React.memo(
   (props: AnomalyOccurrenceChartProps) => {
     const getAnomaliesForChart = () => {
-      if (props.isHCDetector) {
-        if (props.selectedHeatmapCell) {
-          return filterWithHeatmapFilter(
-            props.anomalies,
-            props.selectedHeatmapCell
-          );
-        } else {
-          return [];
-        }
-      } else {
-        return props.anomalies;
-      }
+      return props.isHCDetector && !props.selectedHeatmapCell
+        ? []
+        : props.anomalies;
     };
     const getAnomalySummaryForChart = () => {
-      if (props.isHCDetector) {
-        if (props.selectedHeatmapCell) {
-          return getAnomalySummary(
-            filterWithHeatmapFilter(props.anomalies, props.selectedHeatmapCell)
-          );
-        } else {
-          return [];
-        }
-      } else {
-        return props.anomalySummary;
-      }
+      return props.isHCDetector && !props.selectedHeatmapCell
+        ? []
+        : props.anomalySummary;
     };
 
     return (

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -45,11 +45,6 @@ import { NoFeaturePrompt } from '../components/FeatureChart/NoFeaturePrompt';
 import { focusOnFeatureAccordion } from '../../ConfigureModel/utils/helpers';
 import moment from 'moment';
 import { HeatmapCell } from './AnomalyHeatmapChart';
-import {
-  filterWithHeatmapFilter,
-  entityListsMatch,
-} from '../../utils/anomalyResultUtils';
-import { Entity } from '../../../../server/models/interfaces';
 
 interface FeatureBreakDownProps {
   title?: string;
@@ -71,60 +66,14 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
     anomaliesResult: Anomalies,
     featureId: string
   ) => {
-    const originalFeatureData = get(
-      anomaliesResult,
-      `featureData.${featureId}`,
-      []
-    );
-    if (props.isHCDetector) {
-      if (props.selectedHeatmapCell) {
-        const anomaliesFound = get(anomaliesResult, 'anomalies', []);
-        const filteredFeatureData = [];
-        for (let i = 0; i < anomaliesFound.length; i++) {
-          const currentAnomalyData = anomaliesResult.anomalies[i];
-          const dataEntityList = get(
-            currentAnomalyData,
-            'entity',
-            []
-          ) as Entity[];
-          const cellEntityList = get(
-            props,
-            'selectedHeatmapCell.entityList',
-            []
-          ) as Entity[];
-          if (
-            !isEmpty(dataEntityList) &&
-            entityListsMatch(dataEntityList, cellEntityList) &&
-            get(currentAnomalyData, 'plotTime', 0) >=
-              props.dateRange.startDate &&
-            get(currentAnomalyData, 'plotTime', 0) <= props.dateRange.endDate
-          ) {
-            filteredFeatureData.push(originalFeatureData[i]);
-          }
-        }
-        return filteredFeatureData;
-      } else {
-        return [];
-      }
-    } else {
-      return originalFeatureData;
-    }
+    return props.isHCDetector && !props.selectedHeatmapCell
+      ? []
+      : get(anomaliesResult, `featureData.${featureId}`, []);
   };
   const getAnnotationData = () => {
-    if (props.isHCDetector) {
-      if (props.selectedHeatmapCell) {
-        return filterWithHeatmapFilter(
-          props.annotations,
-          props.selectedHeatmapCell,
-          true,
-          'coordinates.x0'
-        );
-      } else {
-        return [];
-      }
-    } else {
-      return props.annotations;
-    }
+    return props.isHCDetector && !props.selectedHeatmapCell
+      ? []
+      : props.annotations;
   };
 
   return (

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -25,7 +25,7 @@
  */
 
 import React from 'react';
-import { get, isEmpty } from 'lodash';
+import { get } from 'lodash';
 import {
   EuiFlexItem,
   EuiFlexGroup,
@@ -40,6 +40,8 @@ import {
   Anomalies,
   DateRange,
   FEATURE_TYPE,
+  FeatureAggregationData,
+  EntityData,
 } from '../../../models/interfaces';
 import { NoFeaturePrompt } from '../components/FeatureChart/NoFeaturePrompt';
 import { focusOnFeatureAccordion } from '../../ConfigureModel/utils/helpers';
@@ -49,13 +51,13 @@ import { HeatmapCell } from './AnomalyHeatmapChart';
 interface FeatureBreakDownProps {
   title?: string;
   detector: Detector;
-  anomaliesResult: Anomalies;
+  anomalyAndFeatureResults: Anomalies[];
   annotations: any[];
   isLoading: boolean;
   dateRange: DateRange;
   featureDataSeriesName: string;
   showFeatureMissingDataPointAnnotation?: boolean;
-  rawAnomalyResults?: Anomalies;
+  rawAnomalyResults?: Anomalies[];
   isFeatureDataMissing?: boolean;
   isHCDetector?: boolean;
   selectedHeatmapCell?: HeatmapCell;
@@ -63,12 +65,42 @@ interface FeatureBreakDownProps {
 
 export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
   const getFeatureDataForChart = (
-    anomaliesResult: Anomalies,
+    anomalyAndFeatureResults: Anomalies[],
     featureId: string
   ) => {
-    return props.isHCDetector && !props.selectedHeatmapCell
-      ? []
-      : get(anomaliesResult, `featureData.${featureId}`, []);
+    if (props.isHCDetector && !props.selectedHeatmapCell) {
+      return [];
+    } else {
+      let featureResults = [] as FeatureAggregationData[][];
+      if (anomalyAndFeatureResults !== undefined) {
+        anomalyAndFeatureResults.forEach((timeSeries: Anomalies) => {
+          const curFeatureData = get(
+            timeSeries,
+            `featureData.${featureId}`,
+            []
+          ) as FeatureAggregationData[];
+          featureResults.push(curFeatureData);
+        });
+      }
+      return featureResults;
+    }
+  };
+
+  // Returns an array of entity combinations - one for each time series.
+  // Need to propagate this data to the chart in order to label the different possible time series
+  const getEntityDataForChart = (anomalyAndFeatureResults: Anomalies[]) => {
+    if (props.isHCDetector && !props.selectedHeatmapCell) {
+      return [];
+    } else {
+      let entityData = [] as EntityData[][];
+      if (anomalyAndFeatureResults !== undefined) {
+        anomalyAndFeatureResults.forEach((timeSeries: Anomalies) => {
+          // extracting the entity data from the first anomaly point in the time series
+          entityData.push(get(timeSeries, 'anomalies.0.entity', []));
+        });
+      }
+      return entityData;
+    }
   };
   const getAnnotationData = () => {
     return props.isHCDetector && !props.selectedHeatmapCell
@@ -105,10 +137,11 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
           <React.Fragment key={`${feature.featureName}-${feature.featureId}`}>
             <FeatureChart
               feature={feature}
-              featureData={
+              featureData={getFeatureDataForChart(
+                props.anomalyAndFeatureResults,
                 //@ts-ignore
-                getFeatureDataForChart(props.anomaliesResult, feature.featureId)
-              }
+                feature.featureId
+              )}
               rawFeatureData={getFeatureDataForChart(
                 //@ts-ignore
                 props.rawAnomalyResults,
@@ -155,6 +188,7 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
                 props.showFeatureMissingDataPointAnnotation
               }
               detectorEnabledTime={props.detector.enabledTime}
+              entityData={getEntityDataForChart(props.anomalyAndFeatureResults)}
             />
             {index + 1 ===
             get(props, 'detector.featureAttributes', []).length ? null : (

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -189,6 +189,7 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
               }
               detectorEnabledTime={props.detector.enabledTime}
               entityData={getEntityDataForChart(props.anomalyAndFeatureResults)}
+              isHCDetector={props.isHCDetector}
             />
             {index + 1 ===
             get(props, 'detector.featureAttributes', []).length ? null : (

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomaliesChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomaliesChart.test.tsx
@@ -106,6 +106,7 @@ describe('<AnomaliesChart /> spec', () => {
       isHistorical: false,
       isHCDetector: true,
       detectorCategoryField: ['category-1'],
+      selectedCategoryFields: [{ label: 'category-1' }],
     });
     getByText('Test title');
     getByText('Top 10');
@@ -118,10 +119,15 @@ describe('<AnomaliesChart /> spec', () => {
       isHistorical: false,
       isHCDetector: true,
       detectorCategoryField: ['category-1, category-2'],
+      selectedCategoryFields: [
+        { label: 'category-1' },
+        { label: 'category-2' },
+      ],
     });
     getByText('Test title');
     getByText('Top 10');
-    getByText('category-1, category-2');
+    getByText('category-1');
+    getByText('category-2');
   });
   test('renders the component for historical, non-HC detector', () => {
     console.error = jest.fn();
@@ -142,6 +148,7 @@ describe('<AnomaliesChart /> spec', () => {
       isHistorical: true,
       isHCDetector: true,
       detectorCategoryField: ['category-1'],
+      selectedCategoryFields: [{ label: 'category-1' }],
     });
     getByText('Test title');
     getByText('Top 10');
@@ -154,33 +161,28 @@ describe('<AnomaliesChart /> spec', () => {
       isHistorical: true,
       isHCDetector: true,
       detectorCategoryField: ['category-1', 'category-2'],
+      selectedCategoryFields: [
+        { label: 'category-1' },
+        { label: 'category-2' },
+      ],
     });
     getByText('Test title');
     getByText('Top 10');
-    getByText('category-1, category-2');
+    getByText('category-1');
+    getByText('category-2');
   });
-  test('renders multiple category fields if stored in alphabetical order', () => {
+  test('renders the component with a subset of category fields selected', () => {
     console.error = jest.fn();
-    const { getByText } = renderDataFilter({
+    const { getByText, queryByText } = renderDataFilter({
       ...DEFAULT_PROPS,
-      isHistorical: false,
+      isHistorical: true,
       isHCDetector: true,
-      detectorCategoryField: ['a', 'b'],
+      detectorCategoryField: ['category-1', 'category-2'],
+      selectedCategoryFields: [{ label: 'category-1' }],
     });
     getByText('Test title');
     getByText('Top 10');
-    getByText('a, b');
-  });
-  test('renders multiple category fields if stored in non-alphabetical order', () => {
-    console.error = jest.fn();
-    const { getByText } = renderDataFilter({
-      ...DEFAULT_PROPS,
-      isHistorical: false,
-      isHCDetector: true,
-      detectorCategoryField: ['b', 'a'],
-    });
-    getByText('Test title');
-    getByText('Top 10');
-    getByText('a, b');
+    getByText('category-1');
+    expect(queryByText('category-2')).toBeNull();
   });
 });

--- a/public/pages/AnomalyCharts/containers/__tests__/AnomalyHeatmapChart.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/AnomalyHeatmapChart.test.tsx
@@ -24,7 +24,7 @@
  * permissions and limitations under the License.
  */
 
-import { render, getByText } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import {
   AnomalyHeatmapChart,
@@ -44,7 +44,7 @@ describe('<AnomalyHeatmapChart /> spec', () => {
   test('AnomalyHeatmapChart with Sample anomaly data', () => {
     const { container } = render(
       <AnomalyHeatmapChart
-        title={'test-tile'}
+        title={'test-title'}
         detectorId="test-detector-id"
         detectorName="test-detector-name"
         detectorInterval={1}
@@ -63,7 +63,7 @@ describe('<AnomalyHeatmapChart /> spec', () => {
   test('AnomalyHeatmapChart with anomaly summaries data', () => {
     const { container } = render(
       <AnomalyHeatmapChart
-        title={'test-tile'}
+        title={'test-title'}
         detectorId="test-detector-id"
         detectorName="test-detector-name"
         detectorInterval={1}
@@ -82,7 +82,7 @@ describe('<AnomalyHeatmapChart /> spec', () => {
   test('AnomalyHeatmapChart with one category field', () => {
     const { container, getByText } = render(
       <AnomalyHeatmapChart
-        title={'test-tile'}
+        title={'test-title'}
         detectorId="test-detector-id"
         detectorName="test-detector-name"
         detectorInterval={1}
@@ -95,6 +95,7 @@ describe('<AnomalyHeatmapChart /> spec', () => {
         entityAnomalySummaries={[FAKE_ENTITY_ANOMALY_SUMMARIES]}
         heatmapDisplayOption={INITIAL_HEATMAP_DISPLAY_OPTION}
         categoryField={['test-field']}
+        selectedCategoryFields={[{ label: 'test-field' }]}
       />
     );
     expect(container).toMatchSnapshot();
@@ -104,7 +105,7 @@ describe('<AnomalyHeatmapChart /> spec', () => {
   test('AnomalyHeatmapChart with multiple category fields', () => {
     const { container, getByText } = render(
       <AnomalyHeatmapChart
-        title={'test-tile'}
+        title={'test-title'}
         detectorId="test-detector-id"
         detectorName="test-detector-name"
         detectorInterval={1}
@@ -117,10 +118,15 @@ describe('<AnomalyHeatmapChart /> spec', () => {
         entityAnomalySummaries={[FAKE_ENTITY_ANOMALY_SUMMARIES]}
         heatmapDisplayOption={INITIAL_HEATMAP_DISPLAY_OPTION}
         categoryField={['test-field-1', 'test-field-2']}
+        selectedCategoryFields={[
+          { label: 'test-field-1' },
+          { label: 'test-field-2' },
+        ]}
       />
     );
     expect(container).toMatchSnapshot();
     getByText('View by:');
-    getByText('test-field-1, test-field-2');
+    getByText('test-field-1');
+    getByText('test-field-2');
   });
 });

--- a/public/pages/AnomalyCharts/containers/__tests__/FeatureBreakDown.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/FeatureBreakDown.test.tsx
@@ -70,7 +70,7 @@ describe('<FeatureBreakDown /> spec', () => {
         <FeatureBreakDown
           title="test"
           detector={detector}
-          anomaliesResult={anomaliesResult}
+          anomalyAndFeatureResults={[anomaliesResult]}
           annotations={[]}
           isLoading={false}
           dateRange={dateRange}

--- a/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/AnomalyHeatmapChart.test.tsx.snap
+++ b/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/AnomalyHeatmapChart.test.tsx.snap
@@ -51,24 +51,33 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
           style="padding: 12px; margin-bottom: 6px;"
         >
           <div
-            class="euiFlexItem"
-            style="margin-bottom: 0px;"
-          >
-            <div
-              class="euiText euiText--medium"
-            >
-              <h4>
-                View by: 
-                <b />
-              </h4>
-            </div>
-          </div>
-          <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <h4>
+                    View by:
+                  </h4>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <h4 />
+                </div>
+              </div>
               <div
                 class="euiFlexItem"
                 style="min-width: 300px;"
@@ -192,7 +201,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                   >
                     <input
                       type="hidden"
-                      value="by_severity"
+                      value="severity"
                     />
                     <div
                       class="euiFormControlLayout"
@@ -452,24 +461,95 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
           style="padding: 12px; margin-bottom: 6px;"
         >
           <div
-            class="euiFlexItem"
-            style="margin-bottom: 0px;"
-          >
-            <div
-              class="euiText euiText--medium"
-            >
-              <h4>
-                View by: 
-                <b />
-              </h4>
-            </div>
-          </div>
-          <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <h4>
+                    View by:
+                  </h4>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+                style="min-width: 300px;"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  class="euiComboBox"
+                  role="combobox"
+                >
+                  <div
+                    class="euiFormControlLayout"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <div
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        data-test-subj="comboBoxInput"
+                        tabindex="-1"
+                      >
+                        <p
+                          class="euiComboBoxPlaceholder"
+                        >
+                          Select categorical fields
+                        </p>
+                        <div
+                          class="euiComboBox__input"
+                          style="font-size: 14px; display: inline-block;"
+                        >
+                          <input
+                            aria-controls=""
+                            data-test-subj="comboBoxSearchInput"
+                            role="textbox"
+                            style="box-sizing: content-box; width: 2px;"
+                            value=""
+                          />
+                          <div
+                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <button
+                          aria-label="Open list of options"
+                          class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                          data-test-subj="comboBoxToggleListButton"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                              fill-rule="non-zero"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <div
                 class="euiFlexItem"
                 style="min-width: 300px;"
@@ -606,7 +686,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                   >
                     <input
                       type="hidden"
-                      value="by_severity"
+                      value="severity"
                     />
                     <div
                       class="euiFormControlLayout"
@@ -875,26 +955,181 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
           style="padding: 12px; margin-bottom: 6px;"
         >
           <div
-            class="euiFlexItem"
-            style="margin-bottom: 0px;"
-          >
-            <div
-              class="euiText euiText--medium"
-            >
-              <h4>
-                View by: 
-                <b>
-                  test-field-1, test-field-2
-                </b>
-              </h4>
-            </div>
-          </div>
-          <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <h4>
+                    View by:
+                  </h4>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+                style="min-width: 300px;"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  class="euiComboBox"
+                  role="combobox"
+                >
+                  <div
+                    class="euiFormControlLayout"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <div
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        data-test-subj="comboBoxInput"
+                        tabindex="-1"
+                      >
+                        <span
+                          class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                          title="test-field-1"
+                        >
+                          <span
+                            class="euiBadge__content"
+                          >
+                            <span
+                              class="euiBadge__text"
+                            >
+                              test-field-1
+                            </span>
+                            <button
+                              aria-label="Remove test-field-1 from selection in this group"
+                              class="euiBadge__iconButton"
+                              title="Remove test-field-1 from selection in this group"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--small euiBadge__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                tabindex="-1"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                        </span>
+                        <span
+                          class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                          title="test-field-2"
+                        >
+                          <span
+                            class="euiBadge__content"
+                          >
+                            <span
+                              class="euiBadge__text"
+                            >
+                              test-field-2
+                            </span>
+                            <button
+                              aria-label="Remove test-field-2 from selection in this group"
+                              class="euiBadge__iconButton"
+                              title="Remove test-field-2 from selection in this group"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--small euiBadge__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                tabindex="-1"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                        </span>
+                        <div
+                          class="euiComboBox__input"
+                          style="font-size: 14px; display: inline-block;"
+                        >
+                          <input
+                            aria-controls=""
+                            data-test-subj="comboBoxSearchInput"
+                            role="textbox"
+                            style="box-sizing: content-box; width: 2px;"
+                            value=""
+                          />
+                          <div
+                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <button
+                          aria-label="Clear input"
+                          class="euiFormControlLayoutClearButton"
+                          data-test-subj="comboBoxClearButton"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          aria-label="Open list of options"
+                          class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                          data-test-subj="comboBoxToggleListButton"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                              fill-rule="non-zero"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <div
                 class="euiFlexItem"
                 style="min-width: 300px;"
@@ -1031,7 +1266,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                   >
                     <input
                       type="hidden"
-                      value="by_severity"
+                      value="severity"
                     />
                     <div
                       class="euiFormControlLayout"
@@ -1300,26 +1535,146 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
           style="padding: 12px; margin-bottom: 6px;"
         >
           <div
-            class="euiFlexItem"
-            style="margin-bottom: 0px;"
-          >
-            <div
-              class="euiText euiText--medium"
-            >
-              <h4>
-                View by: 
-                <b>
-                  test-field
-                </b>
-              </h4>
-            </div>
-          </div>
-          <div
             class="euiFlexItem euiFlexItem--flexGrowZero"
           >
             <div
               class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
             >
+              <div
+                class="euiFlexItem euiFlexItem--flexGrowZero"
+                style="margin-bottom: 0px;"
+              >
+                <div
+                  class="euiText euiText--medium"
+                >
+                  <h4>
+                    View by:
+                  </h4>
+                </div>
+              </div>
+              <div
+                class="euiFlexItem"
+                style="min-width: 300px;"
+              >
+                <div
+                  aria-expanded="false"
+                  aria-haspopup="listbox"
+                  class="euiComboBox"
+                  role="combobox"
+                >
+                  <div
+                    class="euiFormControlLayout"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <div
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        data-test-subj="comboBoxInput"
+                        tabindex="-1"
+                      >
+                        <span
+                          class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                          title="test-field"
+                        >
+                          <span
+                            class="euiBadge__content"
+                          >
+                            <span
+                              class="euiBadge__text"
+                            >
+                              test-field
+                            </span>
+                            <button
+                              aria-label="Remove test-field from selection in this group"
+                              class="euiBadge__iconButton"
+                              title="Remove test-field from selection in this group"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="euiIcon euiIcon--small euiBadge__icon"
+                                focusable="false"
+                                height="16"
+                                role="img"
+                                tabindex="-1"
+                                viewBox="0 0 16 16"
+                                width="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                                />
+                              </svg>
+                            </button>
+                          </span>
+                        </span>
+                        <div
+                          class="euiComboBox__input"
+                          style="font-size: 14px; display: inline-block;"
+                        >
+                          <input
+                            aria-controls=""
+                            data-test-subj="comboBoxSearchInput"
+                            role="textbox"
+                            style="box-sizing: content-box; width: 2px;"
+                            value=""
+                          />
+                          <div
+                            style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                      >
+                        <button
+                          aria-label="Clear input"
+                          class="euiFormControlLayoutClearButton"
+                          data-test-subj="comboBoxClearButton"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          aria-label="Open list of options"
+                          class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                          data-test-subj="comboBoxToggleListButton"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M13.069 5.157L8.384 9.768a.546.546 0 01-.768 0L2.93 5.158a.552.552 0 00-.771 0 .53.53 0 000 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 000-.76.552.552 0 00-.771 0z"
+                              fill-rule="non-zero"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <div
                 class="euiFlexItem"
                 style="min-width: 300px;"
@@ -1456,7 +1811,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                   >
                     <input
                       type="hidden"
-                      value="by_severity"
+                      value="severity"
                     />
                     <div
                       class="euiFormControlLayout"

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -204,7 +204,7 @@ export const ANOMALY_HEATMAP_COLORSCALE = [
 
 export enum AnomalyHeatmapSortType {
   SEVERITY = 'severity',
-  OCCURRENCES = 'occurrence',
+  OCCURRENCE = 'occurrence',
 }
 
 const getHeatmapColorByValue = (value: number) => {

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -40,6 +40,8 @@ import {
   MonitorAlert,
   AnomalySummary,
   EntityData,
+  EntityOptionsMap,
+  EntityOption,
 } from '../../../models/interfaces';
 import { dateFormatter, minuteDateFormatter } from '../../utils/helpers';
 import { RectAnnotationDatum } from '@elastic/charts';
@@ -747,12 +749,10 @@ const getChildEntities = (
   childCategoryFields: string[],
   childEntityCombos: Entity[][]
 ) => {
-  const childEntityOptionsMap = {} as {
-    [categoryField: string]: { label: string }[];
-  };
+  const childEntityOptionsMap = {} as EntityOptionsMap;
   childCategoryFields.forEach((categoryField: string) => {
     // init the map for each category field
-    childEntityOptionsMap[categoryField] = [] as { label: string }[];
+    childEntityOptionsMap[categoryField] = [] as EntityOption[];
     childEntityCombos.forEach((childEntityCombo: Entity[]) => {
       childEntityCombo.forEach((childEntity: Entity) => {
         if (categoryField === childEntity.name) {
@@ -770,9 +770,7 @@ export const getMultiCategoryFilters = (
   parentEntities: Entity[],
   childEntities: Entity[][],
   allCategoryFields: string[],
-  selectedChildEntities: {
-    [childCategoryField: string]: { label: string }[];
-  },
+  selectedChildEntities: EntityOptionsMap,
   onSelectedOptionsChange: (childCategoryField: string, options: any[]) => void
 ) => {
   const parentEntityFields = parentEntities.map(
@@ -830,7 +828,7 @@ export const getMultiCategoryFilters = (
 // The cartesian product would be [[A1, B1], [A1, B2], [A2, B1], [A2, B2]]
 export const getAllEntityCombos = (
   parentEntities: Entity[],
-  childEntities: { [childCategoryField: string]: { label: string }[] }
+  childEntities: EntityOptionsMap
 ) => {
   let entitySources = [] as Entity[][];
   // getting parent sources
@@ -840,7 +838,7 @@ export const getAllEntityCombos = (
   for (var childCategoryField in childEntities) {
     let curChildEntities = [] as Entity[];
     childEntities[childCategoryField].forEach(
-      (childEntityValue: { label: string }) => {
+      (childEntityValue: EntityOption) => {
         const childEntity = {
           name: childCategoryField,
           value: childEntityValue.label,
@@ -863,5 +861,5 @@ export const getAllEntityCombos = (
     //@ts-ignore
     (a, b) => a.flatMap((x) => b.map((y) => [...x, y])),
     [[]]
-  );
+  ) as Entity[][];
 };

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -26,7 +26,14 @@
 
 import { cloneDeep, defaultTo, get, isEmpty, orderBy } from 'lodash';
 import React from 'react';
-import { EuiTitle, EuiSpacer } from '@elastic/eui';
+import {
+  EuiTitle,
+  EuiSpacer,
+  EuiText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiComboBox,
+} from '@elastic/eui';
 import {
   DateRange,
   Detector,
@@ -699,5 +706,89 @@ export const getHCTitle = (entityList: Entity[]) => {
       </EuiTitle>
       <EuiSpacer size="s" />
     </div>
+  );
+};
+
+export const getCategoryFieldOptions = (categoryFields: string[]) => {
+  const categoryFieldOptions = [] as any[];
+  if (categoryFields !== undefined) {
+    categoryFields.forEach((categoryField: string) => {
+      categoryFieldOptions.push({
+        label: categoryField,
+      });
+    });
+  }
+  return categoryFieldOptions;
+};
+
+const getMultiCategoryFilterPrefix = (prefilteredEntities: Entity[]) => {
+  return (
+    <EuiText>
+      <h3>
+        Viewing results for&nbsp;
+        {prefilteredEntities.map((entity: Entity) => {
+          return (
+            <span>
+              {entity.name} <b>{entity.value}</b>
+              {''}
+            </span>
+          );
+        })}
+      </h3>
+    </EuiText>
+  );
+};
+
+export const getMultiCategoryFilter = (
+  entityList: Entity[],
+  selectedCategoryFields: string[]
+) => {
+  // TODO: shouldn't need the prefiltered/unfiltered. When the new API is added,
+  // the heatmap cell should only include the prefiltered entities; the unfiltered entities
+  // will be the set difference of prefiltered entities & category fields
+  const prefilteredEntities = entityList.filter((entity: Entity) =>
+    selectedCategoryFields.includes(entity.name)
+  );
+  const unfilteredEntities = entityList
+    .filter((entity: Entity) => !selectedCategoryFields.includes(entity.name))
+    .map((entity: Entity) => entity.name);
+
+  return (
+    <EuiFlexGroup
+      gutterSize="s"
+      alignItems="center"
+      style={{ marginBottom: '4px' }}
+    >
+      <EuiFlexItem grow={false}>
+        {getMultiCategoryFilterPrefix(prefilteredEntities)}
+      </EuiFlexItem>
+      {unfilteredEntities.map((unfilteredEntity: string) => {
+        return (
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <EuiFlexItem>
+              <EuiText>
+                <h3>and&nbsp;{unfilteredEntity}&nbsp;&nbsp;</h3>
+              </EuiText>
+            </EuiFlexItem>
+            <EuiFlexItem style={{ minWidth: 300 }}>
+              <EuiComboBox
+                placeholder="Select categorical fields"
+                options={[
+                  {
+                    label: 'some-value',
+                  },
+                ]}
+                selectedOptions={[
+                  {
+                    label: 'some-selected-value',
+                  },
+                ]}
+                onChange={() => {}}
+              />
+            </EuiFlexItem>
+          </div>
+        );
+      })}
+    </EuiFlexGroup>
   );
 };

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -197,8 +197,8 @@ export const ANOMALY_HEATMAP_COLORSCALE = [
 ];
 
 export enum AnomalyHeatmapSortType {
-  SEVERITY = 'by_severity',
-  OCCURRENCES = 'by_occurrences',
+  SEVERITY = 'severity',
+  OCCURRENCES = 'occurrence',
 }
 
 const getHeatmapColorByValue = (value: number) => {
@@ -236,7 +236,7 @@ const buildBlankStringWithLength = (length: number) => {
   return result;
 };
 
-export const getAnomaliesHeatmapData = (
+export const getSampleAnomaliesHeatmapData = (
   anomalies: any[] | undefined,
   dateRange: DateRange,
   sortType: AnomalyHeatmapSortType = AnomalyHeatmapSortType.SEVERITY,
@@ -352,7 +352,7 @@ const buildHeatmapPlotData = (
   } as PlotData;
 };
 
-export const getEntitytAnomaliesHeatmapData = (
+export const getEntityAnomaliesHeatmapData = (
   dateRange: DateRange,
   entitiesAnomalySummaryResult: EntityAnomalySummaries[],
   displayTopNum: number

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -52,6 +52,7 @@ import {
   calculateTimeWindowsWithMaxDataPoints,
   convertToEntityString,
   transformEntityListsForHeatmap,
+  convertToCategoryFieldString,
 } from '../../utils/anomalyResultUtils';
 import { HeatmapCell } from '../containers/AnomalyHeatmapChart';
 import {
@@ -60,6 +61,7 @@ import {
 } from '../../../../server/models/interfaces';
 import { toFixedNumberForAnomaly } from '../../../../server/utils/helpers';
 import { Entity } from '../../../../server/models/interfaces';
+import { TOP_CHILD_ENTITIES_TO_FETCH } from '../../DetectorResults/utils/constants';
 
 export const convertAlerts = (response: any): MonitorAlert[] => {
   const alerts = get(response, 'response.alerts', []);
@@ -766,12 +768,16 @@ const getChildEntities = (
   return childEntityOptionsMap;
 };
 
+// Returns a string list of selected parent entities (populated from the selected heatmap cell)
+// + an array of comboboxes, one for each child category field. Populates the top
+// child entities per combo box.
 export const getMultiCategoryFilters = (
   parentEntities: Entity[],
   childEntities: Entity[][],
   allCategoryFields: string[],
   selectedChildEntities: EntityOptionsMap,
-  onSelectedOptionsChange: (childCategoryField: string, options: any[]) => void
+  onSelectedOptionsChange: (childCategoryField: string, options: any[]) => void,
+  sortType: AnomalyHeatmapSortType
 ) => {
   const parentEntityFields = parentEntities.map(
     (entity: Entity) => entity.name
@@ -780,6 +786,8 @@ export const getMultiCategoryFilters = (
     (categoryField: string) => !parentEntityFields.includes(categoryField)
   );
 
+  // Based on the available child entities, categorize them into their appropriate category field
+  // so each combo box can be filled with the appopriate entity options
   const childEntityOptions = getChildEntities(
     childCategoryFields,
     childEntities
@@ -815,6 +823,18 @@ export const getMultiCategoryFilters = (
           </div>
         );
       })}
+      <EuiFlexItem>
+        <EuiText
+          className="sublabel"
+          style={{ marginLeft: '8px', marginBottom: '0px', maxWidth: 300 }}
+        >
+          {`The top ${TOP_CHILD_ENTITIES_TO_FETCH} values of ${convertToCategoryFieldString(
+            childCategoryFields,
+            ', '
+          )} sorted by anomaly ${sortType} are available to
+          view.`}
+        </EuiText>
+      </EuiFlexItem>
     </EuiFlexGroup>
   );
 };

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -740,18 +740,15 @@ const getMultiCategoryFilterPrefix = (prefilteredEntities: Entity[]) => {
 };
 
 export const getMultiCategoryFilter = (
-  entityList: Entity[],
-  selectedCategoryFields: string[]
+  prefilteredEntities: Entity[],
+  allCategoryFields: string[]
 ) => {
-  // TODO: shouldn't need the prefiltered/unfiltered. When the new API is added,
-  // the heatmap cell should only include the prefiltered entities; the unfiltered entities
-  // will be the set difference of prefiltered entities & category fields
-  const prefilteredEntities = entityList.filter((entity: Entity) =>
-    selectedCategoryFields.includes(entity.name)
+  const prefilteredEntityFields = prefilteredEntities.map(
+    (entity: Entity) => entity.name
   );
-  const unfilteredEntities = entityList
-    .filter((entity: Entity) => !selectedCategoryFields.includes(entity.name))
-    .map((entity: Entity) => entity.name);
+  const unfilteredCategoryFields = allCategoryFields.filter(
+    (categoryField: string) => !prefilteredEntityFields.includes(categoryField)
+  );
 
   return (
     <EuiFlexGroup
@@ -762,7 +759,7 @@ export const getMultiCategoryFilter = (
       <EuiFlexItem grow={false}>
         {getMultiCategoryFilterPrefix(prefilteredEntities)}
       </EuiFlexItem>
-      {unfilteredEntities.map((unfilteredEntity: string) => {
+      {unfilteredCategoryFields.map((unfilteredEntity: string) => {
         return (
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <EuiFlexItem>

--- a/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
+++ b/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
@@ -249,7 +249,7 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
             selectedHeatmapCell={selectedHeatmapCell}
             newDetector={newDetector}
             zoomRange={zoomRange}
-            anomaliesResult={anomaliesResult}
+            anomalyAndFeatureResults={[anomaliesResult]}
             showAlerts={false}
             isNotSample={false}
           />
@@ -267,10 +267,10 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
             <FeatureBreakDown
               title={getFeatureBreakdownWording(false)}
               detector={newDetector}
-              anomaliesResult={anomaliesResult}
-              annotations={generateAnomalyAnnotations(
-                get(anomaliesResult, 'anomalies', [])
-              )}
+              anomalyAndFeatureResults={[anomaliesResult]}
+              annotations={generateAnomalyAnnotations([
+                get(anomaliesResult, 'anomalies', []),
+              ])}
               isLoading={isLoading}
               dateRange={zoomRange}
               featureDataSeriesName={getFeatureDataWording(false)}

--- a/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
+++ b/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
@@ -41,6 +41,7 @@ import {
   getAnomalyHistoryWording,
   getFeatureBreakdownWording,
   getFeatureDataWording,
+  getAnomalySummary,
 } from '../../AnomalyCharts/utils/anomalyChartUtils';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -52,7 +53,10 @@ import { AnomaliesChart } from '../../AnomalyCharts/containers/AnomaliesChart';
 import { HeatmapCell } from '../../AnomalyCharts/containers/AnomalyHeatmapChart';
 import { FeatureBreakDown } from '../../AnomalyCharts/containers/FeatureBreakDown';
 import { useHideSideNavBar } from '../../main/hooks/useHideSideNavBar';
-import { generateAnomalyAnnotations } from '../../utils/anomalyResultUtils';
+import {
+  generateAnomalyAnnotations,
+  filterSampleData,
+} from '../../utils/anomalyResultUtils';
 import { focusOnFirstWrongFeature } from '../utils/helpers';
 import { prepareDetector } from '../utils/helpers';
 import { FeaturesFormikValues } from '../models/interfaces';
@@ -95,6 +99,21 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
 
   const isHCDetector = !isEmpty(get(newDetector, 'categoryField', []));
 
+  const sampleAnomaliesResult = useSelector(
+    (state: AppState) => state.anomalies.anomaliesResult
+  );
+
+  const filteredSampleResults = filterSampleData(
+    sampleAnomaliesResult,
+    zoomRange,
+    'plotTime',
+    selectedHeatmapCell
+  );
+
+  const anomalySummary = getAnomalySummary(
+    get(filteredSampleResults, 'anomalies', [])
+  );
+
   useEffect(() => {
     if (!firstPreview) {
       getSampleAnomalies();
@@ -102,8 +121,12 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
   }, [dateRange]);
 
   const handleDateRangeChange = useCallback(
-    (startDate: number, endDate: number, dateRangeOption: string) => {
+    (startDate: number, endDate: number, dateRangeOption?: string) => {
       setDateRange({
+        startDate: startDate,
+        endDate: endDate,
+      });
+      setZoomRange({
         startDate: startDate,
         endDate: endDate,
       });
@@ -120,11 +143,8 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
 
   const handleHeatmapCellSelected = useCallback((heatmapCell: HeatmapCell) => {
     setSelectedHeatmapCell(heatmapCell);
+    setZoomRange(heatmapCell.dateRange);
   }, []);
-
-  const anomaliesResult = useSelector(
-    (state: AppState) => state.anomalies.anomaliesResult
-  );
 
   const getPreviewErrorMessage = (err: any, defaultMessage: string) => {
     if (typeof err === 'string') return err;
@@ -213,6 +233,10 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
                 if (
                   !focusOnFirstWrongFeature(props.errors, props.setFieldTouched)
                 ) {
+                  handleDateRangeChange(
+                    initialStartDate.valueOf(),
+                    initialEndDate.valueOf()
+                  );
                   getSampleAnomalies();
                 }
               }}
@@ -225,7 +249,7 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
         </EuiFlexGroup>
       </EuiCallOut>
       <EuiSpacer />
-      {previewDone && !anomaliesResult.anomalies.length ? (
+      {previewDone && !sampleAnomaliesResult.anomalies.length ? (
         <EuiCallOut
           title={`No sample anomaly result generated. Please check detector interval and make sure you have >400 data points${
             isHCDetector ? ' for some entities ' : ' '
@@ -249,7 +273,8 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
             selectedHeatmapCell={selectedHeatmapCell}
             newDetector={newDetector}
             zoomRange={zoomRange}
-            anomalyAndFeatureResults={[anomaliesResult]}
+            anomalyAndFeatureResults={[filteredSampleResults]}
+            anomalySummary={anomalySummary}
             showAlerts={false}
             isNotSample={false}
           />
@@ -267,9 +292,9 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
             <FeatureBreakDown
               title={getFeatureBreakdownWording(false)}
               detector={newDetector}
-              anomalyAndFeatureResults={[anomaliesResult]}
+              anomalyAndFeatureResults={[filteredSampleResults]}
               annotations={generateAnomalyAnnotations([
-                get(anomaliesResult, 'anomalies', []),
+                get(filteredSampleResults, 'anomalies', []),
               ])}
               isLoading={isLoading}
               dateRange={zoomRange}

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -49,7 +49,6 @@ import {
   Detector,
   Monitor,
   DateRange,
-  AnomalySummary,
   Anomalies,
   EntityOptionsMap,
   EntityOption,
@@ -59,7 +58,6 @@ import {
   getAnomalySummaryQuery,
   getBucketizedAnomalyResultsQuery,
   parseBucketizedAnomalyResults,
-  parseAnomalySummary,
   parsePureAnomalies,
   buildParamsForGetAnomalyResultsWithDateRange,
   FEATURE_DATA_CHECK_WINDOW_OFFSET,
@@ -910,7 +908,12 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                             childEntityCombos,
                             detectorCategoryField,
                             selectedChildEntities,
-                            handleChildEntitiesOptionChanged
+                            handleChildEntitiesOptionChanged,
+                            get(
+                              heatmapDisplayOption,
+                              'sortType',
+                              AnomalyHeatmapSortType.SEVERITY
+                            )
                           )
                         : getHCTitle(selectedHeatmapCell.entityList)
                       : '-'

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -640,9 +640,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                           get(detectorCategoryField, 'length', 0)
                         ? getMultiCategoryFilter(
                             selectedHeatmapCell.entityList,
-                            selectedCategoryFields.map(
-                              (categoryField) => categoryField.label
-                            )
+                            detectorCategoryField
                           )
                         : getHCTitle(selectedHeatmapCell.entityList)
                       : '-'

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -187,15 +187,6 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     EntityOptionsMap
   >({});
 
-  // The selected anomaly results as an array of Anomalies, where each entry
-  // is its own time series, containing anomaly results and feature results
-  // We need to be able to store multiple, in the case of a user selecting a single
-  // category field, and then selecting multiple child category fields,
-  // resulting in multiple time series & sets of results
-  // const [selectedAnomalyResults, setSelectedAnomalyResults] = useState<
-  //   Anomalies[]
-  // >([]);
-
   const detectorCategoryField = get(props.detector, 'categoryField', []);
   const isHCDetector = !isEmpty(detectorCategoryField);
   const isMultiCategory = detectorCategoryField.length > 1;
@@ -772,12 +763,12 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       [childCategoryField]: options,
     };
 
-    // Limit the number of entities to display on the charts at once
     const entityCombosToFetch = getAllEntityCombos(
       get(selectedHeatmapCell, 'entityList', []),
       tempSelectedChildEntities
     );
 
+    // Limit the number of entities to display on the charts at once
     if (entityCombosToFetch.length > MAX_TIME_SERIES_TO_DISPLAY) {
       core.notifications.toasts.addWarning(
         `A maximum of ${MAX_TIME_SERIES_TO_DISPLAY} sets of results can be displayed at one time`

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -238,7 +238,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                   taskId.current,
                   modelId
                 );
-                return dispatch(searchResults(params));
+                return dispatch(searchResults(params, resultIndex));
               })
             : [];
 
@@ -267,7 +267,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
               props.isHistorical,
               taskId.current,
               modelId
-            )
+            ),
+            resultIndex
           )
         );
         allPureAnomalies.push(parsePureAnomalies(anomalySummaryResponse));
@@ -291,7 +292,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
               taskId.current,
               modelId
             );
-            return dispatch(searchResults(params));
+            return dispatch(searchResults(params, resultIndex));
           }
         );
 
@@ -324,7 +325,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
               props.isHistorical,
               taskId.current,
               modelId
-            )
+            ),
+            resultIndex
           )
         );
         allBucketizedAnomalyResults.push(
@@ -636,7 +638,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         getDetectorResults(
           props.isHistorical ? taskId.current : props.detector?.id,
           params,
-          props.isHistorical ? true : false
+          props.isHistorical ? true : false,
+          resultIndex
         )
       );
     });
@@ -718,7 +721,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       taskId.current,
       heatmapCell.entityList
     );
-    const result = await dispatch(searchResults(query));
+    const result = await dispatch(searchResults(query, resultIndex));
 
     // Gets top child entities as an Entity[][],
     // where each entry in the array is a unique combination of entity values

--- a/public/pages/DetectorResults/utils/constants.ts
+++ b/public/pages/DetectorResults/utils/constants.ts
@@ -61,5 +61,8 @@ export const NO_DATA_IN_WINDOW_ERROR_MESSAGE =
 export const NO_RCF_MODEL_ERROR_MESSAGE =
   'No RCF models are available either because RCF models are not ready or all nodes are unresponsive or the system might have bugs';
 
-export const DEFAULT_TOP_CHILD_ENTITIES_TO_FETCH = 10;
-export const DEFAULT_TOP_CHILD_ENTITIES_TO_DISPLAY = 5;
+export const TOP_CHILD_ENTITIES_TO_FETCH = 20;
+
+export const MAX_TIME_SERIES_TO_DISPLAY = 5;
+
+export const ENTITY_COLORS = ['red', 'blue', 'black', 'green', 'orange'];

--- a/public/pages/DetectorResults/utils/constants.ts
+++ b/public/pages/DetectorResults/utils/constants.ts
@@ -60,3 +60,6 @@ export const NO_DATA_IN_WINDOW_ERROR_MESSAGE =
 //https://github.com/opensearch-project/anomaly-detection/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java#L81
 export const NO_RCF_MODEL_ERROR_MESSAGE =
   'No RCF models are available either because RCF models are not ready or all nodes are unresponsive or the system might have bugs';
+
+export const DEFAULT_TOP_CHILD_ENTITIES_TO_FETCH = 10;
+export const DEFAULT_TOP_CHILD_ENTITIES_TO_DISPLAY = 5;

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -67,7 +67,6 @@ import {
   MAX_ANOMALIES,
   MISSING_FEATURE_DATA_SEVERITY,
 } from '../../utils/constants';
-//import { HeatmapCell } from '../AnomalyCharts/containers/AnomalyHeatmapChart';
 import {
   AnomalyHeatmapSortType,
   NUM_CELLS,
@@ -258,13 +257,16 @@ export const prepareDataForChart = (data: any[][], dateRange: DateRange) => {
   return preparedData;
 };
 
+// Generates a set of annotations for each anomaly result time series.
+// One time series is a single AnomalyData[]. We pass an array of time series
+// since multiple time series may need to be processed.
 export const generateAnomalyAnnotations = (
   anomalies: AnomalyData[][]
 ): any[][] => {
   let annotations = [] as any[];
-  anomalies.forEach((anomalies: AnomalyData[]) => {
+  anomalies.forEach((anomalyTimeSeries: AnomalyData[]) => {
     annotations.push(
-      anomalies
+      anomalyTimeSeries
         .filter((anomaly: AnomalyData) => anomaly.anomalyGrade > 0)
         .map((anomaly: AnomalyData) => ({
           coordinates: {

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -46,6 +46,8 @@ import {
   MODEL_ID_FIELD,
   ENTITY_LIST_FIELD,
   ENTITY_LIST_DELIMITER,
+  HEATMAP_CELL_ENTITY_DELIMITER,
+  HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER,
 } from '../../../server/utils/constants';
 import { toFixedNumberForAnomaly } from '../../../server/utils/helpers';
 import {
@@ -1530,31 +1532,41 @@ export const convertToCategoryFieldString = (
   return categoryFieldString;
 };
 
-export const convertToCategoryFieldAndEntityString = (entityList: Entity[]) => {
+export const convertToCategoryFieldAndEntityString = (
+  entityList: Entity[],
+  delimiter: string = '\n'
+) => {
   let entityString = '';
   if (!isEmpty(entityList)) {
     entityList.forEach((entity: any, index) => {
       if (index > 0) {
-        entityString += '\n';
+        entityString += delimiter;
       }
-      entityString += entity.name + ': ' + entity.value;
+      entityString +=
+        entity.name +
+        `${HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER} ` +
+        entity.value;
     });
   }
   return entityString;
 };
 
-export const convertToEntityList = (
-  entityListAsString: string,
-  categoryFields: string[],
-  delimiter: string
+export const convertHeatmapCellEntityStringToEntityList = (
+  heatmapCellEntityString: string
 ) => {
   let entityList = [] as Entity[];
-  const valueArr = entityListAsString.split(delimiter);
+  const entitiesAsStringList = heatmapCellEntityString.split(
+    HEATMAP_CELL_ENTITY_DELIMITER
+  );
   var i;
-  for (i = 0; i < valueArr.length; i++) {
+  for (i = 0; i < entitiesAsStringList.length; i++) {
+    const entityAsString = entitiesAsStringList[i];
+    const entityAsFieldValuePair = entityAsString.split(
+      HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER
+    );
     entityList.push({
-      name: categoryFields[i],
-      value: valueArr[i],
+      name: entityAsFieldValuePair[0],
+      value: entityAsFieldValuePair[1],
     });
   }
   return entityList;
@@ -1604,7 +1616,10 @@ const getEntityFilters = (
 export const transformEntityListsForHeatmap = (entityLists: any[]) => {
   let transformedEntityLists = [] as any[];
   entityLists.forEach((entityList: Entity[]) => {
-    const listAsString = convertToEntityString(entityList, ', ');
+    const listAsString = convertToCategoryFieldAndEntityString(
+      entityList,
+      ', '
+    );
     let row = [];
     var i;
     for (i = 0; i < NUM_CELLS; i++) {

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -1179,6 +1179,40 @@ export const parseTopEntityAnomalySummaryResults = (
   return topEntityAnomalySummaries;
 };
 
+export const parseAggTopEntityAnomalySummaryResults = (
+  result: any
+): EntityAnomalySummaries[] => {
+  const rawEntityAnomalySummaries = get(result, `response.buckets`, []);
+  let topEntityAnomalySummaries = [] as EntityAnomalySummaries[];
+  rawEntityAnomalySummaries.forEach((item: any) => {
+    // Loop through the K/V pairs in the "key" dict returned in the composite
+    // agg bucket key from multi-category filter API
+    const entityListAsKey = get(item, `${KEY_FIELD}`, {}) as {
+      [key: string]: string;
+    };
+    let entityList = [] as Entity[];
+    for (var entity in entityListAsKey) {
+      entityList.push({
+        name: entity,
+        value: entityListAsKey[entity] as string,
+      });
+    }
+
+    const anomalyCount = get(item, DOC_COUNT_FIELD, 0);
+    const maxAnomalyGrade = get(item, 'max_anomaly_grade', 0);
+    const entityAnomalySummary = {
+      maxAnomaly: maxAnomalyGrade,
+      anomalyCount: anomalyCount,
+    } as EntityAnomalySummary;
+    const entityAnomalySummaries = {
+      entityList: entityList,
+      anomalySummaries: [entityAnomalySummary],
+    } as EntityAnomalySummaries;
+    topEntityAnomalySummaries.push(entityAnomalySummaries);
+  });
+  return topEntityAnomalySummaries;
+};
+
 export const getEntityAnomalySummariesQuery = (
   startTime: number,
   endTime: number,

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -65,7 +65,7 @@ import {
   MAX_ANOMALIES,
   MISSING_FEATURE_DATA_SEVERITY,
 } from '../../utils/constants';
-import { HeatmapCell } from '../AnomalyCharts/containers/AnomalyHeatmapChart';
+//import { HeatmapCell } from '../AnomalyCharts/containers/AnomalyHeatmapChart';
 import {
   AnomalyHeatmapSortType,
   NUM_CELLS,
@@ -936,27 +936,26 @@ export const getFeatureDataMissingMessageAndActionItem = (
   }
 };
 
-export const filterWithHeatmapFilter = (
-  data: any[],
-  heatmapCell: HeatmapCell | undefined,
-  isFilteringWithEntity: boolean = true,
-  timeField: string = 'plotTime'
-) => {
-  if (!heatmapCell) {
-    return data;
-  }
+// export const filterWithHeatmapFilter = (
+//   data: any[],
+//   heatmapCell: HeatmapCell | undefined,
+//   selectedEntitites: Entity[],
+//   isFilteringWithEntity: boolean = true,
+//   timeField: string = 'plotTime'
+// ) => {
+//   if (!heatmapCell) {
+//     return data;
+//   }
 
-  if (isFilteringWithEntity) {
-    data = data
-      .filter((anomaly) => !isEmpty(get(anomaly, 'entity', [])))
-      .filter((anomaly) => {
-        const dataEntityList = get(anomaly, 'entity');
-        const cellEntityList = get(heatmapCell, 'entityList');
-        return entityListsMatch(dataEntityList, cellEntityList);
-      });
-  }
-  return filterWithDateRange(data, heatmapCell.dateRange, timeField);
-};
+//   if (isFilteringWithEntity) {
+//     data = data
+//       .filter((anomaly) => !isEmpty(get(anomaly, 'entity', [])))
+//       .filter((anomaly) => {
+//         return entityListsMatch(get(anomaly, 'entity'), selectedEntitites);
+//       });
+//   }
+//   return filterWithDateRange(data, heatmapCell.dateRange, timeField);
+// };
 
 // Generates query to get the top anomalous entities (or entity pairs)
 // for some detector, sorting by severity or occurrence.
@@ -1616,21 +1615,21 @@ export const convertHeatmapCellEntityStringToEntityList = (
   return entityList;
 };
 
-export const entityListsMatch = (
-  entityListA: Entity[],
-  entityListB: Entity[]
-) => {
-  if (get(entityListA, 'length') !== get(entityListB, 'length')) {
-    return false;
-  }
-  var i;
-  for (i = 0; i < entityListA.length; i++) {
-    if (entityListA[i].value !== entityListB[i].value) {
-      return false;
-    }
-  }
-  return true;
-};
+// export const entityListsMatch = (
+//   entityListA: Entity[],
+//   entityListB: Entity[]
+// ) => {
+//   if (get(entityListA, 'length') !== get(entityListB, 'length')) {
+//     return false;
+//   }
+//   var i;
+//   for (i = 0; i < entityListA.length; i++) {
+//     if (entityListA[i].value !== entityListB[i].value) {
+//       return false;
+//     }
+//   }
+//   return true;
+// };
 
 // Helper fn to get the correct filters based on how many categorical fields there are.
 const getHCFilters = (modelId: string | undefined, entityList: Entity[]) => {

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -1129,6 +1129,14 @@ export const getTopAnomalousEntitiesQuery = (
                         },
                       }
                     : {}),
+                  [ENTITY_LIST_FIELD]: {
+                    top_hits: {
+                      size: 1,
+                      _source: {
+                        include: [ENTITY_FIELD],
+                      },
+                    },
+                  },
                 },
               },
             },
@@ -1209,9 +1217,7 @@ export const parseTopEntityAnomalySummaryResults = (
     const entityList = isMultiCategory
       ? get(item, `${ENTITY_LIST_FIELD}.hits.hits.0._source.entity`, [])
       : ([
-          {
-            value: get(item, KEY_FIELD, 0),
-          },
+          get(item, `${ENTITY_LIST_FIELD}.hits.hits.0._source`, {}),
         ] as Entity[]);
 
     const maxAnomalyGrade = isMultiCategory
@@ -1623,23 +1629,7 @@ export const convertHeatmapCellEntityStringToEntityList = (
   return entityList;
 };
 
-// export const entityListsMatch = (
-//   entityListA: Entity[],
-//   entityListB: Entity[]
-// ) => {
-//   if (get(entityListA, 'length') !== get(entityListB, 'length')) {
-//     return false;
-//   }
-//   var i;
-//   for (i = 0; i < entityListA.length; i++) {
-//     if (entityListA[i].value !== entityListB[i].value) {
-//       return false;
-//     }
-//   }
-//   return true;
-// };
-
-// Helper fn to get the correct filters based on how many categorical fields there are.
+// Adding filters for all entity values
 const appendEntityFilters = (requestBody: any, entityList: Entity[]) => {
   if (entityList !== undefined && !isEmpty(entityList)) {
     entityList.forEach((entity: Entity) => {

--- a/public/redux/reducers/anomalyResults.ts
+++ b/public/redux/reducers/anomalyResults.ts
@@ -32,6 +32,7 @@ import { get } from 'lodash';
 
 const DETECTOR_RESULTS = 'ad/DETECTOR_RESULTS';
 const SEARCH_ANOMALY_RESULTS = 'ad/SEARCH_ANOMALY_RESULTS';
+const GET_TOP_ANOMALY_RESULTS = 'ad/GET_TOP_ANOMALY_RESULTS';
 
 export interface Anomalies {
   requesting: boolean;
@@ -86,6 +87,22 @@ const reducer = handleActions<Anomalies>(
         errorMessage: get(action, 'error.error', action.error),
       }),
     },
+    [GET_TOP_ANOMALY_RESULTS]: {
+      REQUEST: (state: Anomalies): Anomalies => ({
+        ...state,
+        requesting: true,
+        errorMessage: '',
+      }),
+      SUCCESS: (state: Anomalies, action: APIResponseAction): Anomalies => ({
+        ...state,
+        requesting: false,
+      }),
+      FAILURE: (state: Anomalies, action: APIResponseAction): Anomalies => ({
+        ...state,
+        requesting: false,
+        errorMessage: get(action, 'error.error', action.error),
+      }),
+    },
   },
   initialDetectorsState
 );
@@ -115,6 +132,21 @@ export const searchResults = (
     client.post(`..${AD_NODE_API.DETECTOR}/results/_search/${resultIndex}`, {
       body: JSON.stringify(requestBody),
     }),
+});
+
+export const getTopAnomalyResults = (
+  detectorId: string,
+  isHistorical: boolean,
+  requestBody: any
+): APIAction => ({
+  type: GET_TOP_ANOMALY_RESULTS,
+  request: (client: HttpSetup) =>
+    client.post(
+      `..${AD_NODE_API.DETECTOR}/${detectorId}/_topAnomalies/${isHistorical}`,
+      {
+        body: JSON.stringify(requestBody),
+      }
+    ),
 });
 
 export default reducer;

--- a/server/cluster/ad/adPlugin.ts
+++ b/server/cluster/ad/adPlugin.ts
@@ -185,6 +185,7 @@ export default function adPlugin(Client: any, config: any, components: any) {
     },
     method: 'GET',
   });
+
   ad.matchDetector = ca({
     url: {
       fmt: `${API.DETECTOR_BASE}/match?name=<%=detectorName%>`,
@@ -198,10 +199,39 @@ export default function adPlugin(Client: any, config: any, components: any) {
     needBody: true,
     method: 'GET',
   });
+
   ad.detectorCount = ca({
     url: {
       fmt: `${API.DETECTOR_BASE}/count`,
     },
     method: 'GET',
+  });
+
+  ad.topAnomalyResults = ca({
+    url: {
+      fmt: `${API.DETECTOR_BASE}/<%=detectorId%>/results/_topAnomalies?historical=false`,
+      req: {
+        detectorId: {
+          type: 'string',
+          required: true,
+        },
+      },
+      needBody: true,
+    },
+    method: 'POST',
+  });
+
+  ad.topHistoricalAnomalyResults = ca({
+    url: {
+      fmt: `${API.DETECTOR_BASE}/<%=detectorId%>/results/_topAnomalies?historical=true`,
+      req: {
+        detectorId: {
+          type: 'string',
+          required: true,
+        },
+      },
+      needBody: true,
+    },
+    method: 'POST',
   });
 }

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -981,8 +981,6 @@ export default class AdService {
           body: request.body,
         });
 
-      console.log('response: ', response);
-
       return opensearchDashboardsResponse.ok({
         body: {
           ok: true,

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -105,6 +105,10 @@ export function registerADRoutes(apiRouter: Router, adService: AdService) {
   );
   apiRouter.get('/detectors/{detectorName}/_match', adService.matchDetector);
   apiRouter.get('/detectors/_count', adService.getDetectorCount);
+  apiRouter.post(
+    '/detectors/{detectorId}/_topAnomalies/{isHistorical}',
+    adService.getTopAnomalyResults
+  );
 }
 
 export default class AdService {
@@ -946,6 +950,47 @@ export default class AdService {
       });
     } catch (err) {
       console.log('Anomaly detector - Unable to get results', err);
+      return opensearchDashboardsResponse.ok({
+        body: {
+          ok: false,
+          error: getErrorMessage(err),
+        },
+      });
+    }
+  };
+
+  getTopAnomalyResults = async (
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    try {
+      let { detectorId, isHistorical } = request.params as {
+        detectorId: string;
+        isHistorical: any;
+      };
+      isHistorical = JSON.parse(isHistorical) as boolean;
+      const requestPath = isHistorical
+        ? 'ad.topHistoricalAnomalyResults'
+        : 'ad.topAnomalyResults';
+
+      const response = await this.client
+        .asScoped(request)
+        .callAsCurrentUser(requestPath, {
+          detectorId: detectorId,
+          body: request.body,
+        });
+
+      console.log('response: ', response);
+
+      return opensearchDashboardsResponse.ok({
+        body: {
+          ok: true,
+          response: response,
+        },
+      });
+    } catch (err) {
+      console.log('Anomaly detector - getTopAnomalyResults', err);
       return opensearchDashboardsResponse.ok({
         body: {
           ok: false,

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -106,6 +106,7 @@ export const MODEL_ID_FIELD = 'model_id';
 export const DOC_COUNT_FIELD = 'doc_count';
 export const KEY_FIELD = 'key';
 export const ENTITY_LIST_FIELD = 'entity_list';
+export const MAX_ANOMALY_GRADE_FIELD = 'max_anomaly_grade';
 
 // y-axis values in the heatmap chart should be in the form:
 // <category-field-value-1><br><category-field-value-2>

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -106,7 +106,15 @@ export const MODEL_ID_FIELD = 'model_id';
 export const DOC_COUNT_FIELD = 'doc_count';
 export const KEY_FIELD = 'key';
 export const ENTITY_LIST_FIELD = 'entity_list';
+
+// y-axis values in the heatmap chart should be in the form:
+// <category-field-value-1><br><category-field-value-2>
 export const ENTITY_LIST_DELIMITER = '<br>';
+
+// when hovering over a cell, the entity list should be in the form:
+// <category-field-name-1>:<category-field-value-1>, <category-field-name-2>:<category-field-value-2>
+export const HEATMAP_CELL_ENTITY_DELIMITER = ',';
+export const HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER = ':';
 
 export const STACK_TRACE_PATTERN = '.java:';
 export const OPENSEARCH_EXCEPTION_PREFIX =

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -112,9 +112,9 @@ export const ENTITY_LIST_FIELD = 'entity_list';
 export const ENTITY_LIST_DELIMITER = '<br>';
 
 // when hovering over a cell, the entity list should be in the form:
-// <category-field-name-1>:<category-field-value-1>, <category-field-name-2>:<category-field-value-2>
-export const HEATMAP_CELL_ENTITY_DELIMITER = ',';
-export const HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER = ':';
+// <category-field-name-1>: <category-field-value-1>, <category-field-name-2>: <category-field-value-2>
+export const HEATMAP_CELL_ENTITY_DELIMITER = ', ';
+export const HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER = ': ';
 
 export const STACK_TRACE_PATTERN = '.java:';
 export const OPENSEARCH_EXCEPTION_PREFIX =


### PR DESCRIPTION
### Description

This PR adds support for filtering results on a subset of categorical fields. For example, if a user has 2 categorical fields selected, they can now search for the top values of one field, ignoring the other. And, when selecting a value of one of these fields, a sorted list of the top values of the other field is displayed for viewing on the anomaly and feature charts. This is supported for both real-time and historical scenarios.

The primary changes in this PR include:
- Adding support for new multi-category filtering API (see [backend PR](https://github.com/opensearch-project/anomaly-detection/pull/261))
- Adding a combo box filter at the top of the charts to select some subset of categorical fields, rather than a hardcoded string that includes all of the fields.
- Adding a combo box filter when a heatmap cell is selected, to select multiple values to display on the charts.
- Adding support for multiple time series on the anomaly charts and feature charts.
- Moving anomaly filtering / sorting logic from the child components into the base container (`AnomalyHistory`), making them more stateless as components should be.
- Minor changes to the entity list format in the heatmap cell. Changed from `Entities: <entity-value-1>, <entity-value-2>` => `Entities: <entity-name-1>: <entity-value1>, <entity-name-2>: <entity-value-2>`. The main reason for this change is so the full entity information can be passed to the child components when needed - before, only the values were being passed.
- Fixing bucketized results - previous code had a bug where bucketized results weren't being retrieved properly. That has been fixed here, which also meant more logic needed to be added to handle zooming from bucketized results => non-bucketized results.
- Misc. other cleanup (fixed stale data occasionally showing up on feature and details charts, fixed sample anomaly zoom state bug, separated logic of sample vs. non-sample data in heatmap chart, added comments for existing vars or methods that weren't clear, renamed many vars and methods to make them more clear)

Testing:
- All UT pass
- All IT pass
- Confirmed it is consistent for real-time and historical
- Confirmed nothing breaks on non-high-cardinality & high-cardinality-single-category detector results
- Confirmed nothing breaks on sample anomalies via preview

Screenshots:

New combo box filter for categorical fields:
![Screen Shot 2021-10-28 at 12 57 11 PM](https://user-images.githubusercontent.com/62119629/139326650-b6d74155-8800-4648-8fec-32d38f56b5f5.png)

New combo box filter for child categorical field values (when a heatmap cell is selected):
![Screen Shot 2021-10-28 at 12 57 42 PM](https://user-images.githubusercontent.com/62119629/139326705-6cc9f69f-3a51-4114-ae0e-9263d31cf9a7.png)

Multi-time-series support, with consistent coloring for anomaly & feature results:
![Screen Shot 2021-10-28 at 12 58 08 PM](https://user-images.githubusercontent.com/62119629/139326724-df8422d9-e3d5-474b-9e62-a69d4f532fdf.png)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
