### PR TITLE
Add auto labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+# Default all changes to backporting to 1.x branch
+backport 1.x:
+- '*'
+- '*/*'
+- '*/**/*'
+- '*/**/**/*'
+- '*/**/**/**/*'
+- '*/**/**/**/**/*'
+- '*/**/**/**/**/**/*'
+- '*/**/**/**/**/**/**/*'
+- '*/**/**/**/**/**/**/**/*'
+- '*/**/**/**/**/**/**/**/**/*'
+- '.github/**/*'
+
+# Adding "github actions" label to files in .github or its subdirectories
+github actions:
+- '.github/**/*'
+
+# Adding "documentation" label to markdown files or updating release notes
+documentation:
+- '*.md'
+- 'release-notes/*'
+
+# Adding a "dependencies" label when yarn.lock is updated
+dependencies:
+- 'yarn.lock'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+      - name: Label
+        uses: actions/labeler@v4
+        with:
+          repo-token: ${{ steps.github_app_token.outputs.token }}


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

This PR adds a labeling github action which is triggered on PRs opening to `main`. There are 2 added files:
1. `.github/labeler.yml`: configures the labels to add to the PR, if the PR's changed files match any of the glob patterns specified. For example, this adds a `dependencies` label whenever a PR is opened that changes `yarn.lock`.
2. `.github/workflows/labeler.yml`: the actual github action which uses the specified config. Uses permissions from the OpenSearch GitHub app to be able to write to the PR, since that is not possible using the default `GITHUB_TOKEN`. For more details see [here](https://github.com/actions/labeler/pull/51/files), [here](https://github.com/actions/first-interaction/issues/10)

Example PR of this working in my forked repo (using a personal bot in order to get permissions to write to PRs in this repo): https://github.com/ohltyler/anomaly-detection-dashboards-plugin-1/pull/7 (auto-label workflow run: [link](https://github.com/ohltyler/anomaly-detection-dashboards-plugin-1/runs/5456681248?check_suite_focus=true))

Notes:
- it is defaulting all changes to `backport 1.x` - this is because this plugin is not tracking the next major version (2.0.0), and so all changes merged to `main` currently are being backported to `1.x` branch already (note this will need to change when moving to `2.0.0` compatibility / having `2.x` branch). Also note `backport 1.x` is the branch name used by the auto-backport bot to open a backport PR to `1.x` branch when a PR is merged, so this closes the gap and allows for a fully automated way to open a PR -> merge PR -> backport to release branch.
- it will add or remove labels based on changes in the PR - for example if `yarn.lock` was originally changed and then reverted within the PR, the labeler would add and remove the `dependencies` label as well
- `.github/**/*` pattern had to be added separately in `backport 1.x` label due to the labeler not picking up directories starting with `.` by default

~~TODO: understand the github bot permissions and if it can be used for this github action. Until then, this PR is blocked when trying to use the default repo token. Ref: https://github.com/actions/first-interaction/issues/10, use of an app to solve: mentioned [here](https://github.com/actions/first-interaction/issues/10#issuecomment-570991638)~~

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
