### PR TITLE
Update labeler to default backports to 2.x

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-# Default all changes to backporting to 1.x branch
-backport 1.x:
+# Default all changes to backporting to 2.x branch
+backport 2.x:
 - '*'
 - '*/*'
 - '*/**/*'


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Update labeler to default backports to `2.x` branch.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
