### PR TITLE
Bump to 2.1.0 compatibility

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -10,8 +10,8 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: '2.0'
-  OPENSEARCH_VERSION: '2.0.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
+  OPENSEARCH_VERSION: '2.1.0-SNAPSHOT'
 jobs:
   test-without-security:
     name: Run integ tests without security

--- a/.github/workflows/unit-tests-workflow.yml
+++ b/.github/workflows/unit-tests-workflow.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - "*"
 env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_DASHBOARDS_VERSION: '2.x'
 jobs:
   tests:
     name: Run unit tests

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "anomalyDetectionDashboards",
-  "version": "2.0.2.0",
-  "opensearchDashboardsVersion": "2.0.2",
+  "version": "2.1.0.0",
+  "opensearchDashboardsVersion": "2.1.0",
   "configPath": ["anomaly_detection_dashboards"],
   "requiredPlugins": ["navigation"],
   "optionalPlugins": [],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "anomaly-detection-dashboards",
-  "version": "2.0.2.0",
+  "version": "2.1.0.0",
   "description": "OpenSearch Anomaly Detection Dashboards Plugin",
   "main": "index.js",
   "config": {
-    "plugin_version": "2.0.2.0",
+    "plugin_version": "2.1.0.0",
     "plugin_name": "anomalyDetectionDashboards",
     "plugin_zip_name": "anomaly-detection-dashboards"
   },


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Bump plugin to `2.1.0.0`, and compatibility with core Dashboards `2.1.0`.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
