### PR TITLE
Non blocker

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -231,9 +231,11 @@ export type EntityOptionsMap = {
 export type ValidationModelResponse = {
   message: String;
   sub_issues?: { [key: string]: string };
+  validationType: string;
 };
 
 export interface ValidationSettingResponse {
   issueType: string;
   message: string;
+  validationType: string;
 }

--- a/public/pages/DefineDetector/utils/constants.tsx
+++ b/public/pages/DefineDetector/utils/constants.tsx
@@ -12,7 +12,6 @@
 import { FILTER_TYPES, UIFilter } from '../../../models/interfaces';
 import { OPERATORS_MAP } from '../../DefineDetector/components/DataFilterList/utils/constant';
 import { DetectorDefinitionFormikValues } from '../../DefineDetector/models/interfaces';
-
 export const EMPTY_UI_FILTER: UIFilter = {
   filterType: FILTER_TYPES.SIMPLE,
   fieldInfo: [],

--- a/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
+++ b/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
@@ -28,7 +28,7 @@ import {
 import { FilterDisplayList } from '../FilterDisplayList';
 import { ConfigCell, FixedWidthRow } from '../../../../components/ConfigCell';
 import { toStringConfigCell } from '../../utils/helpers';
-
+import { isEqual } from 'lodash';
 interface DetectorDefinitionFieldsProps {
   detector: Detector;
   onEditDetectorDefinition(): void;
@@ -94,19 +94,36 @@ export const DetectorDefinitionFields = (
         !props.validDetectorSettings &&
         props.validationResponse.hasOwnProperty('message')
       ) {
-        return (
-          <EuiCallOut
-            title="Issues found in the detector settings"
-            color="danger"
-            iconType="alert"
-            size="s"
-            style={{ marginBottom: '10px' }}
-          >
-            <ul>
-              <li>{props.validationResponse.message}</li>
-            </ul>
-          </EuiCallOut>
-        );
+        if (isEqual(props.validationResponse.validationType, 'model')) {
+          return (
+            <EuiCallOut
+              title="We identified some areas that might improve your model"
+              color="warning"
+              iconType="iInCircle"
+              size="s"
+              style={{ marginBottom: '10px' }}
+            >
+              {JSON.stringify(props.validationResponse.message).replace(
+                /\"/g,
+                ''
+              )}
+            </EuiCallOut>
+          );
+        } else {
+          return (
+            <EuiCallOut
+              title="Issues found in the detector settings"
+              color="danger"
+              iconType="alert"
+              size="s"
+              style={{ marginBottom: '10px' }}
+            >
+              <ul>
+                <li>{props.validationResponse.message}</li>
+              </ul>
+            </EuiCallOut>
+          );
+        }
       } else {
         return null;
       }

--- a/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
+++ b/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
@@ -20,7 +20,7 @@ import {
   EuiText,
 } from '@elastic/eui';
 import React from 'react';
-import { get } from 'lodash';
+import { get, isEqual } from 'lodash';
 import {
   Detector,
   ValidationSettingResponse,
@@ -28,7 +28,6 @@ import {
 import { FilterDisplayList } from '../FilterDisplayList';
 import { ConfigCell, FixedWidthRow } from '../../../../components/ConfigCell';
 import { toStringConfigCell } from '../../utils/helpers';
-import { isEqual } from 'lodash';
 interface DetectorDefinitionFieldsProps {
   detector: Detector;
   onEditDetectorDefinition(): void;
@@ -94,7 +93,9 @@ export const DetectorDefinitionFields = (
         !props.validDetectorSettings &&
         props.validationResponse.hasOwnProperty('message')
       ) {
-        if (isEqual(props.validationResponse.validationType, 'model')) {
+        if (
+          isEqual(get(props, 'validationResponse.validationType', ''), 'model')
+        ) {
           return (
             <EuiCallOut
               title="We identified some areas that might improve your model"

--- a/public/pages/ReviewAndCreate/components/FilterDisplayList/FilterDisplayList.tsx
+++ b/public/pages/ReviewAndCreate/components/FilterDisplayList/FilterDisplayList.tsx
@@ -27,7 +27,7 @@ export const FilterDisplayList = (props: FilterDisplayListProps) => {
   let filters = get(props, 'uiMetadata.filters', []);
   const oldFilterType = get(props, 'uiMetadata.filterType', undefined);
 
-  // We want to show the custom filter if filters is empty and 
+  // We want to show the custom filter if filters is empty and
   // props.filterQuery isn't empty.
   // Two possible situations for the if branch:
   // First, old detectors with custom filters will have no filter list, but

--- a/public/pages/ReviewAndCreate/components/ModelConfigurationFields/ModelConfigurationFields.tsx
+++ b/public/pages/ReviewAndCreate/components/ModelConfigurationFields/ModelConfigurationFields.tsx
@@ -26,7 +26,7 @@ import {
   FeatureAttributes,
   ValidationModelResponse,
 } from '../../../../models/interfaces';
-import { get, sortBy } from 'lodash';
+import { get, sortBy, isEqual } from 'lodash';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import { CodeModal } from '../../../../components/CodeModal/CodeModal';
 import { AdditionalSettings } from '../AdditionalSettings/AdditionalSettings';
@@ -253,26 +253,45 @@ export const ModelConfigurationFields = (
       !props.validModel &&
       props.validationFeatureResponse.hasOwnProperty('message')
     ) {
-      return (
-        <EuiCallOut
-          title="issues found in the model configuration"
-          color="danger"
-          iconType="alert"
-          size="s"
-          style={{ marginBottom: '10px' }}
-        >
-          {/* Callout can either display feature subissue which related to a specific 
-          feature issue or display a feature_attribute issue that is general like
-          more then x anomaly feature or dulicate feature names */}
-          {props.validationFeatureResponse.hasOwnProperty('sub_issues') ? (
-            getFeatureValidationCallout(props.validationFeatureResponse)
-          ) : (
-            <ul>
-              <li>{JSON.stringify(props.validationFeatureResponse.message)}</li>
-            </ul>
-          )}
-        </EuiCallOut>
-      );
+      if (isEqual(props.validationFeatureResponse.validationType, 'model')) {
+        return (
+          <EuiCallOut
+            title="We identified some areas that might improve your model"
+            color="warning"
+            iconType="iInCircle"
+            size="s"
+            style={{ marginBottom: '10px' }}
+          >
+            {JSON.stringify(props.validationFeatureResponse.message).replace(
+              /\"/g,
+              ''
+            )}
+          </EuiCallOut>
+        );
+      } else {
+        return (
+          <EuiCallOut
+            title="issues found in the model configuration"
+            color="danger"
+            iconType="alert"
+            size="s"
+            style={{ marginBottom: '10px' }}
+          >
+            {/* Callout can either display feature subissue which related to a specific 
+            feature issue or display a feature_attribute issue that is general like
+            more then x anomaly feature or dulicate feature names */}
+            {props.validationFeatureResponse.hasOwnProperty('sub_issues') ? (
+              getFeatureValidationCallout(props.validationFeatureResponse)
+            ) : (
+              <ul>
+                <li>
+                  {JSON.stringify(props.validationFeatureResponse.message)}
+                </li>
+              </ul>
+            )}
+          </EuiCallOut>
+        );
+      }
     } else {
       return null;
     }

--- a/public/pages/ReviewAndCreate/components/ModelConfigurationFields/ModelConfigurationFields.tsx
+++ b/public/pages/ReviewAndCreate/components/ModelConfigurationFields/ModelConfigurationFields.tsx
@@ -253,7 +253,12 @@ export const ModelConfigurationFields = (
       !props.validModel &&
       props.validationFeatureResponse.hasOwnProperty('message')
     ) {
-      if (isEqual(props.validationFeatureResponse.validationType, 'model')) {
+      if (
+        isEqual(
+          get(props, 'validationFeatureResponse.validationType', ''),
+          'model'
+        )
+      ) {
         return (
           <EuiCallOut
             title="We identified some areas that might improve your model"
@@ -271,7 +276,7 @@ export const ModelConfigurationFields = (
       } else {
         return (
           <EuiCallOut
-            title="issues found in the model configuration"
+            title="Issues found in the model configuration"
             color="danger"
             iconType="alert"
             size="s"

--- a/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -92,7 +92,6 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
   useEffect(() => {
     dispatch(validateDetector(formikToDetector(props.values), 'model'))
       .then((resp: any) => {
-        console.log('resp: ' + JSON.stringify(resp));
         if (isEmpty(Object.keys(resp.response))) {
           setValidDetectorSettings(true);
           setValidModelConfigurations(true);

--- a/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -20,7 +20,6 @@ import {
   EuiTitle,
   EuiButtonEmpty,
   EuiSpacer,
-  EuiCallOut,
 } from '@elastic/eui';
 import {
   createDetector,
@@ -93,6 +92,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
   useEffect(() => {
     dispatch(validateDetector(formikToDetector(props.values), 'model'))
       .then((resp: any) => {
+        console.log('resp: ' + JSON.stringify(resp));
         if (isEmpty(Object.keys(resp.response))) {
           setValidDetectorSettings(true);
           setValidModelConfigurations(true);
@@ -114,7 +114,11 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
                 validationType: validationType,
               };
 
-              // Potentially remove warning toast in these cases
+              // These issue types only come up during non-blocker validation after blocker validation has passed
+              // This means that the configurations don't have any blocking issues but request either timed out during
+              // non blocking validation or due to an issue in core. This means we aren't able to provide any recommendation
+              // and user has no way of re-trying except re-rendering page which isn't straightforward. At the moment we will
+              // hide these failures instead of explaining both levels of validation being done in the backend.
               if (issueType == 'aggregation' || issueType == 'timeout') {
                 setValidDetectorSettings(true);
                 setValidModelConfigurations(true);

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -377,10 +377,13 @@ export const createDetector = (requestBody: Detector): APIAction => ({
     }),
 });
 
-export const validateDetector = (requestBody: Detector): APIAction => ({
+export const validateDetector = (
+  requestBody: Detector,
+  validationType: string
+): APIAction => ({
   type: VALIDATE_DETECTOR,
   request: (client: HttpSetup) =>
-    client.post(`..${AD_NODE_API.DETECTOR}/_validate`, {
+    client.post(`..${AD_NODE_API.DETECTOR}/_validate/${validationType}`, {
       body: JSON.stringify(requestBody),
     }),
 });

--- a/server/cluster/ad/adPlugin.ts
+++ b/server/cluster/ad/adPlugin.ts
@@ -45,7 +45,13 @@ export default function adPlugin(Client: any, config: any, components: any) {
   });
   ad.validateDetector = ca({
     url: {
-      fmt: `${API.DETECTOR_BASE}/_validate`,
+      fmt: `${API.DETECTOR_BASE}/_validate/<%=validationType%>`,
+      req: {
+        validationType: {
+          type: 'string',
+          required: true,
+        },
+      },
     },
     needBody: true,
     method: 'POST',

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -233,11 +233,9 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
-      console.log('request.params: ' + request.params);
       let { validationType } = request.params as {
         validationType: string;
       };
-      console.log('params: ' + validationType);
       const requestBody = JSON.stringify(
         convertPreviewInputKeysToSnakeCase(request.body)
       );

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -95,7 +95,10 @@ export function registerADRoutes(apiRouter: Router, adService: AdService) {
     '/detectors/{detectorId}/_topAnomalies/{isHistorical}',
     adService.getTopAnomalyResults
   );
-  apiRouter.post('/detectors/_validate', adService.validateDetector);
+  apiRouter.post(
+    '/detectors/_validate/{validationType}',
+    adService.validateDetector
+  );
 }
 
 export default class AdService {
@@ -230,6 +233,11 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      console.log('request.params: ' + request.params);
+      let { validationType } = request.params as {
+        validationType: string;
+      };
+      console.log('params: ' + validationType);
       const requestBody = JSON.stringify(
         convertPreviewInputKeysToSnakeCase(request.body)
       );
@@ -237,6 +245,7 @@ export default class AdService {
         .asScoped(request)
         .callAsCurrentUser('ad.validateDetector', {
           body: requestBody,
+          validationType: validationType,
         });
       return opensearchDashboardsResponse.ok({
         body: {


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description

This PR integrates the new additional type parameter for validation API that includes `model` validation. Since `model` (non-blocker) validation also runs `detector` (blocker) validation, currently I only call the validate API with `model` parameter. In the future we can separate the two if we want to make the non-blocker validation an optional action. With this API integrated the user will be able to see any non-blocking issues.

#### Changes include:
* If response type is model then object passed to model or detector definition will include that information and the callout will be of color `warning` instead of `danger`

### Screenshot:

![Screen Shot 2022-03-07 at 8 22 12 AM](https://user-images.githubusercontent.com/67072393/157074718-cbe0c688-1396-4a67-9730-841d5302bdcd.png)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
