### PR TITLE
Fix bug of detector task calls failing if no state index

### DIFF
--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -260,19 +260,29 @@ export default class AdService {
 
       // Get real-time and historical task info to populate the
       // task and job-related fields
-      const realtimeTaskResponse: any = await this.client
-        .asScoped(request)
-        .callAsCurrentUser('ad.searchTasks', {
-          body: getLatestTaskForDetectorQuery(detectorId, true),
-        });
-      const historicalTaskResponse: any = await this.client
-        .asScoped(request)
-        .callAsCurrentUser('ad.searchTasks', {
-          body: getLatestTaskForDetectorQuery(detectorId, false),
-        });
+      // We wrap these calls in a try/catch, and suppress any index_not_found_exceptions
+      // which can occur if no detector jobs have been ran on a new cluster.
+      let realtimeTasksResponse = {} as any;
+      let historicalTasksResponse = {} as any;
+      try {
+        realtimeTasksResponse = await this.client
+          .asScoped(request)
+          .callAsCurrentUser('ad.searchTasks', {
+            body: getLatestTaskForDetectorQuery(detectorId, true),
+          });
+        historicalTasksResponse = await this.client
+          .asScoped(request)
+          .callAsCurrentUser('ad.searchTasks', {
+            body: getLatestTaskForDetectorQuery(detectorId, false),
+          });
+      } catch (err) {
+        if (!isIndexNotFoundError(err)) {
+          throw err;
+        }
+      }
 
       const realtimeTask = get(
-        get(realtimeTaskResponse, 'hits.hits', []).map((taskResponse: any) => {
+        get(realtimeTasksResponse, 'hits.hits', []).map((taskResponse: any) => {
           return {
             id: get(taskResponse, '_id'),
             ...get(taskResponse, '_source'),
@@ -281,7 +291,7 @@ export default class AdService {
         0
       );
       const historicalTask = get(
-        get(historicalTaskResponse, 'hits.hits', []).map(
+        get(historicalTasksResponse, 'hits.hits', []).map(
           (taskResponse: any) => {
             return {
               id: get(taskResponse, '_id'),
@@ -667,16 +677,26 @@ export default class AdService {
 
       // Fetch the latest realtime and historical tasks for all detectors
       // using terms aggregations
-      const realtimeTasksResponse: any = await this.client
-        .asScoped(request)
-        .callAsCurrentUser('ad.searchTasks', {
-          body: getLatestDetectorTasksQuery(true),
-        });
-      const historicalTasksResponse: any = await this.client
-        .asScoped(request)
-        .callAsCurrentUser('ad.searchTasks', {
-          body: getLatestDetectorTasksQuery(false),
-        });
+      // We wrap these calls in a try/catch, and suppress any index_not_found_exceptions
+      // which can occur if no detector jobs have been ran on a new cluster.
+      let realtimeTasksResponse = {} as any;
+      let historicalTasksResponse = {} as any;
+      try {
+        realtimeTasksResponse = await this.client
+          .asScoped(request)
+          .callAsCurrentUser('ad.searchTasks', {
+            body: getLatestDetectorTasksQuery(true),
+          });
+        historicalTasksResponse = await this.client
+          .asScoped(request)
+          .callAsCurrentUser('ad.searchTasks', {
+            body: getLatestDetectorTasksQuery(false),
+          });
+      } catch (err) {
+        if (!isIndexNotFoundError(err)) {
+          throw err;
+        }
+      }
 
       const realtimeTasks = get(
         realtimeTasksResponse,


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Fixes an edge case where calls to the search task API will fail if the `.opendistro-anomaly-detection-state` system index doesn't exist, which will only happen on a fresh cluster that has never ran any detector job (once any job is ran,the system index is created).

This fixes all places where the search task API is called on server-side, and wraps in a separate try/catch to suppress any `index_not_found_exception`, so that the rest of the logic can be executed normally.

The side effects of this bug (which are now fixed):
1. Detector list will fail to show any detectors, shows error toast saying error getting all detectors
2. Detector details pages will fail, shows error toast saying error getting detector

### Issues Resolved
Closes #109 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
