### PR TITLE
Fix chart range bug of non-HC anomaly and feature charts

### DIFF
--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -90,9 +90,8 @@ export const FeatureChart = (props: FeatureChartProps) => {
   const getDisabledChartBackground = () =>
     darkModeEnabled() ? '#25262E' : '#F0F0F0';
 
-  const [showCustomExpression, setShowCustomExpression] = useState<boolean>(
-    false
-  );
+  const [showCustomExpression, setShowCustomExpression] =
+    useState<boolean>(false);
   const timeFormatter = niceTimeFormatter([
     props.dateRange.startDate,
     props.dateRange.endDate,
@@ -216,6 +215,10 @@ export const FeatureChart = (props: FeatureChartProps) => {
             showLegendDisplayValue={false}
             legendPosition={Position.Right}
             theme={FEATURE_CHART_THEME}
+            xDomain={{
+              min: props.dateRange.startDate,
+              max: props.dateRange.endDate,
+            }}
           />
           {props.feature.featureEnabled ? (
             <RectAnnotation

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -304,11 +304,18 @@ export const AnomalyDetailsChart = React.memo(
     }, [props.anomalies, zoomRange, aggregatedAnomalies, selectedAggId]);
 
     const handleZoomRangeChange = (start: number, end: number) => {
-      setZoomRange({
-        startDate: start,
-        endDate: end,
-      });
-      props.onZoomRangeChange(start, end);
+      // In the HC scenario, we only want to change the local zoom range.
+      // We don't want to change the overall date range, since that would auto-de-select
+      // any selected heatmap cell, and re-fetch results based on the new date range
+      if (props.isHCDetector) {
+        setZoomRange({
+          startDate: start,
+          endDate: end,
+        });
+        props.onZoomRangeChange(start, end);
+      } else {
+        props.onDateRangeChange(start, end);
+      }
     };
 
     useEffect(() => {
@@ -505,7 +512,7 @@ export const AnomalyDetailsChart = React.memo(
                       const end = get(
                         brushArea,
                         'x.1',
-                        DEFAULT_DATE_PICKER_RANGE.start
+                        DEFAULT_DATE_PICKER_RANGE.end
                       );
                       handleZoomRangeChange(start, end);
                       if (props.onDatePickerRangeChange) {
@@ -513,6 +520,14 @@ export const AnomalyDetailsChart = React.memo(
                       }
                     }}
                     theme={ANOMALY_CHART_THEME}
+                    xDomain={
+                      showAggregateResults
+                        ? undefined
+                        : {
+                            min: zoomRange.startDate,
+                            max: zoomRange.endDate,
+                          }
+                    }
                   />
                   {(props.isHCDetector && !props.selectedHeatmapCell) ||
                   props.isHistorical ? null : (


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Fixes a bug in the non-high-cardinality scenario where anomaly and feature charts were showing the explicit range based on the timestamps of anomaly results found in the parent date range, rather than showing the static date range itself. (see #121 for details/screenshots).

This fixes that bug by 2 main changes:
1. Explicitly setting the range of `x` values for the chart via `xDomain` chart prop for both anomaly details and feature charts
2. Splitting up the logic for HC and non-HC results, when the zoom range is changed. For example, in the non-HC scenario, if the zoom range is changed, we want to update the parent date range (as shown in the date range picker). In the HC scenario, we only want to change the range shown on the child charts, and not on the parent date range (if we change the parent date range here, then any selected heatmap cell would be de-selected, and the entire heatmap would be re-generated based on the new date range, which we don't want).

Confirmed everything works as expected for non-HC, single-HC, and multi-HC, for both RT and historical results.

### Issues Resolved

Closes #121 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
