### PR TITLE
Remove extra loading spinners

### DIFF
--- a/public/pages/DetectorConfig/containers/DetectorConfig.tsx
+++ b/public/pages/DetectorConfig/containers/DetectorConfig.tsx
@@ -56,12 +56,6 @@ export function DetectorConfig(props: DetectorConfigProps) {
         </EuiPageBody>
       ) : (
         <div>
-          <EuiLoadingSpinner size="s" />
-          &nbsp;&nbsp;
-          <EuiLoadingSpinner size="m" />
-          &nbsp;&nbsp;
-          <EuiLoadingSpinner size="l" />
-          &nbsp;&nbsp;
           <EuiLoadingSpinner size="xl" />
         </div>
       )}


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Removes extra loading spinners on detector config page.

### Issues Resolved

Closes #94

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
