### PR TITLE
Updating backport workflow to include custom branch name

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
@@ -8,9 +8,13 @@ on:
 jobs:
   backport:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     name: Backport
     steps:
       - name: Backport
-        uses: tibdex/backport@v1
+        uses: VachaShah/backport@v1.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch_name: backport/backport-${{ github.event.number }}


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description

Updating the backport workflow to resolve permissions issue https://github.com/opensearch-project/OpenSearch/issues/1712 and allow custom branch naming for backport branches to manage branch permissions.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
