### PR TITLE
remove additional loading spinners and removing master from docker compose

### DIFF
--- a/.github/configurations/docker-compose.yml
+++ b/.github/configurations/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - discovery.seed_hosts=opensearch-node1
-      - cluster.initial_master_nodes=opensearch-node1
+      - cluster.initial_cluster_manager_nodes=opensearch-node1
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - 'ES_JAVA_OPTS=-Xms512m -Xmx512m' # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
     ulimits:

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -429,12 +429,6 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
         </EuiFlexGroup>
       ) : (
         <div>
-          <EuiLoadingSpinner size="s" />
-          &nbsp;&nbsp;
-          <EuiLoadingSpinner size="m" />
-          &nbsp;&nbsp;
-          <EuiLoadingSpinner size="l" />
-          &nbsp;&nbsp;
           <EuiLoadingSpinner size="xl" />
         </div>
       )}


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Remove additional loading spinners that were accidentally added and changing `master` in docker compose setting to `cluster_manager`

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
