### PR TITLE
search only custom result index on detector detail page

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -168,7 +168,7 @@ export const AnomalyDetailsChart = React.memo(
         zoomRange.endDate,
         taskId
       );
-      dispatch(searchResults(anomalyDataRangeQuery, resultIndex))
+      dispatch(searchResults(anomalyDataRangeQuery, resultIndex, true))
         .then((response: any) => {
           // Only retrieve buckets that are in the anomaly results range. This is so
           // we don't show aggregate results for where there is no data at all
@@ -187,7 +187,7 @@ export const AnomalyDetailsChart = React.memo(
             taskId,
             selectedAggId
           );
-          dispatch(searchResults(historicalAggQuery, resultIndex))
+          dispatch(searchResults(historicalAggQuery, resultIndex, true))
             .then((response: any) => {
               const aggregatedAnomalies = parseHistoricalAggregatedAnomalies(
                 response,
@@ -223,7 +223,7 @@ export const AnomalyDetailsChart = React.memo(
           zoomRange.endDate,
           taskId
         );
-        dispatch(searchResults(anomalyDataRangeQuery, resultIndex))
+        dispatch(searchResults(anomalyDataRangeQuery, resultIndex, true))
           .then((response: any) => {
             const dataStartDate = get(
               response,

--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -70,7 +70,8 @@ export const AnomaliesDistributionChart = (
         dispatch,
         0,
         false,
-        ALL_CUSTOM_AD_RESULT_INDICES
+        ALL_CUSTOM_AD_RESULT_INDICES,
+        false
       );
     setAnomalyDistribution(distributionResult);
 

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -101,7 +101,8 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         -1,
         1,
         true,
-        ALL_CUSTOM_AD_RESULT_INDICES
+        ALL_CUSTOM_AD_RESULT_INDICES,
+        false
       );
     } catch (err) {
       console.log(
@@ -124,7 +125,8 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
         MAX_ANOMALIES,
         MAX_LIVE_DETECTORS,
         false,
-        ALL_CUSTOM_AD_RESULT_INDICES
+        ALL_CUSTOM_AD_RESULT_INDICES,
+        false
       );
 
     setLiveAnomalyData(latestLiveAnomalyResult);

--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -448,13 +448,18 @@ export const buildGetAnomalyResultQueryByRange = (
 };
 
 export const getLatestAnomalyResultsByTimeRange = async (
-  func: (request: any, resultIndex: string) => APIAction,
+  func: (
+    request: any,
+    resultIndex: string,
+    onlyQueryCustomResultIndex: boolean
+  ) => APIAction,
   timeRange: string,
   dispatch: Dispatch<any>,
   threshold: number,
   anomalySize: number,
   checkLastIndexOnly: boolean,
-  resultIndex: string
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
 ): Promise<object[]> => {
   let from = 0;
   let anomalyResults = [] as object[];
@@ -469,7 +474,8 @@ export const getLatestAnomalyResultsByTimeRange = async (
           threshold,
           checkLastIndexOnly
         ),
-        resultIndex
+        resultIndex,
+        onlyQueryCustomResultIndex
       )
     );
 
@@ -499,7 +505,11 @@ export const getLatestAnomalyResultsByTimeRange = async (
 };
 
 export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
-  func: (request: any, resultIndex: string) => APIAction,
+  func: (
+    request: any,
+    resultIndex: string,
+    onlyQueryCustomResultIndex: boolean
+  ) => APIAction,
   selectedDetectors: DetectorListItem[],
   timeRange: string,
   dispatch: Dispatch<any>,
@@ -507,7 +517,8 @@ export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
   anomalySize: number,
   detectorNum: number,
   checkLastIndexOnly: boolean,
-  resultIndex: string
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
 ): Promise<object[]> => {
   const detectorAndIdMap = buildDetectorAndIdMap(selectedDetectors);
   let from = 0;
@@ -523,7 +534,8 @@ export const getLatestAnomalyResultsForDetectorsByTimeRange = async (
           threshold,
           checkLastIndexOnly
         ),
-        resultIndex
+        resultIndex,
+        onlyQueryCustomResultIndex
       )
     );
     const searchAnomalyResponse = searchResponse.response;
@@ -610,13 +622,18 @@ const selectLatestAnomalousDetectorIds = (
 };
 
 export const getAnomalyDistributionForDetectorsByTimeRange = async (
-  func: (request: any, resultIndex: string) => APIAction,
+  func: (
+    request: any,
+    resultIndex: string,
+    onlyQueryCustomResultIndex: boolean
+  ) => APIAction,
   selectedDetectors: DetectorListItem[],
   timeRange: string,
   dispatch: Dispatch<any>,
   threshold: number,
   checkLastIndexOnly: boolean,
-  resultIndex: string
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
 ) => {
   const aggregationName = 'anomaly_dist';
   const detectorAndIdMap = buildDetectorAndIdMap(selectedDetectors);
@@ -640,7 +657,9 @@ export const getAnomalyDistributionForDetectorsByTimeRange = async (
   };
   const finalQuery = Object.assign({}, getResultQuery, anomaly_dist_aggs);
 
-  const result = await dispatch(func(finalQuery, resultIndex));
+  const result = await dispatch(
+    func(finalQuery, resultIndex, onlyQueryCustomResultIndex)
+  );
 
   const detectorsAggResults = get(
     result,

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -17,7 +17,7 @@ import React, {
   useRef,
 } from 'react';
 
-import { isEmpty, get } from 'lodash';
+import { isEmpty, get, stubTrue } from 'lodash';
 import {
   EuiFlexItem,
   EuiFlexGroup,
@@ -218,7 +218,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
                   taskId.current,
                   modelId
                 );
-                return dispatch(searchResults(params, resultIndex));
+                return dispatch(searchResults(params, resultIndex, true));
               })
             : [];
 
@@ -237,19 +237,17 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
           allPureAnomalies.push(parsePureAnomalies(anomalySummaryResponse));
         });
       } else if (!isHCDetector) {
+        const anomalySummaryQuery = getAnomalySummaryQuery(
+          dateRange.startDate,
+          dateRange.endDate,
+          props.detector.id,
+          undefined,
+          props.isHistorical,
+          taskId.current,
+          modelId
+        );
         const anomalySummaryResponse = await dispatch(
-          searchResults(
-            getAnomalySummaryQuery(
-              dateRange.startDate,
-              dateRange.endDate,
-              props.detector.id,
-              undefined,
-              props.isHistorical,
-              taskId.current,
-              modelId
-            ),
-            resultIndex
-          )
+          searchResults(anomalySummaryQuery, resultIndex, true)
         );
         allPureAnomalies.push(parsePureAnomalies(anomalySummaryResponse));
       }
@@ -272,7 +270,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
               taskId.current,
               modelId
             );
