### PR TITLE
Fix bug of HC historical results not auto-refreshing

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -437,6 +437,13 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       if (showLoading) {
         setIsLoading(false);
       }
+      // After fetching raw results, re-fetch the latest HC anomaly summaries, if applicable.
+      // Also clear any selected heatmap cell data in all of the child charts,
+      // in case a user selected one while the job was still running.
+      if (isHCDetector) {
+        setSelectedHeatmapCell(undefined);
+        fetchHCAnomalySummaries();
+      }
     }
   };
 


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Fixes a bug where heatmap chart data doesn't auto-refresh properly in the historical scenario. Note that the data would still show fine if the page was refreshed (switched tabs, etc.).

The bug was that the entity-level anomaly summaries weren't being fetched during the auto-refresh codepath, and were always being passed as an empty list. The heatmap chart data is prepared using the summaries, and so because the summaries were always empty, the heatmap chart data was always subsequently empty.

The fix is to add a call to fetch the entity summaries (`fetchHCAnomalySummaries()`) after fetching the raw results (`fetchRawAnomalyResults()`) in `AnomalyHistory`, which is rendered as a child component in `HistoricalDetectorResults`. Note that `fetchRawAnomalyResults()` is called in a custom hook (see lines 353-363), which is listening on changes for `props.detector`. And, `props.detector` is changed during auto refresh, where the task progress is updated (`props.detector.taskProgress`), hence triggering this whole workflow.


Confirmed nothing breaks after historical job is `FINISHED`/`STOPPED`, as well as real-time scenarios.

### Issues Resolved
Closes #130 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
