### PR TITLE
Fix missing data call out if window delay is large

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "2.0.0.0",
-  "opensearchDashboardsVersion": "2.0.0",
+  "version": "2.0.2.0",
+  "opensearchDashboardsVersion": "2.0.2",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "2.0.0.0",
+  "version": "2.0.2.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "2.0.0.0",
+    "plugin_version": "2.0.2.0",
     "plugin_name": "anomalyDetectionDashboards",
     "plugin_zip_name": "anomaly-detection-dashboards"
   },

--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -12,6 +12,8 @@
 import { InitProgress } from '../../server/models/interfaces';
 import { DATA_TYPES } from '../utils/constants';
 import { DETECTOR_STATE } from '../../server/utils/constants';
+import { Duration } from 'moment';
+import moment from 'moment';
 
 export type FieldInfo = {
   label: string;
@@ -78,8 +80,82 @@ export type FeatureAttributes = {
   aggregationQuery: { [key: string]: any };
 };
 
+// all possible valid units accepted by the backend
 export enum UNITS {
+  NANOS = "Nanos",
+  MICROS = "Micros",
+  MILLIS = "Millis",
+  SECONDS = "Seconds",
   MINUTES = 'Minutes',
+  HOURS = "Hours",
+  HALF_DAYS = "HalfDays",
+  DAYS = "Days",
+  WEEKS = "Weeks",
+  MONTHS = "Months",
+  YEARS = "Years",
+  DECADES = "Decades",
+  CENTURIES = "Centuries",
+  MILLENNIA = "Millennia",
+  ERAS = "Eras",
+  FOREVER = "Forever"
+}
+
+// cannot create a method in enum, have to write function separately
+export function toDuration(units: UNITS): Duration {
+  switch(units) {
+    case UNITS.NANOS: {
+      // Duration in moment library does not support
+      return moment.duration(0.000000001, 'seconds');
+    }
+    case UNITS.MICROS: {
+      return moment.duration(0.000001, 'seconds');
+    }
+    case UNITS.MILLIS: {
+      return moment.duration(0.001, 'seconds');
+    }
+    case UNITS.SECONDS: {
+      return moment.duration(1, 'seconds');
+    }
+    case UNITS.MINUTES: {
+      return moment.duration(60, 'seconds');
+    }
+    case UNITS.HOURS: {
+      return moment.duration(3600, 'seconds');
+    }
+    case UNITS.HALF_DAYS: {
+      return moment.duration(43200, 'seconds');
+    }
+    case UNITS.DAYS: {
+      return moment.duration(86400, 'seconds');
+    }
+    case UNITS.WEEKS: {
+      return moment.duration(7 * 86400, 'seconds');
+    }
+    case UNITS.MONTHS: {
+      return moment.duration(31556952 / 12, 'seconds');
+    }
+    case UNITS.YEARS: {
+      return moment.duration(31556952, 'seconds');
+    }
+    case UNITS.DECADES: {
+      return moment.duration(31556952 * 10, 'seconds');
+    }
+    case UNITS.CENTURIES: {
+      return moment.duration(31556952 * 100, 'seconds');
+    }
+    case UNITS.MILLENNIA: {
+      return moment.duration(31556952 * 1000, 'seconds');
+    }
+    case UNITS.ERAS: {
+      return moment.duration(31556952 * 1000000000, 'seconds');
+    }
+    case UNITS.FOREVER: {
+      return moment.duration(Number.MAX_VALUE, 'seconds');
+    }
+    default:
+      break;
+  }
+  throw new Error("Unexpected unit: " + units);
 }
 
 export type Schedule = {

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -68,6 +68,7 @@ interface FeatureChartProps {
   rawFeatureData: FeatureAggregationData[][];
   entityData: EntityData[][];
   isHCDetector?: boolean;
+  windowDelay: Schedule;
 }
 
 export const FeatureChart = (props: FeatureChartProps) => {
@@ -228,11 +229,14 @@ export const FeatureChart = (props: FeatureChartProps) => {
                       ? flattenData(props.rawFeatureData)
                       : flattenData(props.featureData),
                     props.detectorInterval.interval,
+                    props.windowDelay,
                     getFeatureMissingAnnotationDateRange(
                       props.dateRange,
                       props.detectorEnabledTime
                     ),
-                    props.dateRange
+                    props.dateRange,
+                    // date range is selected by customer in UX so window delay time is not considered
+                    false
                   )}
                   marker={<EuiIcon type="alert" />}
                   style={{

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -27,6 +27,7 @@ import {
   FEATURE_TYPE,
   FeatureAggregationData,
   EntityData,
+  UNITS,
 } from '../../../models/interfaces';
 import { NoFeaturePrompt } from '../components/FeatureChart/NoFeaturePrompt';
 import { focusOnFeatureAccordion } from '../../ConfigureModel/utils/helpers';
@@ -175,6 +176,11 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
               detectorEnabledTime={props.detector.enabledTime}
               entityData={getEntityDataForChart(props.anomalyAndFeatureResults)}
               isHCDetector={props.isHCDetector}
+              windowDelay={
+                get(props, `detector.windowDelay.period`,  {
+                  period: { interval: 0, unit: UNITS.MINUTES },
+                })
+              }
             />
             {index + 1 ===
             get(props, 'detector.featureAttributes', []).length ? null : (

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -208,11 +208,11 @@ export function AnomalyResults(props: AnomalyResultsProps) {
   const checkLatestFeatureDataPoints = async () => {
     let windowDelayInMinutes = 0;
     if (detector.windowDelay !== undefined) {
-      let windowDelay = detector.windowDelay.period;
-      let windowDelayUnit = get(windowDelay, 'unit',  UNITS.MINUTES);
+      const windowDelay = detector.windowDelay.period;
+      const windowDelayUnit = get(windowDelay, 'unit',  UNITS.MINUTES);
 
       // current time minus window delay
-      let windowDelayInterval = get(windowDelay, 'interval',  0);
+      const windowDelayInterval = get(windowDelay, 'interval',  0);
       windowDelayInMinutes = windowDelayInterval * toDuration(windowDelayUnit).asMinutes();
     }
 

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -53,7 +53,7 @@ import {
   getDetectorStateDetails,
 } from '../../DetectorDetail/utils/helpers';
 import moment from 'moment';
-import { DateRange } from '../../../models/interfaces';
+import { DateRange, UNITS, toDuration } from '../../../models/interfaces';
 import {
   getFeatureDataPointsForDetector,
   buildParamsForGetAnomalyResultsWithDateRange,
@@ -204,10 +204,29 @@ export function AnomalyResults(props: AnomalyResultsProps) {
 
   const isHCDetector = !isEmpty(get(detector, 'categoryField', []));
 
+  // ran during componentDidMount and componentDidUpdate
   const checkLatestFeatureDataPoints = async () => {
+    let windowDelayInMinutes = 0;
+    if (detector.windowDelay !== undefined) {
+      let windowDelay = detector.windowDelay.period;
+      let windowDelayUnit = get(windowDelay, 'unit',  UNITS.MINUTES);
+
+      // current time minus window delay
+      let windowDelayInterval = get(windowDelay, 'interval',  0);
+      windowDelayInMinutes = windowDelayInterval * toDuration(windowDelayUnit).asMinutes();
+    }
+
+    // The query in this function uses data start/end time. So we should consider window delay
+    let adjustedCurrentTime = moment().subtract(
+      windowDelayInMinutes,
+      'minutes'
+    );;
+
+    // check from FEATURE_DATA_POINTS_WINDOW + FEATURE_DATA_CHECK_WINDOW_OFFSET (currently 5) intervals to now
     const featureDataPointsRange = {
       startDate: Math.max(
-        moment()
+        // clone since subtract mutates the original moment that we need to use as endData later
+        adjustedCurrentTime.clone()
           .subtract(
             (FEATURE_DATA_POINTS_WINDOW + FEATURE_DATA_CHECK_WINDOW_OFFSET) *
               detectorIntervalInMin,
@@ -217,7 +236,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
         //@ts-ignore
         detector.enabledTime
       ),
-      endDate: moment().valueOf(),
+      endDate: adjustedCurrentTime.valueOf(),
     } as DateRange;
 
     const params = buildParamsForGetAnomalyResultsWithDateRange(
@@ -239,7 +258,8 @@ export function AnomalyResults(props: AnomalyResultsProps) {
         detector,
         featuresData,
         detectorIntervalInMin,
-        featureDataPointsRange
+        featureDataPointsRange,
+        true
       );
 
       const featureMissingSeveritiesMap =

--- a/public/pages/utils/__tests__/anomalyResultUtils.test.ts
+++ b/public/pages/utils/__tests__/anomalyResultUtils.test.ts
@@ -1,0 +1,315 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { getFeatureMissingDataAnnotations, getFeatureDataPointsForDetector } from '../anomalyResultUtils';
+import { getRandomDetector } from '../../../redux/reducers/__tests__/utils';
+import {
+    UNITS,
+    Detector,
+    FeatureAttributes
+  } from '../../../models/interfaces';
+
+describe('anomalyResultUtils', () => {
+    let randomDetector_20_min : Detector;
+    let randomDetector_20_sec : Detector;
+    let feature_id = 'deny_max';
+    beforeAll(() => {
+        randomDetector_20_min = {
+            ...getRandomDetector(true),
+            detectionInterval: {
+                period: {
+                  interval: 1,
+                  unit: UNITS.MINUTES,
+                },
+              },
+            windowDelay: {
+                period: {
+                  interval: 20,
+                  unit: UNITS.MINUTES,
+                },
+              },
+              featureAttributes: [
+                {
+                  featureId: feature_id,
+                  featureName: feature_id,
+                  featureEnabled: true,
+                },
+              ] as FeatureAttributes[],
+          };
+
+          randomDetector_20_sec= {
+            ...getRandomDetector(true),
+            detectionInterval: {
+                period: {
+                  interval: 1,
+                  unit: UNITS.MINUTES,
+                },
+              },
+            windowDelay: {
+                period: {
+                  interval: 20,
+                  unit: UNITS.SECONDS,
+                },
+              },
+              featureAttributes: [
+                {
+                  featureId: feature_id,
+                  featureName: feature_id,
+                  featureEnabled: true,
+                },
+              ] as FeatureAttributes[],
+          };
+    });
+    describe('getFeatureDataPointsForDetector', () => {
+        test('returns no missing data with 20 minute window delay', () => {
+            expect(
+              getFeatureDataPointsForDetector(
+                  randomDetector_20_min,
+                  {
+                      "deny_max":
+                      [
+                          {"startTime":1655253197686,"endTime":1655253257686,"plotTime":1655253257686,"data":13451},
+                          {"startTime":1655253137689,"endTime":1655253197689,"plotTime":1655253197689,"data":10973},
+                          {"startTime":1655253077698,"endTime":1655253137698,"plotTime":1655253137698,"data":11777},
+                          {"startTime":1655253017690,"endTime":1655253077690,"plotTime":1655253077690,"data":21588}
+                      ]
+                  },
+                  randomDetector_20_min.detectionInterval.period.interval,
+                  {
+                      startDate: 1655252995079,
+                      endDate: 1655253295079
+                  },
+                  true
+              )
+            ).toEqual(
+                {
+                    "deny_max":
+                    [
+                        {"isMissing":false,"plotTime":1655253060000,"startTime":1655253000000,"endTime":1655253060000},
+                        {"isMissing":false,"plotTime":1655253120000,"startTime":1655253060000,"endTime":1655253120000},
+                        {"isMissing":false,"plotTime":1655253180000,"startTime":1655253120000,"endTime":1655253180000}
+                    ]
+                });
+          });
+          test('returns missing data with 20 minute window delay', () => {
+              expect(
+                  getFeatureDataPointsForDetector(
+                      randomDetector_20_min,
+                      {
+                          feature_id:[
+                          ]
+                      },
+                      randomDetector_20_min.detectionInterval.period.interval,
+                      {
+                          startDate: 1655252995079,
+                          endDate: 1655253295079
+                      },
+                      true
+                  )
+                ).toEqual(
+                    {
+                        "deny_max":
+                        [
+                            {"isMissing":true,"plotTime":1655253060000,"startTime":1655253000000,"endTime":1655253060000},
+                            {"isMissing":true,"plotTime":1655253120000,"startTime":1655253060000,"endTime":1655253120000},
+                            {"isMissing":true,"plotTime":1655253180000,"startTime":1655253120000,"endTime":1655253180000}
+                        ]
+                    });
+          });
+          test('returns missing data with 20 seconds window delay', () => {
+              expect(
+                getFeatureDataPointsForDetector(
+                    randomDetector_20_sec,
+                    {
+                        "deny_max":[
+                            {"startTime":1655245177235,"endTime":1655245237235,"plotTime":1655245237235,"data":14719},
+                            {"startTime":1655245117232,"endTime":1655245177232,"plotTime":1655245177232,"data":14476}]
+                          },
+                    randomDetector_20_sec.detectionInterval.period.interval,
+                    {
+                        startDate: 1655244944254,
+                        endDate: 1655245244254
+                    },
+                    true
+                )
+              ).toEqual(
+                    {
+                      "deny_max":[
+                          {"isMissing":true,"plotTime":1655245020000,"startTime":1655244960000,"endTime":1655245020000},
+                          {"isMissing":true,"plotTime":1655245080000,"startTime":1655245020000,"endTime":1655245080000},
+                          {"isMissing":true,"plotTime":1655245140000,"startTime":1655245080000,"endTime":1655245140000}
+                      ]
+                    }
+                  );
+            });
+            test('returns partially missing data with 20 seconds window delay', () => {
+              expect(
+                  getFeatureDataPointsForDetector(
+                      randomDetector_20_sec,
+                      {
+                          "deny_max":[
+                              {"startTime":1655245357224,"endTime":1655245417224,"plotTime":1655245417224,"data":8675},
+                              {"startTime":1655245297232,"endTime":1655245357232,"plotTime":1655245357232,"data":9397},
+                              {"startTime":1655245237231,"endTime":1655245297231,"plotTime":1655245297231,"data":12102},
+                              {"startTime":1655245177235,"endTime":1655245237235,"plotTime":1655245237235,"data":14719}]
+                      },
+                      randomDetector_20_sec.detectionInterval.period.interval,
+                      {
+                          startDate: 1655245124258,
+                          endDate: 1655245424258
+                      },
+                      true
+                  )
+                ).toEqual(
+                      {
+                          "deny_max":[
+                              {"isMissing":true,"plotTime":1655245200000,"startTime":1655245140000,"endTime":1655245200000},
+                              {"isMissing":false,"plotTime":1655245260000,"startTime":1655245200000,"endTime":1655245260000},
+                              {"isMissing":false,"plotTime":1655245320000,"startTime":1655245260000,"endTime":1655245320000}]
+                      }
+                    );
+            });
+    });
+    describe('getFeatureMissingDataAnnotations', () => {
+        test('returns missing data annotation with 20 seconds window delay', () => {
+            expect(
+                getFeatureMissingDataAnnotations(
+                    [
+                        {"startTime":1654731937236,"endTime":1654731997236,"plotTime":1654731997236,"data":9998},
+                        {"startTime":1654731877250,"endTime":1654731937250,"plotTime":1654731937250,"data":14841},
+                        {"startTime":1654731817236,"endTime":1654731877236,"plotTime":1654731877236,"data":6777},
+                        {"startTime":1654731757234,"endTime":1654731817234,"plotTime":1654731817234,"data":15443},
+                        {"startTime":1654731697230,"endTime":1654731757230,"plotTime":1654731757230,"data":9612},
+                        {"startTime":1654731637234,"endTime":1654731697234,"plotTime":1654731697234,"data":13992},
+                        {"startTime":1654731577232,"endTime":1654731637232,"plotTime":1654731637232,"data":10522},
+                        {"startTime":1654731517232,"endTime":1654731577232,"plotTime":1654731577232,"data":10945}
+                    ],
+                    randomDetector_20_sec.detectionInterval.period.interval,
+                    randomDetector_20_sec.windowDelay.period,
+                    {
+                        startDate: 1654731477228,
+                        endDate: 1654731697232
+                    },
+                    {
+                        startDate: 1654731477228,
+                        endDate: 1654731697232
+                    },
+                    false
+                )
+            ).toEqual(
+                [
+                    // our tests use UTC time zone. But in real application, it is local time.
+                    {
+                        "dataValue":1654731540000,
+                        "details":"There is feature data point missing between 06/08/22 11:38 PM and 06/08/22 11:39 PM",
+                        "header":"06/08/22 11:39:00 PM"
+                    }
+                ]
+            );
+        });
+        test('returns no missing data annotation with 20 seconds window delay', () => {
+            expect(
+                getFeatureMissingDataAnnotations(
+                    [
+                        {"startTime":1655249917234,"endTime":1655249977234,"plotTime":1655249977234,"data":8326},
+                        {"startTime":1655249857233,"endTime":1655249917233,"plotTime":1655249917233,"data":10953},
+                        {"startTime":1655249797235,"endTime":1655249857235,"plotTime":1655249857235,"data":14106},
+                        {"startTime":1655249737234,"endTime":1655249797234,"plotTime":1655249797234,"data":15453},
+                        {"startTime":1655249677234,"endTime":1655249737234,"plotTime":1655249737234,"data":8721},
+                        {"startTime":1655249617233,"endTime":1655249677233,"plotTime":1655249677233,"data":8606},
+                        {"startTime":1655249557233,"endTime":1655249617233,"plotTime":1655249617233,"data":8996},
+                        {"startTime":1655249497232,"endTime":1655249557232,"plotTime":1655249557232,"data":10809},
+                        {"startTime":1655249437230,"endTime":1655249497230,"plotTime":1655249497230,"data":5445}
+                    ],
+                    randomDetector_20_sec.detectionInterval.period.interval,
+                    randomDetector_20_sec.windowDelay.period,
+                    {
+                        startDate: 1655249857234,
+                        endDate: 1655250031633
+                    },
+                    {
+                        startDate: 1655249857234,
+                        endDate: 1655250031633
+                    },
+                    false
+                )
+            ).toEqual(
+                []
+            );
+        });
+        test('returns missing data annotation with 20 minutes window delay', () => {
+            expect(
+                getFeatureMissingDataAnnotations(
+                    // timestamps in descending order
+                    [
+                        {"startTime":1654652417693,"endTime":1654652477693,"plotTime":1654652477693,"data":9050},
+                        {"startTime":1654652357688,"endTime":1654652417688,"plotTime":1654652417688,"data":13895},
+                        {"startTime":1654652297691,"endTime":1654652357691,"plotTime":1654652357691,"data":11362},
+                        {"startTime":1654652237690,"endTime":1654652297690,"plotTime":1654652297690,"data":13253},
+                        {"startTime":1654652177690,"endTime":1654652237690,"plotTime":1654652237690,"data":15658},
+                        {"startTime":1654652117689,"endTime":1654652177689,"plotTime":1654652177689,"data":10015},
+                        {"startTime":1654652057688,"endTime":1654652117688,"plotTime":1654652117688,"data":12291}
+                    ],
+                    randomDetector_20_min.detectionInterval.period.interval,
+                    randomDetector_20_min.windowDelay.period,
+                    {
+                        startDate: 1654651997688,
+                        endDate: 1654653617693
+                    },
+                    {
+                        startDate: 1654651997688,
+                        endDate: 1654653617693
+                    },
+                    false
+                )
+            ).toEqual(
+                // our tests use UTC time zone. But in real application, it is local time.
+                [
+                    {
+                        "dataValue":1654652040000,
+                        "details":"There is feature data point missing between 06/08/22 1:33 AM and 06/08/22 1:34 AM",
+                        "header":"06/08/22 01:34:00 AM"
+                    }
+                ]
+            );
+        });
+        test('returns no missing data annotation with 20 minutes window delay', () => {
+            expect(
+                getFeatureMissingDataAnnotations(
+                    [
+                        {"startTime":1655250437690,"endTime":1655250497690,"plotTime":1655250497690,"data":13888},
+                        {"startTime":1655250377688,"endTime":1655250437688,"plotTime":1655250437688,"data":8246},
+                        {"startTime":1655250317687,"endTime":1655250377687,"plotTime":1655250377687,"data":16812},
+                        {"startTime":1655250257691,"endTime":1655250317691,"plotTime":1655250317691,"data":9834},
+                        {"startTime":1655250197688,"endTime":1655250257688,"plotTime":1655250257688,"data":12409},
+                        {"startTime":1655250137686,"endTime":1655250197686,"plotTime":1655250197686,"data":14615},
+                        {"startTime":1655250077703,"endTime":1655250137703,"plotTime":1655250137703,"data":8377}
+                    ],
+                    randomDetector_20_min.detectionInterval.period.interval,
+                    randomDetector_20_min.windowDelay.period,
+                    {
+                        startDate: 1655250377690,
+                        endDate: 1655251724454
+                    },
+                    {
+                        startDate: 1655250377690,
+                        endDate: 1655251724454
+                    },
+                    false
+                )
+            ).toEqual(
+                []
+            );
+        });
+    });
+    
+      
+});


### PR DESCRIPTION
### Description

The missing feature callout only shows when fetching feature data points based on the interval and time range, and if there are any empty points Previously, when I configured the window delay to 20 minutes, the missing data call out will show. The reason is that the window delay offset isn't being considered in the time range used in the feature fetching query, or in the displayed chart, such that it shows as empty, when it's actually expected to be empty based on the window delay.This PR fixed the bug by considering window delay in missing feature calculations.

Testing done:
1. done e2e testing and verified the problem is fixed.
2. added unit tests.

Signed-off-by: Kaituo Li <kaituo@amazon.com>

### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/223

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
