### PR TITLE
Add branch constants in CI workflow for 2.x

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -12,6 +12,8 @@ on:
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
   OPENSEARCH_VERSION: '2.4.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_FTREPO_VERSION: '2.x'
+  ANOMALY_DETECTION_PLUGIN_VERSION: '2.x'
 jobs:
   test-without-security:
     name: Run integ tests without security
@@ -26,7 +28,7 @@ jobs:
         with:
           path: anomaly-detection
           repository: opensearch-project/anomaly-detection
-          ref: '2.x'
+          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
       - name: Run Opensearch with plugin
         run: |
           cd anomaly-detection
@@ -72,7 +74,7 @@ jobs:
         with:
           path: opensearch-dashboards-functional-test
           repository: opensearch-project/opensearch-dashboards-functional-test
-          ref: 'main' # TODO: change to a branch when the branching strategy in that repo has been established
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_FTREPO_VERSION }}
       - name: Get Cypress version
         id: cypress_version
         run: |


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Same as #345 but for 2.x branch.


### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
