### PR TITLE
[Backport 1.x] Bump plugin to 1.3.0.0 (#160)

### DIFF
--- a/.github/workflows/e2e-tests-workflow.yml
+++ b/.github/workflows/e2e-tests-workflow.yml
@@ -8,7 +8,7 @@ on:
       - main
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '1.x'
-  OPENSEARCH_VERSION: '1.2.0-SNAPSHOT'
+  OPENSEARCH_VERSION: '1.3.0-SNAPSHOT'
 jobs:
   test-with-security:
     name: Run e2e tests without security

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "1.2.0.0",
-  "opensearchDashboardsVersion": "1.2.0",
+  "version": "1.3.0.0",
+  "opensearchDashboardsVersion": "1.3.0",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "1.2.0.0",
+  "version": "1.3.0.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "1.2.0.0",
+    "plugin_version": "1.3.0.0",
     "plugin_name": "anomalyDetectionDashboards",
     "plugin_zip_name": "anomaly-detection-dashboards"
   },


### PR DESCRIPTION
### Description

Manual backport of #160 to 1.x. Bot was failing saying conflicts, but when performing manual steps, there was no conflicts. Probably some bug in the bot. 