-            return dispatch(searchResults(params, resultIndex));
+            return dispatch(searchResults(params, resultIndex, true));
           }
         );
 
@@ -295,19 +293,17 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
           }
         );
       } else if (!isHCDetector) {
+        const bucketizedAnomalyResultsQuery = getBucketizedAnomalyResultsQuery(
+          dateRange.startDate,
+          dateRange.endDate,
+          props.detector.id,
+          undefined,
+          props.isHistorical,
+          taskId.current,
+          modelId
+        );
         const bucketizedAnomalyResultResponse = await dispatch(
-          searchResults(
-            getBucketizedAnomalyResultsQuery(
-              dateRange.startDate,
-              dateRange.endDate,
-              props.detector.id,
-              undefined,
-              props.isHistorical,
-              taskId.current,
-              modelId
-            ),
-            resultIndex
-          )
+          searchResults(bucketizedAnomalyResultsQuery, resultIndex, true)
         );
         allBucketizedAnomalyResults.push(
           parseBucketizedAnomalyResults(bucketizedAnomalyResultResponse)
@@ -404,10 +400,22 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       );
       const detectorResultResponse = props.isHistorical
         ? await dispatch(
-            getDetectorResults(taskId.current || '', params, true, resultIndex)
+            getDetectorResults(
+              taskId.current || '',
+              params,
+              true,
+              resultIndex,
+              true
+            )
           )
         : await dispatch(
-            getDetectorResults(props.detector.id, params, false, resultIndex)
+            getDetectorResults(
+              props.detector.id,
+              params,
+              false,
+              resultIndex,
+              true
+            )
           );
       const rawAnomaliesData = get(detectorResultResponse, 'response', []);
       const rawAnomaliesResult = {
@@ -526,7 +534,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
         props.isHistorical,
         taskId.current
       );
-      const result = await dispatch(searchResults(query, resultIndex));
+      const result = await dispatch(searchResults(query, resultIndex, true));
       topEntityAnomalySummaries = parseTopEntityAnomalySummaryResults(
         result,
         isMultiCategory
@@ -545,7 +553,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
           props.isHistorical,
           taskId.current
         );
-        return dispatch(searchResults(entityResultQuery, resultIndex));
+        return dispatch(searchResults(entityResultQuery, resultIndex, true));
       }
     );
 
@@ -618,7 +626,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
           props.isHistorical ? taskId.current : props.detector?.id,
           params,
           props.isHistorical ? true : false,
-          resultIndex
+          resultIndex,
+          true
         )
       );
     });
