### PR TITLE
support create monitor with custom result index

### DIFF
--- a/public/pages/AnomalyCharts/components/AlertsButton/AlertsButton.tsx
+++ b/public/pages/AnomalyCharts/components/AlertsButton/AlertsButton.tsx
@@ -23,6 +23,7 @@ export interface AlertsButtonProps extends EuiButtonProps {
   detectorName: string;
   detectorInterval: number;
   unit: string;
+  resultIndex?: string;
 }
 
 export const AlertsButton = (props: AlertsButtonProps) => {
@@ -41,7 +42,8 @@ export const AlertsButton = (props: AlertsButtonProps) => {
             props.detectorId,
             props.detectorName,
             props.detectorInterval,
-            props.unit.toUpperCase()
+            props.unit.toUpperCase(),
+            props.resultIndex
           )}`}
           {...props}
         >

--- a/public/pages/AnomalyCharts/components/AlertsFlyout/AlertsFlyout.tsx
+++ b/public/pages/AnomalyCharts/components/AlertsFlyout/AlertsFlyout.tsx
@@ -34,6 +34,7 @@ type AlertsFlyoutProps = {
   unit: string;
   monitor?: Monitor;
   onClose(): void;
+  resultIndex?: string;
 };
 
 const alertSteps = [
@@ -117,6 +118,7 @@ export const AlertsFlyout = (props: AlertsFlyoutProps) => {
               detectorInterval={props.detectorInterval}
               unit={props.unit}
               fill
+              resultIndex={props.resultIndex}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -177,6 +177,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
         1
       )}
       unit={get(props.detector, 'detectionInterval.period.unit', 'Minutes')}
+      resultIndex={get(props.detector, 'resultIndex')}
     />
   );
 
@@ -279,6 +280,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
                         handleCategoryFieldsChange={
                           props.handleCategoryFieldsChange
                         }
+                        resultIndex={get(props.detector, 'resultIndex')}
                       />,
                       props.isNotSample !== true
                         ? [

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -652,6 +652,7 @@ export const AnomalyDetailsChart = React.memo(
             )}
             monitor={props.monitor}
             onClose={() => setShowAlertsFlyout(false)}
+            resultIndex={get(props.detector, 'resultIndex')}
           />
         ) : null}
       </React.Fragment>

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -72,6 +72,7 @@ interface AnomalyHeatmapChartProps {
   categoryField?: string[];
   selectedCategoryFields?: any[];
   handleCategoryFieldsChange(selectedOptions: any[]): void;
+  resultIndex?: string;
 }
 
 export interface HeatmapCell {
@@ -670,6 +671,7 @@ export const AnomalyHeatmapChart = React.memo(
             unit={get(props, 'unit', 'Minutes')}
             monitor={props.monitor}
             onClose={() => setShowAlertsFlyout(false)}
+            resultIndex={props.resultIndex}
           />
         ) : null}
       </React.Fragment>

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -129,16 +129,21 @@ export const getAlertingCreateMonitorLink = (
   detectorId: string,
   detectorName: string,
   detectorInterval: number,
-  unit: string
+  unit: string,
+  resultIndex?: string
 ): string => {
   try {
     const core = React.useContext(CoreServicesContext) as CoreStart;
     const navLinks = get(core, 'chrome.navLinks', undefined);
     const url = `${navLinks.get(ALERTING_PLUGIN_NAME)?.url}`;
     const alertingRootUrl = getPluginRootPath(url, ALERTING_PLUGIN_NAME);
-    return `${alertingRootUrl}#/create-monitor?searchType=ad&adId=${detectorId}&name=${detectorName}&interval=${
-      2 * detectorInterval
-    }&unit=${unit}`;
+    return !resultIndex
+      ? `${alertingRootUrl}#/create-monitor?searchType=ad&adId=${detectorId}&name=${detectorName}&interval=${
+          2 * detectorInterval
+        }&unit=${unit}`
+      : `${alertingRootUrl}#/create-monitor?searchType=ad&adId=${detectorId}&name=${detectorName}&interval=${
+          2 * detectorInterval
+        }&unit=${unit}&adResultIndex=${resultIndex}`;
   } catch (e) {
     console.error('unable to get the alerting URL', e);
     return '';


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

When user click set up alerts button on detector realtime result page, we need to pass AD result index to monitor creation page, so the monitor can query correct AD result index.

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
