### PR TITLE
Force heatmap y-axis to be category type

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -633,6 +633,7 @@ export const AnomalyHeatmapChart = React.memo(
                       showgrid: false,
                       fixedrange: true,
                       automargin: true,
+                      type: 'category',
                       tickmode: 'array',
                       tickvals: heatmapData[0].y,
                       ticktext: heatmapData[0].y.map((label: string) =>


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Plotly tries to determine the axis type based on the input data given. For the y-axis in the heatmap chart, we don't want this functionality, since all given data is values for a given categorical field, so it should always be categorical. This PR forces the axis type to be `category`. See more details on axis `type` functionality [here](https://plotly.com/python/reference/layout/yaxis/#layout-yaxis-type).

This fixes a significant bug, where currently all values read as numerical by plotly will cause overlapping axes and an unreadable heatmap chart:
<img width="96" alt="Screen Shot 2021-12-22 at 4 10 03 PM" src="https://user-images.githubusercontent.com/62119629/147953977-ead324ee-1f8c-442c-a3dd-b71022ad6e70.png">

After the fix, that same data now renders properly:
![Screen Shot 2022-01-03 at 8 04 08 AM](https://user-images.githubusercontent.com/62119629/147953995-aa6f282b-3256-45d1-a9fe-2df9fbbaf3ce.png)

### Issues Resolved

#166 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