@@ -699,7 +708,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       taskId.current,
       heatmapCell.entityList
     );
-    const result = await dispatch(searchResults(query, resultIndex));
+
+    const result = await dispatch(searchResults(query, resultIndex, true));
 
     // Gets top child entities as an Entity[][],
     // where each entry in the array is a unique combination of entity values

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -228,7 +228,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
     try {
       const resultIndex = get(detector, 'resultIndex', '');
       const detectorResultResponse = await dispatch(
-        getDetectorResults(detectorId, params, false, resultIndex)
+        getDetectorResults(detectorId, params, false, resultIndex, true)
       );
       const featuresData = get(
         detectorResultResponse,

--- a/public/pages/DetectorResults/containers/AnomalyResultsLiveChart.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResultsLiveChart.tsx
@@ -131,7 +131,13 @@ export const AnomalyResultsLiveChart = (
           intervals
         );
         await dispatch(
-          getDetectorLiveResults(detectorId, queryParams, false, resultIndex)
+          getDetectorLiveResults(
+            detectorId,
+            queryParams,
+            false,
+            resultIndex,
+            true
+          )
         );
       } catch (err) {
         console.error(
@@ -157,7 +163,8 @@ export const AnomalyResultsLiveChart = (
           props.detector.id,
           detectionInterval,
           LIVE_CHART_CONFIG.MONITORING_INTERVALS,
-          resultIndex
+          resultIndex,
+          true
         );
       }, LIVE_CHART_CONFIG.REFRESH_INTERVAL_IN_SECONDS);
       return () => {

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -96,13 +96,22 @@ export const getLiveAnomalyResults = (
   detectorId: string,
   detectionInterval: number,
   intervals: number,
-  resultIndex: string
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
 ) => {
   const queryParams = getQueryParamsForLiveAnomalyResults(
     detectionInterval,
     intervals
   );
-  dispatch(getDetectorLiveResults(detectorId, queryParams, false, resultIndex));
+  dispatch(
+    getDetectorLiveResults(
+      detectorId,
+      queryParams,
+      false,
+      resultIndex,
+      onlyQueryCustomResultIndex
+    )
+  );
 };
 
 export const buildParamsForGetAnomalyResultsWithDateRange = (

--- a/public/redux/reducers/__tests__/anomalyResults.test.ts
+++ b/public/redux/reducers/__tests__/anomalyResults.test.ts
@@ -43,7 +43,13 @@ describe('anomaly results reducer actions', () => {
       };
       const resultIndex = 'opensearch-ad-plugin-result-test';
       await store.dispatch(
-        getDetectorResults(tempDetectorId, queryParams, false, resultIndex)
+        getDetectorResults(
+          tempDetectorId,
+          queryParams,
+          false,
+          resultIndex,
+          true
+        )
       );
       const actions = store.getActions();
 
@@ -61,7 +67,9 @@ describe('anomaly results reducer actions', () => {
         featureData: undefined,
       });
       expect(httpMockedClient.get).toHaveBeenCalledWith(
-        `..${AD_NODE_API.DETECTOR}/${tempDetectorId}/results/${false}/${resultIndex}`,
+        `..${
+          AD_NODE_API.DETECTOR
+        }/${tempDetectorId}/results/${false}/${resultIndex}/true`,
         { query: queryParams }
       );
     });
@@ -79,7 +87,7 @@ describe('anomaly results reducer actions', () => {
       };
       try {
         await store.dispatch(
-          getDetectorResults(tempDetectorId, queryParams, false, '')
+          getDetectorResults(tempDetectorId, queryParams, false, '', false)
         );
       } catch (e) {
         const actions = store.getActions();
@@ -95,7 +103,7 @@ describe('anomaly results reducer actions', () => {
           errorMessage: 'Something went wrong',
         });
         expect(httpMockedClient.get).toHaveBeenCalledWith(
-          `..${AD_NODE_API.DETECTOR}/${tempDetectorId}/results/${false}/`,
+          `..${AD_NODE_API.DETECTOR}/${tempDetectorId}/results/${false}`,
           { query: queryParams }
         );
       }

--- a/public/redux/reducers/anomalyResults.ts
+++ b/public/redux/reducers/anomalyResults.ts
@@ -9,7 +9,6 @@
  * GitHub history for details.
  */
 
-
 import { APIAction, APIResponseAction, HttpSetup } from '../middleware/types';
 import handleActions from '../utils/handleActions';
 import { AD_NODE_API } from '../../../utils/constants';
@@ -97,28 +96,54 @@ export const getDetectorResults = (
   id: string,
   queryParams: any,
   isHistorical: boolean,
-  resultIndex: string
-): APIAction => ({
-  type: DETECTOR_RESULTS,
-  request: (client: HttpSetup) =>
-    client.get(
-      `..${AD_NODE_API.DETECTOR}/${id}/results/${isHistorical}/${resultIndex}`,
-      {
-        query: queryParams,
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
+): APIAction =>
+  !resultIndex
+    ? {
+        type: DETECTOR_RESULTS,
+        request: (client: HttpSetup) =>
+          client.get(
+            `..${AD_NODE_API.DETECTOR}/${id}/results/${isHistorical}`,
+            {
+              query: queryParams,
+            }
+          ),
       }
-    ),
-});
+    : {
+        type: DETECTOR_RESULTS,
+        request: (client: HttpSetup) =>
+          client.get(
+            `..${AD_NODE_API.DETECTOR}/${id}/results/${isHistorical}/${resultIndex}/${onlyQueryCustomResultIndex}`,
+            {
+              query: queryParams,
+            }
+          ),
+      };
 
 export const searchResults = (
   requestBody: any,
-  resultIndex: string
-): APIAction => ({
-  type: SEARCH_ANOMALY_RESULTS,
-  request: (client: HttpSetup) =>
-    client.post(`..${AD_NODE_API.DETECTOR}/results/_search/${resultIndex}`, {
-      body: JSON.stringify(requestBody),
-    }),
-});
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
+): APIAction =>
+  !resultIndex
+    ? {
+        type: SEARCH_ANOMALY_RESULTS,
+        request: (client: HttpSetup) =>
+          client.post(`..${AD_NODE_API.DETECTOR}/results/_search`, {
+            body: JSON.stringify(requestBody),
+          }),
+      }
+    : {
+        type: SEARCH_ANOMALY_RESULTS,
+        request: (client: HttpSetup) =>
+          client.post(
+            `..${AD_NODE_API.DETECTOR}/results/_search/${resultIndex}/${onlyQueryCustomResultIndex}`,
+            {
+              body: JSON.stringify(requestBody),
+            }
+          ),
+      };
 
 export const getTopAnomalyResults = (
   detectorId: string,

--- a/public/redux/reducers/liveAnomalyResults.ts
+++ b/public/redux/reducers/liveAnomalyResults.ts
@@ -59,16 +59,29 @@ export const getDetectorLiveResults = (
   detectorId: string,
   queryParams: DetectorResultsQueryParams,
   isHistorical: boolean,
-  resultIndex: string
-): APIAction => ({
-  type: DETECTOR_LIVE_RESULTS,
-  request: (client: HttpSetup) =>
-    client.get(
-      `..${AD_NODE_API.DETECTOR}/${detectorId}/results/${isHistorical}/${resultIndex}`,
-      {
-        query: queryParams,
+  resultIndex: string,
+  onlyQueryCustomResultIndex: boolean
+): APIAction =>
+  !resultIndex
+    ? {
+        type: DETECTOR_LIVE_RESULTS,
+        request: (client: HttpSetup) =>
+          client.get(
+            `..${AD_NODE_API.DETECTOR}/${detectorId}/results/${isHistorical}`,
+            {
+              query: queryParams,
+            }
+          ),
       }
-    ),
-});
+    : {
+        type: DETECTOR_LIVE_RESULTS,
+        request: (client: HttpSetup) =>
+          client.get(
+            `..${AD_NODE_API.DETECTOR}/${detectorId}/results/${isHistorical}/${resultIndex}/${onlyQueryCustomResultIndex}`,
+            {
+              query: queryParams,
+            }
+          ),
+      };
 
 export default reducer;

--- a/server/cluster/ad/adPlugin.ts
+++ b/server/cluster/ad/adPlugin.ts
@@ -100,9 +100,21 @@ export default function adPlugin(Client: any, config: any, components: any) {
 
   ad.searchResults = ca({
     url: {
-      fmt: `${API.DETECTOR_BASE}/results/_search/<%=resultIndex%>`,
+      fmt: `${API.DETECTOR_BASE}/results/_search`,
+    },
+    needBody: true,
+    method: 'POST',
+  });
+
+  ad.searchResultsFromCustomResultIndex = ca({
+    url: {
+      fmt: `${API.DETECTOR_BASE}/results/_search/<%=resultIndex%>?only_query_custom_result_index=<%=onlyQueryCustomResultIndex%>`,
       req: {
         resultIndex: {
+          type: 'string',
+          required: false,
+        },
+        onlyQueryCustomResultIndex: {
           type: 'string',
           required: false,
         },


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description

Only query custom result index for detector detail page. Query both default and custom AD result index on dashboard and detector list page.


### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
