### PR TITLE
Add remote integ test workflow; clean up old integ test workflow

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -91,4 +91,4 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: opensearch-dashboards-functional-test
-          command: yarn run cypress run --env SECURITY_ENABLED=false --spec "cypress/integration/plugins/anomaly-detection-dashboards-plugin/*.js"
+          command: yarn run cypress run --env SECURITY_ENABLED=false --spec cypress/integration/plugins/anomaly-detection-dashboards-plugin/*.js

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -1,6 +1,7 @@
-# Soon-to-be deprecated way of running integ tests. In the future all tests will be moved to
-# https://github.com/opensearch-project/opensearch-dashboards-functional-test
-name: E2E tests workflow
+# Running AD integ tests stored in https://github.com/opensearch-project/opensearch-dashboards-functional-test
+# In the future we should pull dependencies from bundled build snapshots. Because that is not available
+# yet we build the cluster from source (besides core Opensearch, which is a pulled min artifact).
+name: Remote integ tests workflow
 on:
   push:
     branches:
@@ -13,7 +14,7 @@ env:
   OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
 jobs:
   test-without-security:
-    name: Run e2e tests without security
+    name: Run integ tests without security
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -66,8 +67,14 @@ jobs:
           cd OpenSearch-Dashboards
           yarn start --no-base-path --no-watch &
           sleep 300
-      - name: Run Cypress e2e tests
+      - name: Checkout opensearch-dashboards-functional-test
+        uses: actions/checkout@v2
+        with:
+          path: opensearch-dashboards-functional-test
+          repository: opensearch-project/opensearch-dashboards-functional-test
+          ref: 'main' # TODO: change to a branch when the branching strategy in that repo has been established
+      - name: Run AD cypress tests
         uses: cypress-io/github-action@v2.5.0
         with:
-          working-directory: OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
-          command: yarn cy:run --env SECURITY_ENABLED=false
+          working-directory: opensearch-dashboards-functional-test
+          command: npx cypress run --env SECURITY_ENABLED=false --spec "cypress/integration/plugins/anomaly-detection-dashboards-plugin/*.js"

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -73,8 +73,22 @@ jobs:
           path: opensearch-dashboards-functional-test
           repository: opensearch-project/opensearch-dashboards-functional-test
           ref: 'main' # TODO: change to a branch when the branching strategy in that repo has been established
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./opensearch-dashboards-functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - run: npx cypress cache list
+      - run: npx cypress cache path
       - name: Run AD cypress tests
-        uses: cypress-io/github-action@v2.5.0
+        uses: cypress-io/github-action@v2
         with:
           working-directory: opensearch-dashboards-functional-test
-          command: npx cypress run --env SECURITY_ENABLED=false --spec "cypress/integration/plugins/anomaly-detection-dashboards-plugin/*.js"
+          command: yarn run cypress run --env SECURITY_ENABLED=false --spec "cypress/integration/plugins/anomaly-detection-dashboards-plugin/*.js"


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Adds a CI workflow where the integ tests that are stored in opensearch-dashboards-functional-test repo are pulled and ran. Note only a few tests have been added there so far (see [here](https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/64)) - the long-term plan will be to migrate all integ tests there. Also cleans up the existing CI workflow which incorrectly states that it's running with security enabled.

Note that the added workflow is for testing against the upcoming release version, thus the cluster setup process is complex and limited. Because there is no snapshot bundled builds, we rely on the existing methods:
1. Set up OpenSearch by running `./gradlew run` in backend AD repo, which spins up a cluster with only AD plugin installed (core OpenSearch is pulled via `min` artifact).
2. Set up Dashboards by pulling and running from source, with only AD plugin installed.
3. No security plugin (and no security-enabled tests) due to complications in installing it alongside AD plugin.

### Issues Resolved

Closes #162 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
