### PR TITLE
Wait for detector to load before checking indices exist

### DIFF
--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -161,7 +161,10 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
         core.notifications.toasts.addDanger('Error getting all indices');
       });
     };
-    getInitialIndices();
+    // only need to check if indices exist after detector finishes loading
+    if (!isLoadingDetector) {
+      getInitialIndices();
+    }
   }, [detector]);
 
   useEffect(() => {
@@ -188,7 +191,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   // If the detector state was changed after opening the stop detector modal,
   // re-check if any jobs are running, and close the modal if it's not needed anymore
   useEffect(() => {
-    if (!isRTJobRunning && !isHistoricalJobRunning) {
+    if (!isRTJobRunning && !isHistoricalJobRunning && !isEmpty(detector)) {
       hideStopDetectorModal();
     }
   }, [detector]);


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Added two new conditions to two different `useEffect` calls on `DetectorDetail` page. 
First change is to wait for getDetector request to finish loading before checking if the indices themselves exist. Currently we are checking if the indices exist on every change to the detector and while the detector is still loading it continuously loops this API call to check for indices. This then triggers a change in AppState which triggers the change in `detector` variable hence the loop.

The second change is under the same idea where we don't need to call the `useEffect` that calls on `hideStopDetectorModal` if the detector itself is empty.

Further improvements will be made in later PR to optimize `useFetchDetectorInfo` further which is the call updating the `detector` variable.

### Issues Resolved
resolves #251 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
