### PR TITLE
Fix bug of missing annotations on feature charts

### DIFF
--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -37,7 +37,6 @@ import { darkModeEnabled } from '../../../../utils/opensearchDashboardsUtils';
 import {
   prepareDataForChart,
   getFeatureMissingDataAnnotations,
-  filterWithDateRange,
   flattenData,
   convertToEntityString,
 } from '../../../utils/anomalyResultUtils';
@@ -47,13 +46,13 @@ import {
   CHART_COLORS,
   FEATURE_CHART_THEME,
 } from '../../utils/constants';
-import { get, isEmpty } from 'lodash';
+import { get } from 'lodash';
 import { ENTITY_COLORS } from '../../../DetectorResults/utils/constants';
 
 interface FeatureChartProps {
   feature: FeatureAttributes;
   featureData: FeatureAggregationData[][];
-  annotations: any[];
+  annotations: any[][];
   isLoading: boolean;
   dateRange: DateRange;
   featureType: FEATURE_TYPE;
@@ -143,17 +142,6 @@ export const FeatureChart = (props: FeatureChartProps) => {
     return undefined;
   };
 
-  const getFeatureAnnotations = () => {
-    if (isEmpty(props.annotations)) {
-      return [];
-    }
-    return filterWithDateRange(
-      props.annotations,
-      props.dateRange,
-      'coordinates.x0'
-    );
-  };
-
   const featureData = prepareDataForChart(
     props.featureData,
     props.dateRange
@@ -205,9 +193,19 @@ export const FeatureChart = (props: FeatureChartProps) => {
               max: props.dateRange.endDate,
             }}
           />
+          {/**
+           * props.annotations is 2-dimensional, and contains an array of annotations
+           * per time series to show on the charts. We flatten all anomaly annotations into
+           * a 1-D array, and show on all enabled feature line charts.
+           *
+           * Note that feature attribution is supported on the backend as of 1.2 - future
+           * frontend improvements may change the data model of generated annotations,
+           * and thus show different annotations per feature chart (currently all annotations
+           * shown equally across all enabled feature charts for a given detector).
+           */}
           {props.feature.featureEnabled ? (
             <RectAnnotation
-              dataValues={getFeatureAnnotations()}
+              dataValues={flattenData(props.annotations)}
               id="annotations"
               style={{
                 stroke: darkModeEnabled() ? 'red' : '#D5DBDB',

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -37,7 +37,7 @@ interface FeatureBreakDownProps {
   title?: string;
   detector: Detector;
   anomalyAndFeatureResults: Anomalies[];
-  annotations: any[];
+  annotations: any[][];
   isLoading: boolean;
   dateRange: DateRange;
   featureDataSeriesName: string;

--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -54,6 +54,7 @@ import {
   parseAggTopEntityAnomalySummaryResults,
   parseTopChildEntityCombos,
   flattenData,
+  generateAnomalyAnnotations,
 } from '../../utils/anomalyResultUtils';
 import { AnomalyResultsTable } from './AnomalyResultsTable';
 import { AnomaliesChart } from '../../AnomalyCharts/containers/AnomaliesChart';
@@ -787,23 +788,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
     []
   );
 
-  const annotations = anomalyResults
-    ? get(anomalyResults, 'anomalies', [])
-        //@ts-ignore
-        .filter((anomaly: AnomalyData) => anomaly.anomalyGrade > 0)
-        .map((anomaly: AnomalyData) => ({
-          coordinates: {
-            x0: anomaly.startTime,
-            x1: anomaly.endTime,
-          },
-          details: `There is an anomaly with confidence ${
-            anomaly.confidence
-          } between ${minuteDateFormatter(
-            anomaly.startTime
-          )} and ${minuteDateFormatter(anomaly.endTime)}`,
-          entity: get(anomaly, 'entity', []),
-        }))
-    : [];
+  const annotations = generateAnomalyAnnotations(anomalyResults);
 
   const tabs = [
     {


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

When the feature charts are rendered as a child component in the `AnomalyHistory` container, the annotations aren't formatted properly. This is due to one missed place where the annotations weren't converted into 2D arrays, where they should have been as part of #107. The proper conversion is already done when the feature chart is rendered as a child of `AnomaliesChart` container (see [here](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx#L349)). Additionally, the `FeatureChart` wasn't handling the new 2D representation of annotations, so that is fixed as well. Added some clarification comments above that change.

The side effect of this bug is that the annotations were always being passed as an empty array, so no annotations were showing up for the charts.

Confirmed the code changes now show proper annotations for all scenarios:
- Sample anomalies / preview (non-HC, single-HC, multi-HC)
- Real-time (non-HC, single-HC, multi-HC)
- Historical (non-HC, single-HC, multi-HC)
- Zooming
- Multiple features
- Multiple time series


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
