### PR TITLE
Enable codecov in repository UT workflow

### DIFF
--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -49,9 +49,5 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
           yarn run test:jest --coverage
-      - name: Upload coverage to Codecov
+      - name: Uploads coverage
         uses: codecov/codecov-action@v1
-        with:
-          file: ./OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/coverage/cobertura-coverage.xml
-          flags: unittests
-          name: ad-opensearch-dashboards-ut-codecov

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          file: ./OpenSearch-Dashboards/plugins/anomaly-detection-opensearch-dashboard-plugin/coverage/cobertura-coverage.xml
+          file: ./OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/coverage/cobertura-coverage.xml
           flags: unittests
           name: ad-opensearch-dashboards-ut-codecov


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Fixes the codecov GitHub action which had a typo.


### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
