### PR TITLE
Correct AD branch reference for 2.x

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           path: anomaly-detection
           repository: opensearch-project/anomaly-detection
-          ref: 'main'
+          ref: '2.x'
       - name: Run Opensearch with plugin
         run: |
           cd anomaly-detection


### PR DESCRIPTION
Signed-off-by: Jackie Han <jkhanjob@gmail.com>

### Description

Correct AD branch reference for 2.x to avoid the breaking change on main branch

### Issues Resolved

Getting integration tests running and passing

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
