### PR TITLE
Fix custom expression filter cannot show

### DIFF
--- a/public/pages/ReviewAndCreate/components/FilterDisplayList/FilterDisplayList.tsx
+++ b/public/pages/ReviewAndCreate/components/FilterDisplayList/FilterDisplayList.tsx
@@ -26,11 +26,14 @@ export const FilterDisplayList = (props: FilterDisplayListProps) => {
   const [filterIndex, setFilterIndex] = useState<number>(-1);
   let filters = get(props, 'uiMetadata.filters', []);
   const oldFilterType = get(props, 'uiMetadata.filterType', undefined);
-  const isOldDetector = !isEmpty(oldFilterType);
 
-  // Old detectors with custom filters will have no filter list, but
-  // will have a populated filter query
-  if (isEmpty(filters) && (isOldDetector || !isEmpty(props.filterQuery))) {
+  // We want to show the custom filter if filters is empty and 
+  // props.filterQuery isn't empty.
+  // Two possible situations for the if branch:
+  // First, old detectors with custom filters will have no filter list, but
+  // will have a populated filter query.
+  // Second, the detector has been created from API (no uiMetadata.* fields).
+  if (isEmpty(filters) && !isEmpty(props.filterQuery)) {
     return (
       <div>
         <EuiText>

--- a/public/pages/ReviewAndCreate/components/FilterDisplayList/FilterDisplayList.tsx
+++ b/public/pages/ReviewAndCreate/components/FilterDisplayList/FilterDisplayList.tsx
@@ -30,7 +30,7 @@ export const FilterDisplayList = (props: FilterDisplayListProps) => {
 
   // Old detectors with custom filters will have no filter list, but
   // will have a populated filter query
-  if (isEmpty(filters) && isOldDetector && !isEmpty(props.filterQuery)) {
+  if (isEmpty(filters) && (isOldDetector || !isEmpty(props.filterQuery))) {
     return (
       <div>
         <EuiText>

--- a/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
@@ -202,14 +202,24 @@ exports[`<ReviewAndCreate /> spec renders the component 1`] = `
                 <div
                   class="euiFormRow__fieldWrapper"
                 >
-                  <div
-                    class="euiText euiText--medium"
-                  >
-                    <p
-                      class="enabled"
+                  <div>
+                    <div
+                      class="euiText euiText--medium"
                     >
-                      -
-                    </p>
+                      <p
+                        class="enabled"
+                      >
+                        Custom expression:
+                         
+                        <button
+                          class="euiLink euiLink--primary"
+                          data-test-subj="viewFilter"
+                          type="button"
+                        >
+                          View code
+                        </button>
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Description

This PR fixes that a new detector with custom filter created using API cannot show.

Testing done:
1. Created a detector with a custom filter using API and verified the change fixed the issue.

Before:
![Screen Shot 2022-02-12 at 10 38 55 AM](https://user-images.githubusercontent.com/5303417/153928264-44241bea-b5e9-4a3c-b4f9-33e0ef25de3f.png)

After:
![Screen Shot 2022-02-12 at 11 07 12 AM](https://user-images.githubusercontent.com/5303417/153928286-4c1bfb43-4da7-4695-b410-9fd3ffae2b3d.png)

![Screen Shot 2022-02-12 at 11 07 59 AM](https://user-images.githubusercontent.com/5303417/153928298-983197e2-2d2f-49f5-9c1d-2c0fc5f25d94.png)

Signed-off-by: Kaituo Li <kaituo@amazon.com>

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
