### PR TITLE
Remove duplicate icon on external links

### DIFF
--- a/global-setup.js
+++ b/global-setup.js
@@ -1,3 +1,3 @@
 export default () => {
-    process.env.TZ = 'UTC';
-  }
+  process.env.TZ = 'UTC';
+};

--- a/public/components/FormattedFormRow/FormattedFormRow.tsx
+++ b/public/components/FormattedFormRow/FormattedFormRow.tsx
@@ -35,7 +35,7 @@ export const FormattedFormRow = (props: FormattedFormRowProps) => {
           {props.hintLink ? ' ' : null}
           {props.hintLink ? (
             <EuiLink href={props.hintLink} target="_blank">
-              Learn more <EuiIcon size="s" type="popout" />
+              Learn more
             </EuiLink>
           ) : null}
         </EuiText>

--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -82,27 +82,27 @@ export type FeatureAttributes = {
 
 // all possible valid units accepted by the backend
 export enum UNITS {
-  NANOS = "Nanos",
-  MICROS = "Micros",
-  MILLIS = "Millis",
-  SECONDS = "Seconds",
+  NANOS = 'Nanos',
+  MICROS = 'Micros',
+  MILLIS = 'Millis',
+  SECONDS = 'Seconds',
   MINUTES = 'Minutes',
-  HOURS = "Hours",
-  HALF_DAYS = "HalfDays",
-  DAYS = "Days",
-  WEEKS = "Weeks",
-  MONTHS = "Months",
-  YEARS = "Years",
-  DECADES = "Decades",
-  CENTURIES = "Centuries",
-  MILLENNIA = "Millennia",
-  ERAS = "Eras",
-  FOREVER = "Forever"
+  HOURS = 'Hours',
+  HALF_DAYS = 'HalfDays',
+  DAYS = 'Days',
+  WEEKS = 'Weeks',
+  MONTHS = 'Months',
+  YEARS = 'Years',
+  DECADES = 'Decades',
+  CENTURIES = 'Centuries',
+  MILLENNIA = 'Millennia',
+  ERAS = 'Eras',
+  FOREVER = 'Forever',
 }
 
 // cannot create a method in enum, have to write function separately
 export function toDuration(units: UNITS): Duration {
-  switch(units) {
+  switch (units) {
     case UNITS.NANOS: {
       // Duration in moment library does not support
       return moment.duration(0.000000001, 'seconds');
@@ -155,7 +155,7 @@ export function toDuration(units: UNITS): Duration {
     default:
       break;
   }
-  throw new Error("Unexpected unit: " + units);
+  throw new Error('Unexpected unit: ' + units);
 }
 
 export type Schedule = {
@@ -235,7 +235,7 @@ export type AnomalyData = {
   entity?: EntityData[];
   features?: { [key: string]: FeatureAggregationData };
   contributions?: { [key: string]: FeatureContributionData };
-  aggInterval?: string; 
+  aggInterval?: string;
 };
 
 export type FeatureAggregationData = {

--- a/public/pages/AnomalyCharts/components/AnomaliesStat/AnomalyStat.tsx
+++ b/public/pages/AnomalyCharts/components/AnomaliesStat/AnomalyStat.tsx
@@ -91,7 +91,7 @@ export const AlertsStat = (props: {
             target="_blank"
             style={{ fontSize: '14px' }}
           >
-            View monitor <EuiIcon type="popout"></EuiIcon>
+            View monitor
           </EuiLink>
         ) : null}
       </Fragment>

--- a/public/pages/AnomalyCharts/components/AnomaliesStat/__tests__/__snapshots__/AnomalyStat.test.tsx.snap
+++ b/public/pages/AnomalyCharts/components/AnomaliesStat/__tests__/__snapshots__/AnomalyStat.test.tsx.snap
@@ -38,21 +38,7 @@ exports[`<AlertsStat /> spec Alert Stat renders component with monitor and loadi
         style="font-size: 14px;"
         target="_blank"
       >
-        View monitor 
-        <svg
-          aria-hidden="true"
-          class="euiIcon euiIcon--medium"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-          />
-        </svg>
+        View monitor
         <svg
           aria-label="External link"
           class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -116,17 +102,7 @@ exports[`<AlertsStat /> spec Alert Stat renders component with monitor and not l
         style="font-size: 14px;"
         target="_blank"
       >
-        View monitor 
-        <svg
-          aria-hidden="true"
-          class="euiIcon euiIcon--medium euiIcon-isLoading"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        />
+        View monitor
         <svg
           aria-hidden="true"
           aria-label="External link"

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -205,7 +205,7 @@ export const FeatureChart = (props: FeatureChartProps) => {
            * and thus show different annotations per feature chart (currently all annotations
            * shown equally across all enabled feature charts for a given detector).
            */}
-           
+
           {props.feature.featureEnabled ? (
             <RectAnnotation
               dataValues={flattenData(props.annotations)}
@@ -265,7 +265,7 @@ export const FeatureChart = (props: FeatureChartProps) => {
                     ', '
                   )})`
                 : props.featureDataSeriesName;
-                timeSeriesList.push(
+              timeSeriesList.push(
                 <LineSeries
                   id={seriesKey}
                   name={seriesKey}
@@ -280,29 +280,28 @@ export const FeatureChart = (props: FeatureChartProps) => {
                   yAccessors={[CHART_FIELDS.DATA]}
                   data={featureTimeSeries}
                 />
-              )
-              if (featureTimeSeries.map(
-                (item: FeatureAggregationData) => {
-                  if(item.hasOwnProperty('expectedValue')) {
+              );
+              if (
+                featureTimeSeries.map((item: FeatureAggregationData) => {
+                  if (item.hasOwnProperty('expectedValue')) {
                     timeSeriesList.push(
                       <LineSeries
-                        id={"ExpectedValue"}
-                        name={"Expected Value"}
-                        color={"#0475a2"}
+                        id={'ExpectedValue'}
+                        name={'Expected Value'}
+                        color={'#0475a2'}
                         xScaleType={ScaleType.Time}
                         yScaleType={ScaleType.Linear}
                         xAccessor={CHART_FIELDS.PLOT_TIME}
                         yAccessors={[CHART_FIELDS.EXPECTED_VALUE]}
                         data={featureTimeSeries}
                       />
-                    )
+                    );
                   }
-                }
-              ))
-              return timeSeriesList;
+                })
+              )
+                return timeSeriesList;
             }
           )}
-          
         </Chart>
         {showCustomExpression ? (
           <CodeModal

--- a/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyDetailsChart.tsx
@@ -348,30 +348,33 @@ export const AnomalyDetailsChart = React.memo(
       zoomRange.endDate,
     ]);
 
-
     const customAnomalyContributionTooltip = (details?: string) => {
       const anomaly = details ? JSON.parse(details) : undefined;
-      const contributionData = get(anomaly, `contributions`, [])  
+      const contributionData = get(anomaly, `contributions`, []);
 
-      const featureData = get(anomaly, `features`, {}) 
+      const featureData = get(anomaly, `features`, {});
       let featureAttributionList = [] as any[];
       if (Array.isArray(contributionData)) {
         contributionData.map((contribution: any) => {
-          const featureName = get(get(featureData, contribution.feature_id, ""), "name", "") 
-          const dataString = (contribution.data * 100) + "%"
+          const featureName = get(
+            get(featureData, contribution.feature_id, ''),
+            'name',
+            ''
+          );
+          const dataString = contribution.data * 100 + '%';
           featureAttributionList.push(
             <div>
               {featureName}: {dataString} <br />
             </div>
-          )
-        })
+          );
+        });
       } else {
         for (const [, value] of Object.entries(contributionData)) {
           featureAttributionList.push(
             <div>
               {value.name}: {value.attribution} <br />
             </div>
-          )
+          );
         }
       }
       return (
@@ -379,16 +382,15 @@ export const AnomalyDetailsChart = React.memo(
           <EuiText size="xs">
             <EuiIcon type="list" /> <b>Feature Contribution: </b>
             {anomaly ? (
-            <p>
-              <hr style={{ color: '#E0E0E0' }}></hr>
-              {featureAttributionList}
-            </p>
-          ) : null}
+              <p>
+                <hr style={{ color: '#E0E0E0' }}></hr>
+                {featureAttributionList}
+              </p>
+            ) : null}
           </EuiText>
         </div>
       );
     };
-
 
     const generateContributionAnomalyAnnotations = (
       anomalies: AnomalyData[][]
@@ -396,18 +398,17 @@ export const AnomalyDetailsChart = React.memo(
       let annotations = [] as any[];
       anomalies.forEach((anomalyTimeSeries: AnomalyData[]) => {
         annotations.push(
-          Array.isArray(anomalyTimeSeries) ? (
-            anomalyTimeSeries
-            .filter((anomaly: AnomalyData) => anomaly.anomalyGrade > 0)
-            .map((anomaly: AnomalyData) => (              
-              {
-              coordinates: {
-                x0: anomaly.startTime,
-                x1: anomaly.endTime + (anomaly.endTime - anomaly.startTime),
-              },
-              details: `${JSON.stringify(anomaly)}`
-            }))
-          ) : [] 
+          Array.isArray(anomalyTimeSeries)
+            ? anomalyTimeSeries
+                .filter((anomaly: AnomalyData) => anomaly.anomalyGrade > 0)
+                .map((anomaly: AnomalyData) => ({
+                  coordinates: {
+                    x0: anomaly.startTime,
+                    x1: anomaly.endTime + (anomaly.endTime - anomaly.startTime),
+                  },
+                  details: `${JSON.stringify(anomaly)}`,
+                }))
+            : []
         );
       });
       return annotations;
@@ -601,7 +602,9 @@ export const AnomalyDetailsChart = React.memo(
                     />
                   )}
                   <RectAnnotation
-                    dataValues={flattenData(generateContributionAnomalyAnnotations(zoomedAnomalies))}
+                    dataValues={flattenData(
+                      generateContributionAnomalyAnnotations(zoomedAnomalies)
+                    )}
                     id="featureAttributionAnnotation"
                     style={{
                       stroke: CHART_COLORS.ANOMALY_GRADE_COLOR,
@@ -610,8 +613,8 @@ export const AnomalyDetailsChart = React.memo(
                       fill: CHART_COLORS.ANOMALY_GRADE_COLOR,
                     }}
                     renderTooltip={customAnomalyContributionTooltip}
-                  />  
-                
+                  />
+
                   {alertAnnotations ? (
                     <LineAnnotation
                       id="alertAnnotation"
@@ -683,31 +686,31 @@ export const AnomalyDetailsChart = React.memo(
                             get(anomalySeries, '0.entity', []),
                             ', '
                           )})`
-                        : props.anomalyGradeSeriesName; 
-                        return (
-                          <LineSeries
-                            id={seriesKey}
-                            name={seriesKey}
-                            color={
-                              multipleTimeSeries
-                                ? ENTITY_COLORS[index]
-                                : CHART_COLORS.ANOMALY_GRADE_COLOR
-                            }
-                            data={anomalySeries}
-                            xScaleType={
-                              showAggregateResults
-                                ? ScaleType.Ordinal
-                                : ScaleType.Time
-                            }
-                            yScaleType={ScaleType.Linear}
-                            xAccessor={
-                              showAggregateResults
-                                ? CHART_FIELDS.AGG_INTERVAL
-                                : CHART_FIELDS.PLOT_TIME
-                            }
-                            yAccessors={[CHART_FIELDS.ANOMALY_GRADE]}
-                          />
-                        )
+                        : props.anomalyGradeSeriesName;
+                      return (
+                        <LineSeries
+                          id={seriesKey}
+                          name={seriesKey}
+                          color={
+                            multipleTimeSeries
+                              ? ENTITY_COLORS[index]
+                              : CHART_COLORS.ANOMALY_GRADE_COLOR
+                          }
+                          data={anomalySeries}
+                          xScaleType={
+                            showAggregateResults
+                              ? ScaleType.Ordinal
+                              : ScaleType.Time
+                          }
+                          yScaleType={ScaleType.Linear}
+                          xAccessor={
+                            showAggregateResults
+                              ? CHART_FIELDS.AGG_INTERVAL
+                              : CHART_FIELDS.PLOT_TIME
+                          }
+                          yAccessors={[CHART_FIELDS.ANOMALY_GRADE]}
+                        />
+                      );
                     }
                   )}
                 </Chart>

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -176,11 +176,9 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
               detectorEnabledTime={props.detector.enabledTime}
               entityData={getEntityDataForChart(props.anomalyAndFeatureResults)}
               isHCDetector={props.isHCDetector}
-              windowDelay={
-                get(props, `detector.windowDelay.period`,  {
-                  period: { interval: 0, unit: UNITS.MINUTES },
-                })
-              }
+              windowDelay={get(props, `detector.windowDelay.period`, {
+                period: { interval: 0, unit: UNITS.MINUTES },
+              })}
             />
             {index + 1 ===
             get(props, 'detector.featureAttributes', []).length ? null : (

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -640,9 +640,7 @@ export const getFeatureBreakdownWording = (
   return isNotSample ? 'Feature breakdown' : 'Sample feature breakdown';
 };
 
-export const getFeatureDataWording = (
-  isNotSample: boolean | undefined
-) => {
+export const getFeatureDataWording = (isNotSample: boolean | undefined) => {
   return isNotSample ? 'Feature output' : 'Sample feature output';
 };
 

--- a/public/pages/AnomalyCharts/utils/constants.ts
+++ b/public/pages/AnomalyCharts/utils/constants.ts
@@ -24,7 +24,7 @@ export enum CHART_FIELDS {
   CONFIDENCE = 'confidence',
   DATA = 'data',
   AGG_INTERVAL = 'aggInterval',
-  EXPECTED_VALUE = 'expectedValue'
+  EXPECTED_VALUE = 'expectedValue',
 }
 
 export enum CHART_COLORS {
@@ -91,7 +91,7 @@ export const DEFAULT_ANOMALY_SUMMARY = {
   maxAnomalyGrade: 0,
   minConfidence: 0,
   maxConfidence: 0,
-  lastAnomalyOccurrence: '-'
+  lastAnomalyOccurrence: '-',
 };
 
 export const HEATMAP_CHART_Y_AXIS_WIDTH = 30;

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -76,7 +76,7 @@ export function CategoryField(props: CategoryFieldProps) {
           Split a single time series into multiple time series based on
           categorical fields. You can select up to 2.{' '}
           <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-            Learn more <EuiIcon size="s" type="popout" />
+            Learn more
           </EuiLink>
         </EuiText>
       }

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -50,17 +50,7 @@ exports[`<CategoryField /> spec renders the component when disabled 1`] = `
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon-isLoading"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  Learn more
                   <svg
                     aria-hidden="true"
                     aria-label="External link"
@@ -184,21 +174,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
+                  Learn more
                   <svg
                     aria-label="External link"
                     class="euiIcon euiIcon--small euiLink__externalIcon"

--- a/public/pages/ConfigureModel/components/Features/Features.tsx
+++ b/public/pages/ConfigureModel/components/Features/Features.tsx
@@ -55,7 +55,7 @@ export function Features(props: FeaturesProps) {
           A feature is the field in your index that you use to check for
           anomalies. You can add up to 5 features.{' '}
           <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-            Learn more <EuiIcon size="s" type="popout" />
+            Learn more
           </EuiLink>
         </EuiText>
       }

--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -249,7 +249,7 @@ export function ConfigureModel(props: ConfigureModelProps) {
                       and other optional parameters, you can preview your
                       anomalies from a sample feature output.{' '}
                       <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-                        Learn more <EuiIcon size="s" type="popout" />
+                        Learn more
                       </EuiLink>
                     </EuiText>
                     <EuiSpacer size="s" />

--- a/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
+++ b/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
@@ -204,7 +204,7 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
                 ? 'You can preview how your anomalies may look like from sample feature output and adjust the feature settings as needed.'
                 : 'Use the sample data as a reference to fine tune settings. To see the latest preview with your adjustments, click "Refresh preview". Once you are done with your edits, save your changes and run the detector to see real time anomalies for the new data set.'}{' '}
               <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-                Learn more <EuiIcon size="s" type="popout" />
+                Learn more
               </EuiLink>
             </EuiText>
           </EuiFlexItem>

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -35,17 +35,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
             rel="noopener noreferrer"
             target="_blank"
           >
-            Learn more 
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--small euiIcon-isLoading"
-              focusable="false"
-              height="16"
-              role="img"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            />
+            Learn more
             <svg
               aria-hidden="true"
               aria-label="External link"
@@ -105,17 +95,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon-isLoading"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  Learn more
                   <svg
                     aria-hidden="true"
                     aria-label="External link"
@@ -647,17 +627,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon-isLoading"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  Learn more
                   <svg
                     aria-hidden="true"
                     aria-label="External link"
@@ -914,17 +884,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        Learn more 
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoading"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        />
+                        Learn more
                         <svg
                           aria-hidden="true"
                           aria-label="External link"
@@ -1016,21 +976,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
             rel="noopener noreferrer"
             target="_blank"
           >
-            Learn more 
-            <svg
-              aria-hidden="true"
-              class="euiIcon euiIcon--small"
-              focusable="false"
-              height="16"
-              role="img"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-              />
-            </svg>
+            Learn more
             <svg
               aria-label="External link"
               class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1093,21 +1039,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
+                  Learn more
                   <svg
                     aria-label="External link"
                     class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1662,21 +1594,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
+                  Learn more
                   <svg
                     aria-label="External link"
                     class="euiIcon euiIcon--small euiLink__externalIcon"

--- a/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
+++ b/public/pages/Dashboard/Components/EmptyDashboard/EmptyDashboard.tsx
@@ -30,8 +30,7 @@ export class EmptyDashboard extends Component<{}, {}> {
             <p>
               Read about{' '}
               <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-                Get started with Anomaly detection &nbsp;
-                <EuiIcon size="s" type="popout" />
+                Get started with Anomaly detection
               </EuiLink>{' '}
             </p>
           </Fragment>

--- a/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
+++ b/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
@@ -34,17 +34,7 @@ exports[`<EmptyDetector /> spec Empty results renders component with empty messa
           rel="noopener noreferrer"
           target="_blank"
         >
-          Get started with Anomaly detection  
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--small euiIcon-isLoading"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
+          Get started with Anomaly detection
           <svg
             aria-hidden="true"
             aria-label="External link"

--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -56,7 +56,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
         >
           Store detector results to your own index.{' '}
           <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-            Learn more <EuiIcon size="s" type="popout" />
+            Learn more
           </EuiLink>
         </EuiText>
       }

--- a/public/pages/DefineDetector/components/Settings/Settings.tsx
+++ b/public/pages/DefineDetector/components/Settings/Settings.tsx
@@ -38,7 +38,7 @@ export const Settings = () => {
                 fullWidth
                 title="Detector interval"
                 hint={[
-                  `Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need.`
+                  `Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need.`,
                 ]}
                 hintLink={`${BASE_DOCS_LINK}/ad`}
                 isInvalid={isInvalid(field.name, form)}

--- a/public/pages/DefineDetector/components/Settings/__tests__/__snapshots__/Settings.test.tsx.snap
+++ b/public/pages/DefineDetector/components/Settings/__tests__/__snapshots__/Settings.test.tsx.snap
@@ -88,17 +88,7 @@ exports[`<Settings /> spec renders the component 1`] = `
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        Learn more 
-                        <svg
-                          aria-hidden="true"
-                          class="euiIcon euiIcon--small euiIcon-isLoading"
-                          focusable="false"
-                          height="16"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
-                          xmlns="http://www.w3.org/2000/svg"
-                        />
+                        Learn more
                         <svg
                           aria-hidden="true"
                           aria-label="External link"
@@ -202,17 +192,7 @@ exports[`<Settings /> spec renders the component 1`] = `
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small euiIcon-isLoading"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
+                    Learn more
                     <svg
                       aria-hidden="true"
                       aria-label="External link"

--- a/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
+++ b/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
@@ -660,17 +660,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                           rel="noopener noreferrer"
                           target="_blank"
                         >
-                          Learn more 
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--small euiIcon-isLoading"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
+                          Learn more
                           <svg
                             aria-hidden="true"
                             aria-label="External link"
@@ -774,17 +764,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      Learn more 
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--small euiIcon-isLoading"
-                        focusable="false"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      />
+                      Learn more
                       <svg
                         aria-hidden="true"
                         aria-label="External link"
@@ -901,17 +881,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon-isLoading"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  Learn more
                   <svg
                     aria-hidden="true"
                     aria-label="External link"
@@ -1658,21 +1628,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                           rel="noopener noreferrer"
                           target="_blank"
                         >
-                          Learn more 
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--small"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                            />
-                          </svg>
+                          Learn more
                           <svg
                             aria-label="External link"
                             class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1779,21 +1735,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      Learn more 
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--small"
-                        focusable="false"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                        />
-                      </svg>
+                      Learn more
                       <svg
                         aria-label="External link"
                         class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1913,21 +1855,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
+                  Learn more
                   <svg
                     aria-label="External link"
                     class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -2705,21 +2633,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                           rel="noopener noreferrer"
                           target="_blank"
                         >
-                          Learn more 
-                          <svg
-                            aria-hidden="true"
-                            class="euiIcon euiIcon--small"
-                            focusable="false"
-                            height="16"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                            />
-                          </svg>
+                          Learn more
                           <svg
                             aria-label="External link"
                             class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -2826,21 +2740,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      Learn more 
-                      <svg
-                        aria-hidden="true"
-                        class="euiIcon euiIcon--small"
-                        focusable="false"
-                        height="16"
-                        role="img"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                        />
-                      </svg>
+                      Learn more
                       <svg
                         aria-label="External link"
                         class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -2960,21 +2860,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                    />
-                  </svg>
+                  Learn more
                   <svg
                     aria-label="External link"
                     class="euiIcon euiIcon--small euiLink__externalIcon"

--- a/public/pages/DetectorDetail/components/MonitorCallout/MonitorCallout.tsx
+++ b/public/pages/DetectorDetail/components/MonitorCallout/MonitorCallout.tsx
@@ -31,7 +31,7 @@ export const MonitorCallout = (props: MonitorCalloutProps) => {
           href={`${getAlertingMonitorListLink()}/${props.monitorId}`}
           target="_blank"
         >
-          {props.monitorName} <EuiIcon type="popout" size="s" />
+          {props.monitorName}
         </EuiLink>{' '}
         associated with this detector will not receive any anomaly results to
         generate alerts.

--- a/public/pages/DetectorDetail/components/MonitorCallout/__tests__/__snapshots__/MonitorCallout.test.tsx.snap
+++ b/public/pages/DetectorDetail/components/MonitorCallout/__tests__/__snapshots__/MonitorCallout.test.tsx.snap
@@ -39,17 +39,6 @@ exports[`<MonitorCallout /> spec Monitor callout renders component 1`] = `
           target="_blank"
         >
           test-monitor
-           
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--small euiIcon-isLoading"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
           <svg
             aria-hidden="true"
             aria-label="External link"

--- a/public/pages/DetectorJobs/components/HistoricalJob/HistoricalJob.tsx
+++ b/public/pages/DetectorJobs/components/HistoricalJob/HistoricalJob.tsx
@@ -54,7 +54,7 @@ export function HistoricalJob(props: HistoricalJobProps) {
           learning models over long historical data windows (weeks or months).
           You can identify anomaly patterns, seasonality, and trends.{' '}
           <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-            Learn more <EuiIcon size="s" type="popout" />
+            Learn more
           </EuiLink>
         </EuiText>
       }

--- a/public/pages/DetectorJobs/components/HistoricalJob/__tests__/__snapshots__/HistoricalJob.test.tsx.snap
+++ b/public/pages/DetectorJobs/components/HistoricalJob/__tests__/__snapshots__/HistoricalJob.test.tsx.snap
@@ -38,17 +38,7 @@ exports[`<HistoricalJob /> spec renders the component 1`] = `
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                Learn more 
-                <svg
-                  aria-hidden="true"
-                  class="euiIcon euiIcon--small euiIcon-isLoading"
-                  focusable="false"
-                  height="16"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                />
+                Learn more
                 <svg
                   aria-hidden="true"
                   aria-label="External link"

--- a/public/pages/DetectorJobs/components/RealTimeJob/RealTimeJob.tsx
+++ b/public/pages/DetectorJobs/components/RealTimeJob/RealTimeJob.tsx
@@ -47,7 +47,7 @@ export function RealTimeJob(props: RealTimeJobProps) {
           changes. The earlier the detector starts running, the sooner the
           real-time anomalies will be available.{' '}
           <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-            Learn more <EuiIcon size="s" type="popout" />
+            Learn more
           </EuiLink>
         </EuiText>
       }

--- a/public/pages/DetectorJobs/components/RealTimeJob/__tests__/__snapshots__/RealTimeJob.test.tsx.snap
+++ b/public/pages/DetectorJobs/components/RealTimeJob/__tests__/__snapshots__/RealTimeJob.test.tsx.snap
@@ -38,17 +38,7 @@ exports[`<RealTimeJob /> spec renders the component 1`] = `
                 rel="noopener noreferrer"
                 target="_blank"
               >
-                Learn more 
-                <svg
-                  aria-hidden="true"
-                  class="euiIcon euiIcon--small euiIcon-isLoading"
-                  focusable="false"
-                  height="16"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                />
+                Learn more
                 <svg
                   aria-hidden="true"
                   aria-label="External link"

--- a/public/pages/DetectorJobs/containers/__tests__/__snapshots__/DetectorJobs.test.tsx.snap
+++ b/public/pages/DetectorJobs/containers/__tests__/__snapshots__/DetectorJobs.test.tsx.snap
@@ -58,17 +58,7 @@ exports[`<DetectorJobs /> spec configuring detector jobs renders the component 1
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon-isLoading"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  Learn more
                   <svg
                     aria-hidden="true"
                     aria-label="External link"
@@ -174,17 +164,7 @@ exports[`<DetectorJobs /> spec configuring detector jobs renders the component 1
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Learn more 
-                  <svg
-                    aria-hidden="true"
-                    class="euiIcon euiIcon--small euiIcon-isLoading"
-                    focusable="false"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  />
+                  Learn more
                   <svg
                     aria-hidden="true"
                     aria-label="External link"

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -209,24 +209,26 @@ export function AnomalyResults(props: AnomalyResultsProps) {
     let windowDelayInMinutes = 0;
     if (detector.windowDelay !== undefined) {
       const windowDelay = detector.windowDelay.period;
-      const windowDelayUnit = get(windowDelay, 'unit',  UNITS.MINUTES);
+      const windowDelayUnit = get(windowDelay, 'unit', UNITS.MINUTES);
 
       // current time minus window delay
-      const windowDelayInterval = get(windowDelay, 'interval',  0);
-      windowDelayInMinutes = windowDelayInterval * toDuration(windowDelayUnit).asMinutes();
+      const windowDelayInterval = get(windowDelay, 'interval', 0);
+      windowDelayInMinutes =
+        windowDelayInterval * toDuration(windowDelayUnit).asMinutes();
     }
 
     // The query in this function uses data start/end time. So we should consider window delay
     let adjustedCurrentTime = moment().subtract(
       windowDelayInMinutes,
       'minutes'
-    );;
+    );
 
     // check from FEATURE_DATA_POINTS_WINDOW + FEATURE_DATA_CHECK_WINDOW_OFFSET (currently 5) intervals to now
     const featureDataPointsRange = {
       startDate: Math.max(
         // clone since subtract mutates the original moment that we need to use as endData later
-        adjustedCurrentTime.clone()
+        adjustedCurrentTime
+          .clone()
           .subtract(
             (FEATURE_DATA_POINTS_WINDOW + FEATURE_DATA_CHECK_WINDOW_OFFSET) *
               detectorIntervalInMin,

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/utils/helpers.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/utils/helpers.tsx
@@ -27,7 +27,7 @@ const getNames = (detectors: DetectorListItem[]) => {
           href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
           target="_blank"
         >
-          {detectors[i].name} <EuiIcon type="popout" size="s" />
+          {detectors[i].name} />
         </EuiLink>
       ),
     });
@@ -49,7 +49,7 @@ const getNamesAndMonitors = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} <EuiIcon type="popout" size="s" />
+            {detectors[i].name} />
           </EuiLink>
         ),
         Monitor: (
@@ -57,7 +57,7 @@ const getNamesAndMonitors = (
             href={`${getAlertingMonitorListLink()}/${relatedMonitor.id}`}
             target="_blank"
           >
-            {relatedMonitor.name} <EuiIcon type="popout" size="s" />
+            {relatedMonitor.name} />
           </EuiLink>
         ),
       });
@@ -68,7 +68,7 @@ const getNamesAndMonitors = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} <EuiIcon type="popout" size="s" />
+            {detectors[i].name} />
           </EuiLink>
         ),
         Monitor: '-',
@@ -95,7 +95,7 @@ const getNamesAndMonitorsAndStates = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} <EuiIcon type="popout" size="s" />
+            {detectors[i].name} />
           </EuiLink>
         ),
         Monitor: (
@@ -103,7 +103,7 @@ const getNamesAndMonitorsAndStates = (
             href={`${getAlertingMonitorListLink()}/${relatedMonitor.id}`}
             target="_blank"
           >
-            {relatedMonitor.name} <EuiIcon type="popout" size="s" />
+            {relatedMonitor.name} />
           </EuiLink>
         ),
         Running: <EuiText>{isRunning ? 'Yes' : 'No'}</EuiText>,
@@ -115,7 +115,7 @@ const getNamesAndMonitorsAndStates = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} <EuiIcon type="popout" size="s" />
+            {detectors[i].name}
           </EuiLink>
         ),
         Monitor: '-',

--- a/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/EmptyHistoricalDetectorResults.tsx
+++ b/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/EmptyHistoricalDetectorResults.tsx
@@ -55,8 +55,7 @@ export const EmptyHistoricalDetectorResults = (
               href={`${BASE_DOCS_LINK}/ad/index/#step-6-analyze-historical-data`}
               target="_blank"
             >
-              Learn more &nbsp;
-              <EuiIcon size="s" type="popout" />
+              Learn more
             </EuiLink>{' '}
           </p>
         </Fragment>

--- a/public/pages/HistoricalDetectorResults/components/__tests__/__snapshots__/EmptyHistoricalDetectorResults.test.tsx.snap
+++ b/public/pages/HistoricalDetectorResults/components/__tests__/__snapshots__/EmptyHistoricalDetectorResults.test.tsx.snap
@@ -28,17 +28,7 @@ exports[`<EmptyHistoricalDetectorResults /> spec renders component 1`] = `
           rel="noopener noreferrer"
           target="_blank"
         >
-          Learn more  
-          <svg
-            aria-hidden="true"
-            class="euiIcon euiIcon--small euiIcon-isLoading"
-            focusable="false"
-            height="16"
-            role="img"
-            viewBox="0 0 16 16"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          />
+          Learn more
           <svg
             aria-hidden="true"
             aria-label="External link"

--- a/public/pages/Overview/components/CreateWorkflowStepDetails.tsx
+++ b/public/pages/Overview/components/CreateWorkflowStepDetails.tsx
@@ -37,7 +37,7 @@ export const CreateWorkflowStepDetails = (
           <EuiText style={{ fontSize: '14px' }}>
             {props.content}{' '}
             <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-              Learn more <EuiIcon size="s" type="popout" />
+              Learn more
             </EuiLink>
           </EuiText>
         </EuiFlexItem>

--- a/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
+++ b/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
@@ -203,7 +203,7 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
         The anomaly detection plugin automatically detects anomalies in your
         data in near real-time using the Random Cut Forest (RCF) algorithm.{' '}
         <EuiLink href={`${BASE_DOCS_LINK}/ad`} target="_blank">
-          Learn more <EuiIcon size="s" type="popout" />
+          Learn more
         </EuiLink>
       </EuiText>
       <EuiSpacer size="xl" />

--- a/public/pages/Overview/containers/__tests__/__snapshots__/AnomalyDetectionOverview.test.tsx.snap
+++ b/public/pages/Overview/containers/__tests__/__snapshots__/AnomalyDetectionOverview.test.tsx.snap
@@ -51,17 +51,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
       rel="noopener noreferrer"
       target="_blank"
     >
-      Learn more 
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--small euiIcon-isLoading"
-        focusable="false"
-        height="16"
-        role="img"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      />
+      Learn more
       <svg
         aria-hidden="true"
         aria-label="External link"
@@ -164,17 +154,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small euiIcon-isLoading"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
+                    Learn more
                     <svg
                       aria-hidden="true"
                       aria-label="External link"
@@ -236,17 +216,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small euiIcon-isLoading"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
+                    Learn more
                     <svg
                       aria-hidden="true"
                       aria-label="External link"
@@ -308,17 +278,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small euiIcon-isLoading"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
+                    Learn more
                     <svg
                       aria-hidden="true"
                       aria-label="External link"
@@ -380,17 +340,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small euiIcon-isLoading"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    />
+                    Learn more
                     <svg
                       aria-hidden="true"
                       aria-label="External link"
@@ -830,21 +780,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
       rel="noopener noreferrer"
       target="_blank"
     >
-      Learn more 
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--small"
-        focusable="false"
-        height="16"
-        role="img"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-        />
-      </svg>
+      Learn more
       <svg
         aria-label="External link"
         class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -950,21 +886,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1029,21 +951,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1108,21 +1016,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1187,21 +1081,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1656,21 +1536,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
       rel="noopener noreferrer"
       target="_blank"
     >
-      Learn more 
-      <svg
-        aria-hidden="true"
-        class="euiIcon euiIcon--small"
-        focusable="false"
-        height="16"
-        role="img"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-        />
-      </svg>
+      Learn more
       <svg
         aria-label="External link"
         class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1776,21 +1642,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1855,21 +1707,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -1934,21 +1772,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"
@@ -2013,21 +1837,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    Learn more 
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--small"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M13 8.5a.5.5 0 111 0V12a2 2 0 01-2 2H4a2 2 0 01-2-2V4a2 2 0 012-2h3.5a.5.5 0 010 1H4a1 1 0 00-1 1v8a1 1 0 001 1h8a1 1 0 001-1V8.5zm-5.12.339a.5.5 0 11-.706-.707L13.305 2H10.5a.5.5 0 110-1H14a1 1 0 011 1v3.5a.5.5 0 11-1 0V2.72L7.88 8.838z"
-                      />
-                    </svg>
+                    Learn more
                     <svg
                       aria-label="External link"
                       class="euiIcon euiIcon--small euiLink__externalIcon"

--- a/public/pages/utils/__tests__/anomalyResultUtils.test.ts
+++ b/public/pages/utils/__tests__/anomalyResultUtils.test.ts
@@ -9,307 +9,558 @@
  * GitHub history for details.
  */
 
-import { getFeatureMissingDataAnnotations, getFeatureDataPointsForDetector } from '../anomalyResultUtils';
-import { getRandomDetector } from '../../../redux/reducers/__tests__/utils';
 import {
-    UNITS,
-    Detector,
-    FeatureAttributes
-  } from '../../../models/interfaces';
+  getFeatureMissingDataAnnotations,
+  getFeatureDataPointsForDetector,
+} from '../anomalyResultUtils';
+import { getRandomDetector } from '../../../redux/reducers/__tests__/utils';
+import { UNITS, Detector, FeatureAttributes } from '../../../models/interfaces';
 
 describe('anomalyResultUtils', () => {
-    let randomDetector_20_min : Detector;
-    let randomDetector_20_sec : Detector;
-    let feature_id = 'deny_max';
-    beforeAll(() => {
-        randomDetector_20_min = {
-            ...getRandomDetector(true),
-            detectionInterval: {
-                period: {
-                  interval: 1,
-                  unit: UNITS.MINUTES,
-                },
-              },
-            windowDelay: {
-                period: {
-                  interval: 20,
-                  unit: UNITS.MINUTES,
-                },
-              },
-              featureAttributes: [
-                {
-                  featureId: feature_id,
-                  featureName: feature_id,
-                  featureEnabled: true,
-                },
-              ] as FeatureAttributes[],
-          };
+  let randomDetector_20_min: Detector;
+  let randomDetector_20_sec: Detector;
+  let feature_id = 'deny_max';
+  beforeAll(() => {
+    randomDetector_20_min = {
+      ...getRandomDetector(true),
+      detectionInterval: {
+        period: {
+          interval: 1,
+          unit: UNITS.MINUTES,
+        },
+      },
+      windowDelay: {
+        period: {
+          interval: 20,
+          unit: UNITS.MINUTES,
+        },
+      },
+      featureAttributes: [
+        {
+          featureId: feature_id,
+          featureName: feature_id,
+          featureEnabled: true,
+        },
+      ] as FeatureAttributes[],
+    };
 
-          randomDetector_20_sec= {
-            ...getRandomDetector(true),
-            detectionInterval: {
-                period: {
-                  interval: 1,
-                  unit: UNITS.MINUTES,
-                },
+    randomDetector_20_sec = {
+      ...getRandomDetector(true),
+      detectionInterval: {
+        period: {
+          interval: 1,
+          unit: UNITS.MINUTES,
+        },
+      },
+      windowDelay: {
+        period: {
+          interval: 20,
+          unit: UNITS.SECONDS,
+        },
+      },
+      featureAttributes: [
+        {
+          featureId: feature_id,
+          featureName: feature_id,
+          featureEnabled: true,
+        },
+      ] as FeatureAttributes[],
+    };
+  });
+  describe('getFeatureDataPointsForDetector', () => {
+    test('returns no missing data with 20 minute window delay', () => {
+      expect(
+        getFeatureDataPointsForDetector(
+          randomDetector_20_min,
+          {
+            deny_max: [
+              {
+                startTime: 1655253197686,
+                endTime: 1655253257686,
+                plotTime: 1655253257686,
+                data: 13451,
               },
-            windowDelay: {
-                period: {
-                  interval: 20,
-                  unit: UNITS.SECONDS,
-                },
+              {
+                startTime: 1655253137689,
+                endTime: 1655253197689,
+                plotTime: 1655253197689,
+                data: 10973,
               },
-              featureAttributes: [
-                {
-                  featureId: feature_id,
-                  featureName: feature_id,
-                  featureEnabled: true,
-                },
-              ] as FeatureAttributes[],
-          };
+              {
+                startTime: 1655253077698,
+                endTime: 1655253137698,
+                plotTime: 1655253137698,
+                data: 11777,
+              },
+              {
+                startTime: 1655253017690,
+                endTime: 1655253077690,
+                plotTime: 1655253077690,
+                data: 21588,
+              },
+            ],
+          },
+          randomDetector_20_min.detectionInterval.period.interval,
+          {
+            startDate: 1655252995079,
+            endDate: 1655253295079,
+          },
+          true
+        )
+      ).toEqual({
+        deny_max: [
+          {
+            isMissing: false,
+            plotTime: 1655253060000,
+            startTime: 1655253000000,
+            endTime: 1655253060000,
+          },
+          {
+            isMissing: false,
+            plotTime: 1655253120000,
+            startTime: 1655253060000,
+            endTime: 1655253120000,
+          },
+          {
+            isMissing: false,
+            plotTime: 1655253180000,
+            startTime: 1655253120000,
+            endTime: 1655253180000,
+          },
+        ],
+      });
     });
-    describe('getFeatureDataPointsForDetector', () => {
-        test('returns no missing data with 20 minute window delay', () => {
-            expect(
-              getFeatureDataPointsForDetector(
-                  randomDetector_20_min,
-                  {
-                      "deny_max":
-                      [
-                          {"startTime":1655253197686,"endTime":1655253257686,"plotTime":1655253257686,"data":13451},
-                          {"startTime":1655253137689,"endTime":1655253197689,"plotTime":1655253197689,"data":10973},
-                          {"startTime":1655253077698,"endTime":1655253137698,"plotTime":1655253137698,"data":11777},
-                          {"startTime":1655253017690,"endTime":1655253077690,"plotTime":1655253077690,"data":21588}
-                      ]
-                  },
-                  randomDetector_20_min.detectionInterval.period.interval,
-                  {
-                      startDate: 1655252995079,
-                      endDate: 1655253295079
-                  },
-                  true
-              )
-            ).toEqual(
-                {
-                    "deny_max":
-                    [
-                        {"isMissing":false,"plotTime":1655253060000,"startTime":1655253000000,"endTime":1655253060000},
-                        {"isMissing":false,"plotTime":1655253120000,"startTime":1655253060000,"endTime":1655253120000},
-                        {"isMissing":false,"plotTime":1655253180000,"startTime":1655253120000,"endTime":1655253180000}
-                    ]
-                });
-          });
-          test('returns missing data with 20 minute window delay', () => {
-              expect(
-                  getFeatureDataPointsForDetector(
-                      randomDetector_20_min,
-                      {
-                          feature_id:[
-                          ]
-                      },
-                      randomDetector_20_min.detectionInterval.period.interval,
-                      {
-                          startDate: 1655252995079,
-                          endDate: 1655253295079
-                      },
-                      true
-                  )
-                ).toEqual(
-                    {
-                        "deny_max":
-                        [
-                            {"isMissing":true,"plotTime":1655253060000,"startTime":1655253000000,"endTime":1655253060000},
-                            {"isMissing":true,"plotTime":1655253120000,"startTime":1655253060000,"endTime":1655253120000},
-                            {"isMissing":true,"plotTime":1655253180000,"startTime":1655253120000,"endTime":1655253180000}
-                        ]
-                    });
-          });
-          test('returns missing data with 20 seconds window delay', () => {
-              expect(
-                getFeatureDataPointsForDetector(
-                    randomDetector_20_sec,
-                    {
-                        "deny_max":[
-                            {"startTime":1655245177235,"endTime":1655245237235,"plotTime":1655245237235,"data":14719},
-                            {"startTime":1655245117232,"endTime":1655245177232,"plotTime":1655245177232,"data":14476}]
-                          },
-                    randomDetector_20_sec.detectionInterval.period.interval,
-                    {
-                        startDate: 1655244944254,
-                        endDate: 1655245244254
-                    },
-                    true
-                )
-              ).toEqual(
-                    {
-                      "deny_max":[
-                          {"isMissing":true,"plotTime":1655245020000,"startTime":1655244960000,"endTime":1655245020000},
-                          {"isMissing":true,"plotTime":1655245080000,"startTime":1655245020000,"endTime":1655245080000},
-                          {"isMissing":true,"plotTime":1655245140000,"startTime":1655245080000,"endTime":1655245140000}
-                      ]
-                    }
-                  );
-            });
-            test('returns partially missing data with 20 seconds window delay', () => {
-              expect(
-                  getFeatureDataPointsForDetector(
-                      randomDetector_20_sec,
-                      {
-                          "deny_max":[
-                              {"startTime":1655245357224,"endTime":1655245417224,"plotTime":1655245417224,"data":8675},
-                              {"startTime":1655245297232,"endTime":1655245357232,"plotTime":1655245357232,"data":9397},
-                              {"startTime":1655245237231,"endTime":1655245297231,"plotTime":1655245297231,"data":12102},
-                              {"startTime":1655245177235,"endTime":1655245237235,"plotTime":1655245237235,"data":14719}]
-                      },
-                      randomDetector_20_sec.detectionInterval.period.interval,
-                      {
-                          startDate: 1655245124258,
-                          endDate: 1655245424258
-                      },
-                      true
-                  )
-                ).toEqual(
-                      {
-                          "deny_max":[
-                              {"isMissing":true,"plotTime":1655245200000,"startTime":1655245140000,"endTime":1655245200000},
-                              {"isMissing":false,"plotTime":1655245260000,"startTime":1655245200000,"endTime":1655245260000},
-                              {"isMissing":false,"plotTime":1655245320000,"startTime":1655245260000,"endTime":1655245320000}]
-                      }
-                    );
-            });
+    test('returns missing data with 20 minute window delay', () => {
+      expect(
+        getFeatureDataPointsForDetector(
+          randomDetector_20_min,
+          {
+            feature_id: [],
+          },
+          randomDetector_20_min.detectionInterval.period.interval,
+          {
+            startDate: 1655252995079,
+            endDate: 1655253295079,
+          },
+          true
+        )
+      ).toEqual({
+        deny_max: [
+          {
+            isMissing: true,
+            plotTime: 1655253060000,
+            startTime: 1655253000000,
+            endTime: 1655253060000,
+          },
+          {
+            isMissing: true,
+            plotTime: 1655253120000,
+            startTime: 1655253060000,
+            endTime: 1655253120000,
+          },
+          {
+            isMissing: true,
+            plotTime: 1655253180000,
+            startTime: 1655253120000,
+            endTime: 1655253180000,
+          },
+        ],
+      });
     });
-    describe('getFeatureMissingDataAnnotations', () => {
-        test('returns missing data annotation with 20 seconds window delay', () => {
-            expect(
-                getFeatureMissingDataAnnotations(
-                    [
-                        {"startTime":1654731937236,"endTime":1654731997236,"plotTime":1654731997236,"data":9998},
-                        {"startTime":1654731877250,"endTime":1654731937250,"plotTime":1654731937250,"data":14841},
-                        {"startTime":1654731817236,"endTime":1654731877236,"plotTime":1654731877236,"data":6777},
-                        {"startTime":1654731757234,"endTime":1654731817234,"plotTime":1654731817234,"data":15443},
-                        {"startTime":1654731697230,"endTime":1654731757230,"plotTime":1654731757230,"data":9612},
-                        {"startTime":1654731637234,"endTime":1654731697234,"plotTime":1654731697234,"data":13992},
-                        {"startTime":1654731577232,"endTime":1654731637232,"plotTime":1654731637232,"data":10522},
-                        {"startTime":1654731517232,"endTime":1654731577232,"plotTime":1654731577232,"data":10945}
-                    ],
-                    randomDetector_20_sec.detectionInterval.period.interval,
-                    randomDetector_20_sec.windowDelay.period,
-                    {
-                        startDate: 1654731477228,
-                        endDate: 1654731697232
-                    },
-                    {
-                        startDate: 1654731477228,
-                        endDate: 1654731697232
-                    },
-                    false
-                )
-            ).toEqual(
-                [
-                    // our tests use UTC time zone. But in real application, it is local time.
-                    {
-                        "dataValue":1654731540000,
-                        "details":"There is feature data point missing between 06/08/22 11:38 PM and 06/08/22 11:39 PM",
-                        "header":"06/08/22 11:39:00 PM"
-                    }
-                ]
-            );
-        });
-        test('returns no missing data annotation with 20 seconds window delay', () => {
-            expect(
-                getFeatureMissingDataAnnotations(
-                    [
-                        {"startTime":1655249917234,"endTime":1655249977234,"plotTime":1655249977234,"data":8326},
-                        {"startTime":1655249857233,"endTime":1655249917233,"plotTime":1655249917233,"data":10953},
-                        {"startTime":1655249797235,"endTime":1655249857235,"plotTime":1655249857235,"data":14106},
-                        {"startTime":1655249737234,"endTime":1655249797234,"plotTime":1655249797234,"data":15453},
-                        {"startTime":1655249677234,"endTime":1655249737234,"plotTime":1655249737234,"data":8721},
-                        {"startTime":1655249617233,"endTime":1655249677233,"plotTime":1655249677233,"data":8606},
-                        {"startTime":1655249557233,"endTime":1655249617233,"plotTime":1655249617233,"data":8996},
-                        {"startTime":1655249497232,"endTime":1655249557232,"plotTime":1655249557232,"data":10809},
-                        {"startTime":1655249437230,"endTime":1655249497230,"plotTime":1655249497230,"data":5445}
-                    ],
-                    randomDetector_20_sec.detectionInterval.period.interval,
-                    randomDetector_20_sec.windowDelay.period,
-                    {
-                        startDate: 1655249857234,
-                        endDate: 1655250031633
-                    },
-                    {
-                        startDate: 1655249857234,
-                        endDate: 1655250031633
-                    },
-                    false
-                )
-            ).toEqual(
-                []
-            );
-        });
-        test('returns missing data annotation with 20 minutes window delay', () => {
-            expect(
-                getFeatureMissingDataAnnotations(
-                    // timestamps in descending order
-                    [
-                        {"startTime":1654652417693,"endTime":1654652477693,"plotTime":1654652477693,"data":9050},
-                        {"startTime":1654652357688,"endTime":1654652417688,"plotTime":1654652417688,"data":13895},
-                        {"startTime":1654652297691,"endTime":1654652357691,"plotTime":1654652357691,"data":11362},
-                        {"startTime":1654652237690,"endTime":1654652297690,"plotTime":1654652297690,"data":13253},
-                        {"startTime":1654652177690,"endTime":1654652237690,"plotTime":1654652237690,"data":15658},
-                        {"startTime":1654652117689,"endTime":1654652177689,"plotTime":1654652177689,"data":10015},
-                        {"startTime":1654652057688,"endTime":1654652117688,"plotTime":1654652117688,"data":12291}
-                    ],
-                    randomDetector_20_min.detectionInterval.period.interval,
-                    randomDetector_20_min.windowDelay.period,
-                    {
-                        startDate: 1654651997688,
-                        endDate: 1654653617693
-                    },
-                    {
-                        startDate: 1654651997688,
-                        endDate: 1654653617693
-                    },
-                    false
-                )
-            ).toEqual(
-                // our tests use UTC time zone. But in real application, it is local time.
-                [
-                    {
-                        "dataValue":1654652040000,
-                        "details":"There is feature data point missing between 06/08/22 1:33 AM and 06/08/22 1:34 AM",
-                        "header":"06/08/22 01:34:00 AM"
-                    }
-                ]
-            );
-        });
-        test('returns no missing data annotation with 20 minutes window delay', () => {
-            expect(
-                getFeatureMissingDataAnnotations(
-                    [
-                        {"startTime":1655250437690,"endTime":1655250497690,"plotTime":1655250497690,"data":13888},
-                        {"startTime":1655250377688,"endTime":1655250437688,"plotTime":1655250437688,"data":8246},
-                        {"startTime":1655250317687,"endTime":1655250377687,"plotTime":1655250377687,"data":16812},
-                        {"startTime":1655250257691,"endTime":1655250317691,"plotTime":1655250317691,"data":9834},
-                        {"startTime":1655250197688,"endTime":1655250257688,"plotTime":1655250257688,"data":12409},
-                        {"startTime":1655250137686,"endTime":1655250197686,"plotTime":1655250197686,"data":14615},
-                        {"startTime":1655250077703,"endTime":1655250137703,"plotTime":1655250137703,"data":8377}
-                    ],
-                    randomDetector_20_min.detectionInterval.period.interval,
-                    randomDetector_20_min.windowDelay.period,
-                    {
-                        startDate: 1655250377690,
-                        endDate: 1655251724454
-                    },
-                    {
-                        startDate: 1655250377690,
-                        endDate: 1655251724454
-                    },
-                    false
-                )
-            ).toEqual(
-                []
-            );
-        });
+    test('returns missing data with 20 seconds window delay', () => {
+      expect(
+        getFeatureDataPointsForDetector(
+          randomDetector_20_sec,
+          {
+            deny_max: [
+              {
+                startTime: 1655245177235,
+                endTime: 1655245237235,
+                plotTime: 1655245237235,
+                data: 14719,
+              },
+              {
+                startTime: 1655245117232,
+                endTime: 1655245177232,
+                plotTime: 1655245177232,
+                data: 14476,
+              },
+            ],
+          },
+          randomDetector_20_sec.detectionInterval.period.interval,
+          {
+            startDate: 1655244944254,
+            endDate: 1655245244254,
+          },
+          true
+        )
+      ).toEqual({
+        deny_max: [
+          {
+            isMissing: true,
+            plotTime: 1655245020000,
+            startTime: 1655244960000,
+            endTime: 1655245020000,
+          },
+          {
+            isMissing: true,
+            plotTime: 1655245080000,
+            startTime: 1655245020000,
+            endTime: 1655245080000,
+          },
+          {
+            isMissing: true,
+            plotTime: 1655245140000,
+            startTime: 1655245080000,
+            endTime: 1655245140000,
+          },
+        ],
+      });
     });
-    
-      
+    test('returns partially missing data with 20 seconds window delay', () => {
+      expect(
+        getFeatureDataPointsForDetector(
+          randomDetector_20_sec,
+          {
+            deny_max: [
+              {
+                startTime: 1655245357224,
+                endTime: 1655245417224,
+                plotTime: 1655245417224,
+                data: 8675,
+              },
+              {
+                startTime: 1655245297232,
+                endTime: 1655245357232,
+                plotTime: 1655245357232,
+                data: 9397,
+              },
+              {
+                startTime: 1655245237231,
+                endTime: 1655245297231,
+                plotTime: 1655245297231,
+                data: 12102,
+              },
+              {
+                startTime: 1655245177235,
+                endTime: 1655245237235,
+                plotTime: 1655245237235,
+                data: 14719,
+              },
+            ],
+          },
+          randomDetector_20_sec.detectionInterval.period.interval,
+          {
+            startDate: 1655245124258,
+            endDate: 1655245424258,
+          },
+          true
+        )
+      ).toEqual({
+        deny_max: [
+          {
+            isMissing: true,
+            plotTime: 1655245200000,
+            startTime: 1655245140000,
+            endTime: 1655245200000,
+          },
+          {
+            isMissing: false,
+            plotTime: 1655245260000,
+            startTime: 1655245200000,
+            endTime: 1655245260000,
+          },
+          {
+            isMissing: false,
+            plotTime: 1655245320000,
+            startTime: 1655245260000,
+            endTime: 1655245320000,
+          },
+        ],
+      });
+    });
+  });
+  describe('getFeatureMissingDataAnnotations', () => {
+    test('returns missing data annotation with 20 seconds window delay', () => {
+      expect(
+        getFeatureMissingDataAnnotations(
+          [
+            {
+              startTime: 1654731937236,
+              endTime: 1654731997236,
+              plotTime: 1654731997236,
+              data: 9998,
+            },
+            {
+              startTime: 1654731877250,
+              endTime: 1654731937250,
+              plotTime: 1654731937250,
+              data: 14841,
+            },
+            {
+              startTime: 1654731817236,
+              endTime: 1654731877236,
+              plotTime: 1654731877236,
+              data: 6777,
+            },
+            {
+              startTime: 1654731757234,
+              endTime: 1654731817234,
+              plotTime: 1654731817234,
+              data: 15443,
+            },
+            {
+              startTime: 1654731697230,
+              endTime: 1654731757230,
+              plotTime: 1654731757230,
+              data: 9612,
+            },
+            {
+              startTime: 1654731637234,
+              endTime: 1654731697234,
+              plotTime: 1654731697234,
+              data: 13992,
+            },
+            {
+              startTime: 1654731577232,
+              endTime: 1654731637232,
+              plotTime: 1654731637232,
+              data: 10522,
+            },
+            {
+              startTime: 1654731517232,
+              endTime: 1654731577232,
+              plotTime: 1654731577232,
+              data: 10945,
+            },
+          ],
+          randomDetector_20_sec.detectionInterval.period.interval,
+          randomDetector_20_sec.windowDelay.period,
+          {
+            startDate: 1654731477228,
+            endDate: 1654731697232,
+          },
+          {
+            startDate: 1654731477228,
+            endDate: 1654731697232,
+          },
+          false
+        )
+      ).toEqual([
+        // our tests use UTC time zone. But in real application, it is local time.
+        {
+          dataValue: 1654731540000,
+          details:
+            'There is feature data point missing between 06/08/22 11:38 PM and 06/08/22 11:39 PM',
+          header: '06/08/22 11:39:00 PM',
+        },
+      ]);
+    });
+    test('returns no missing data annotation with 20 seconds window delay', () => {
+      expect(
+        getFeatureMissingDataAnnotations(
+          [
+            {
+              startTime: 1655249917234,
+              endTime: 1655249977234,
+              plotTime: 1655249977234,
+              data: 8326,
+            },
+            {
+              startTime: 1655249857233,
+              endTime: 1655249917233,
+              plotTime: 1655249917233,
+              data: 10953,
+            },
+            {
+              startTime: 1655249797235,
+              endTime: 1655249857235,
+              plotTime: 1655249857235,
+              data: 14106,
+            },
+            {
+              startTime: 1655249737234,
+              endTime: 1655249797234,
+              plotTime: 1655249797234,
+              data: 15453,
+            },
+            {
+              startTime: 1655249677234,
+              endTime: 1655249737234,
+              plotTime: 1655249737234,
+              data: 8721,
+            },
+            {
+              startTime: 1655249617233,
+              endTime: 1655249677233,
+              plotTime: 1655249677233,
+              data: 8606,
+            },
+            {
+              startTime: 1655249557233,
+              endTime: 1655249617233,
+              plotTime: 1655249617233,
+              data: 8996,
+            },
+            {
+              startTime: 1655249497232,
+              endTime: 1655249557232,
+              plotTime: 1655249557232,
+              data: 10809,
+            },
+            {
+              startTime: 1655249437230,
+              endTime: 1655249497230,
+              plotTime: 1655249497230,
+              data: 5445,
+            },
+          ],
+          randomDetector_20_sec.detectionInterval.period.interval,
+          randomDetector_20_sec.windowDelay.period,
+          {
+            startDate: 1655249857234,
+            endDate: 1655250031633,
+          },
+          {
+            startDate: 1655249857234,
+            endDate: 1655250031633,
+          },
+          false
+        )
+      ).toEqual([]);
+    });
+    test('returns missing data annotation with 20 minutes window delay', () => {
+      expect(
+        getFeatureMissingDataAnnotations(
+          // timestamps in descending order
+          [
+            {
+              startTime: 1654652417693,
+              endTime: 1654652477693,
+              plotTime: 1654652477693,
+              data: 9050,
+            },
+            {
+              startTime: 1654652357688,
+              endTime: 1654652417688,
+              plotTime: 1654652417688,
+              data: 13895,
+            },
+            {
+              startTime: 1654652297691,
+              endTime: 1654652357691,
+              plotTime: 1654652357691,
+              data: 11362,
+            },
+            {
+              startTime: 1654652237690,
+              endTime: 1654652297690,
+              plotTime: 1654652297690,
+              data: 13253,
+            },
+            {
+              startTime: 1654652177690,
+              endTime: 1654652237690,
+              plotTime: 1654652237690,
+              data: 15658,
+            },
+            {
+              startTime: 1654652117689,
+              endTime: 1654652177689,
+              plotTime: 1654652177689,
+              data: 10015,
+            },
+            {
+              startTime: 1654652057688,
+              endTime: 1654652117688,
+              plotTime: 1654652117688,
+              data: 12291,
+            },
+          ],
+          randomDetector_20_min.detectionInterval.period.interval,
+          randomDetector_20_min.windowDelay.period,
+          {
+            startDate: 1654651997688,
+            endDate: 1654653617693,
+          },
+          {
+            startDate: 1654651997688,
+            endDate: 1654653617693,
+          },
+          false
+        )
+      ).toEqual(
+        // our tests use UTC time zone. But in real application, it is local time.
+        [
+          {
+            dataValue: 1654652040000,
+            details:
+              'There is feature data point missing between 06/08/22 1:33 AM and 06/08/22 1:34 AM',
+            header: '06/08/22 01:34:00 AM',
+          },
+        ]
+      );
+    });
+    test('returns no missing data annotation with 20 minutes window delay', () => {
+      expect(
+        getFeatureMissingDataAnnotations(
+          [
+            {
+              startTime: 1655250437690,
+              endTime: 1655250497690,
+              plotTime: 1655250497690,
+              data: 13888,
+            },
+            {
+              startTime: 1655250377688,
+              endTime: 1655250437688,
+              plotTime: 1655250437688,
+              data: 8246,
+            },
+            {
+              startTime: 1655250317687,
+              endTime: 1655250377687,
+              plotTime: 1655250377687,
+              data: 16812,
+            },
+            {
+              startTime: 1655250257691,
+              endTime: 1655250317691,
+              plotTime: 1655250317691,
+              data: 9834,
+            },
+            {
+              startTime: 1655250197688,
+              endTime: 1655250257688,
+              plotTime: 1655250257688,
+              data: 12409,
+            },
+            {
+              startTime: 1655250137686,
+              endTime: 1655250197686,
+              plotTime: 1655250197686,
+              data: 14615,
+            },
+            {
+              startTime: 1655250077703,
+              endTime: 1655250137703,
+              plotTime: 1655250137703,
+              data: 8377,
+            },
+          ],
+          randomDetector_20_min.detectionInterval.period.interval,
+          randomDetector_20_min.windowDelay.period,
+          {
+            startDate: 1655250377690,
+            endDate: 1655251724454,
+          },
+          {
+            startDate: 1655250377690,
+            endDate: 1655251724454,
+          },
+          false
+        )
+      ).toEqual([]);
+    });
+  });
 });

--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -46,7 +46,7 @@ import {
   FeatureAttributes,
   FeatureContributionData,
   MonitorAlert,
-  toDuration
+  toDuration,
 } from '../../models/interfaces';
 import { getDetectorLiveResults } from '../../redux/reducers/liveAnomalyResults';
 import {
@@ -73,9 +73,7 @@ import {
 } from './constants';
 import { dateFormatter, minuteDateFormatter } from './helpers';
 import { HeatmapCell } from '../AnomalyCharts/containers/AnomalyHeatmapChart';
-import {
-  Schedule, UNITS
-} from '../../models/interfaces'
+import { Schedule, UNITS } from '../../models/interfaces';
 
 export const getQueryParamsForLiveAnomalyResults = (
   detectionInterval: number,
@@ -377,7 +375,7 @@ export const RETURNED_AD_RESULT_FIELDS = [
   'feature_data',
   'entity',
   'relevant_attribution',
-  'expected_values'
+  'expected_values',
 ];
 
 export const getAnomalySummaryQuery = (
@@ -578,22 +576,35 @@ export const parseBucketizedAnomalyResults = (result: any): Anomalies => {
         get(rawAnomaly, 'anomaly_grade') !== undefined &&
         get(rawAnomaly, 'feature_data', []).length > 0
       ) {
-        const featureDataMap: {[key: string]: string} = {};
-        get(rawAnomaly, 'feature_data', []).filter(element => get(element, 'feature_id') && get(element, 'feature_name')).
-        forEach((feature: any) => {
-          featureDataMap[get(feature, 'feature_id')] = get(feature, 'feature_name');
-        });
-        const relevantAttributionMap: {[key: string]: number} = {};
-        get(rawAnomaly, 'relevant_attribution', []).filter(element => get(element, 'feature_id') && get(element, 'data')).
-        forEach((attribution: any) => {
-          relevantAttributionMap[get(attribution, 'feature_id')] = get(attribution, 'data');
-        });
-        const contributions: { [key: string]: FeatureContributionData } = {}
+        const featureDataMap: { [key: string]: string } = {};
+        get(rawAnomaly, 'feature_data', [])
+          .filter(
+            (element) =>
+              get(element, 'feature_id') && get(element, 'feature_name')
+          )
+          .forEach((feature: any) => {
+            featureDataMap[get(feature, 'feature_id')] = get(
+              feature,
+              'feature_name'
+            );
+          });
+        const relevantAttributionMap: { [key: string]: number } = {};
+        get(rawAnomaly, 'relevant_attribution', [])
+          .filter(
+            (element) => get(element, 'feature_id') && get(element, 'data')
+          )
+          .forEach((attribution: any) => {
+            relevantAttributionMap[get(attribution, 'feature_id')] = get(
+              attribution,
+              'data'
+            );
+          });
+        const contributions: { [key: string]: FeatureContributionData } = {};
         for (const [key] of Object.entries(featureDataMap)) {
           contributions[key] = {
             name: featureDataMap[key],
-            attribution: relevantAttributionMap[key]
-          }
+            attribution: relevantAttributionMap[key],
+          };
         }
         anomalies.push({
           anomalyGrade: toFixedNumberForAnomaly(
@@ -604,22 +615,30 @@ export const parseBucketizedAnomalyResults = (result: any): Anomalies => {
           endTime: get(rawAnomaly, 'data_end_time'),
           plotTime: get(rawAnomaly, 'data_end_time'),
           entity: get(rawAnomaly, 'entity'),
-          contributions: toFixedNumberForAnomaly(
-            get(rawAnomaly, 'anomaly_grade')
-          ) > 0 ? contributions : {}
+          contributions:
+            toFixedNumberForAnomaly(get(rawAnomaly, 'anomaly_grade')) > 0
+              ? contributions
+              : {},
         });
 
-        const featureBreakdownAttributionMap: {[key: string]: number} = {};
+        const featureBreakdownAttributionMap: { [key: string]: number } = {};
 
-        get(rawAnomaly, 'relevant_attribution', []).filter(element => get(element, 'feature_id') && get(element, 'data')).
-        forEach((attribution: any) => {
-          featureBreakdownAttributionMap[get(attribution, 'feature_id')] = toFixedNumberForAnomaly(get(attribution, 'data'));
-        });
-             
-        const expectedValueMap: {[key: string]: number} = {};
-        get(rawAnomaly, 'expected_values[0].value_list', []).forEach((expect: any) => {
-          expectedValueMap[get(expect, 'feature_id')] = toFixedNumberForAnomaly(get(expect, 'data'));
-        });
+        get(rawAnomaly, 'relevant_attribution', [])
+          .filter(
+            (element) => get(element, 'feature_id') && get(element, 'data')
+          )
+          .forEach((attribution: any) => {
+            featureBreakdownAttributionMap[get(attribution, 'feature_id')] =
+              toFixedNumberForAnomaly(get(attribution, 'data'));
+          });
+
+        const expectedValueMap: { [key: string]: number } = {};
+        get(rawAnomaly, 'expected_values[0].value_list', []).forEach(
+          (expect: any) => {
+            expectedValueMap[get(expect, 'feature_id')] =
+              toFixedNumberForAnomaly(get(expect, 'data'));
+          }
+        );
 
         get(rawAnomaly, 'feature_data', []).forEach((feature) => {
           if (!get(featureData, get(feature, 'feature_id'))) {
@@ -630,8 +649,9 @@ export const parseBucketizedAnomalyResults = (result: any): Anomalies => {
             startTime: get(rawAnomaly, 'data_start_time'),
             endTime: get(rawAnomaly, 'data_end_time'),
             plotTime: get(rawAnomaly, 'data_end_time'),
-            attribution: featureBreakdownAttributionMap[get(feature, 'feature_id')],
-            expectedValue: expectedValueMap[get(feature, 'feature_id')]
+            attribution:
+              featureBreakdownAttributionMap[get(feature, 'feature_id')],
+            expectedValue: expectedValueMap[get(feature, 'feature_id')],
           });
         });
       }
@@ -712,22 +732,31 @@ export const parsePureAnomalies = (
   if (anomaliesHits.length > 0) {
     anomaliesHits.forEach((item: any) => {
       const rawAnomaly = get(item, '_source');
-      const featureDataMap: {[key: string]: string} = {};
-      get(rawAnomaly, 'feature_data', []).filter(element => get(element, 'feature_id') && get(element, 'feature_name')).
-      forEach((feature: any) => {
-        featureDataMap[get(feature, 'feature_id')] = get(feature, 'feature_name');
-      });
-      const relevantAttributionMap: {[key: string]: number} = {};
-      get(rawAnomaly, 'relevant_attribution', []).filter(element => get(element, 'feature_id') && get(element, 'data')).
-      forEach((attribution: any) => {
-        relevantAttributionMap[get(attribution, 'feature_id')] = toFixedNumberForAnomaly(get(attribution, 'data'));
-      });
-      const contributions: { [key: string]: FeatureContributionData } = {}
+      const featureDataMap: { [key: string]: string } = {};
+      get(rawAnomaly, 'feature_data', [])
+        .filter(
+          (element) =>
+            get(element, 'feature_id') && get(element, 'feature_name')
+        )
+        .forEach((feature: any) => {
+          featureDataMap[get(feature, 'feature_id')] = get(
+            feature,
+            'feature_name'
+          );
+        });
+      const relevantAttributionMap: { [key: string]: number } = {};
+      get(rawAnomaly, 'relevant_attribution', [])
+        .filter((element) => get(element, 'feature_id') && get(element, 'data'))
+        .forEach((attribution: any) => {
+          relevantAttributionMap[get(attribution, 'feature_id')] =
+            toFixedNumberForAnomaly(get(attribution, 'data'));
+        });
+      const contributions: { [key: string]: FeatureContributionData } = {};
       for (const [key] of Object.entries(featureDataMap)) {
         contributions[key] = {
           name: featureDataMap[key],
-          attribution: relevantAttributionMap[key]
-        }
+          attribution: relevantAttributionMap[key],
+        };
       }
       anomalies.push({
         anomalyGrade: toFixedNumberForAnomaly(get(rawAnomaly, 'anomaly_grade')),
@@ -736,7 +765,7 @@ export const parsePureAnomalies = (
         endTime: get(rawAnomaly, 'data_end_time'),
         plotTime: get(rawAnomaly, 'data_end_time'),
         entity: get(rawAnomaly, 'entity'),
-        contributions: contributions
+        contributions: contributions,
       });
     });
   }
@@ -784,10 +813,11 @@ export const getFeatureDataPoints = (
   let windowDelayInMilliSecs = 0;
 
   if (!windowDelayAdjusted) {
-    let windowDelayUnit = get(windowDelay, 'unit',  UNITS.MINUTES);
+    let windowDelayUnit = get(windowDelay, 'unit', UNITS.MINUTES);
 
-    let windowDelayInterval = get(windowDelay, 'interval',  0);
-    windowDelayInMilliSecs = windowDelayInterval * toDuration(windowDelayUnit).asMilliseconds();
+    let windowDelayInterval = get(windowDelay, 'interval', 0);
+    windowDelayInMilliSecs =
+      windowDelayInterval * toDuration(windowDelayUnit).asMilliseconds();
   }
 
   for (
@@ -801,7 +831,8 @@ export const getFeatureDataPoints = (
     // If windowDelayAdjusted is true, windowDelayInMilliSecs is 0.
     getRoundedTimeInMin(
       dateRange.endDate -
-        FEATURE_DATA_CHECK_WINDOW_OFFSET * interval * MIN_IN_MILLI_SECS - windowDelayInMilliSecs
+        FEATURE_DATA_CHECK_WINDOW_OFFSET * interval * MIN_IN_MILLI_SECS -
+        windowDelayInMilliSecs
     );
     currentTime += interval * MIN_IN_MILLI_SECS
   ) {
@@ -986,7 +1017,7 @@ export const getFeatureMissingDataAnnotations = (
  * {
  *    'featureName': data points[]
  * }
- * 
+ *
  * @param detector Detector config
  * @param featureData Feature aggregation data array
  * @param interval Detector interval
@@ -1019,7 +1050,7 @@ export const getFeatureDataPointsForDetector = (
       featureData,
       interval,
       dateRange,
-      get(detector, `windowDelay.period`,  {
+      get(detector, `windowDelay.period`, {
         period: { interval: 0, unit: UNITS.MINUTES },
       }),
       windowDelayAdjusted

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -963,14 +963,16 @@ export default class AdService {
 
       const detectorResult: AnomalyResult[] = [];
       const featureResult: { [key: string]: FeatureResult[] } = {};
-      
+
       get(response, 'hits.hits', []).forEach((result: any) => {
         detectorResult.push({
           startTime: result._source.data_start_time,
           endTime: result._source.data_end_time,
           plotTime: result._source.data_end_time,
-          contributions: result._source.anomaly_grade > 0 
-            ? result._source.relevant_attribution : {},
+          contributions:
+            result._source.anomaly_grade > 0
+              ? result._source.relevant_attribution
+              : {},
           confidence:
             result._source.confidence != null &&
             result._source.confidence !== 'NaN' &&
@@ -995,7 +997,7 @@ export default class AdService {
           // to know feature data belongs to which anomaly result
           features: this.getFeatureData(result),
         });
-        
+
         result._source.feature_data.forEach((featureData: any) => {
           if (!featureResult[featureData.feature_id]) {
             featureResult[featureData.feature_id] = [];
@@ -1008,8 +1010,8 @@ export default class AdService {
               featureData.data != null && featureData.data !== 'NaN'
                 ? toFixedNumberForAnomaly(Number.parseFloat(featureData.data))
                 : 0,
-            name: featureData.feature_name, 
-            expectedValue: this.getExpectedValue(result, featureData)
+            name: featureData.feature_name,
+            expectedValue: this.getExpectedValue(result, featureData),
           });
         });
       });
@@ -1134,16 +1136,17 @@ export default class AdService {
             ? toFixedNumberForAnomaly(Number.parseFloat(featureData.data))
             : 0,
         name: featureData.feature_name,
-        expectedValue: this.getExpectedValue(rawResult, featureData)
+        expectedValue: this.getExpectedValue(rawResult, featureData),
       };
     });
     return featureResult;
   };
 
   getExpectedValue = (rawResult: any, featureData: any) => {
-    let expectedValue = featureData.data != null && featureData.data !== 'NaN' 
-    ? toFixedNumberForAnomaly(Number.parseFloat(featureData.data)) 
-    : 0;
+    let expectedValue =
+      featureData.data != null && featureData.data !== 'NaN'
+        ? toFixedNumberForAnomaly(Number.parseFloat(featureData.data))
+        : 0;
     if (rawResult._source.anomaly_grade > 0) {
       const expectedValueList = rawResult._source.expected_values;
       if (expectedValueList?.length > 0) {
@@ -1151,9 +1154,9 @@ export default class AdService {
           if (expect.feature_id === featureData.feature_id) {
             expectedValue = expect.data;
           }
-        })
+        });
       }
     }
-    return expectedValue
-  }
+    return expectedValue;
+  };
 }

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -43,5 +43,5 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/offline-module-cache/'],
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
   transformIgnorePatterns: ['<rootDir>/node_modules'],
-  globalSetup: "<rootDir>/global-setup.js",
+  globalSetup: '<rootDir>/global-setup.js',
 };


### PR DESCRIPTION
### Description

Removed additional popout icon on all external links with `target="_blank"`. According to EUI docs that automatically sets the link to external which adds the popout icon on its own https://eui.elastic.co/v34.6.0/#/navigation/link. I also tested this by running a cluster.

I also ran `yarn prettier --write ./` which is the reason for some of the unrelated formatting changes.

Even though AD main CI is working I was having problems running it locally so made the change to 2.x and will forward port (I also made an issue on opensearch-build for a potential forward-port bot https://github.com/opensearch-project/opensearch-build/issues/2978)


### Issues Resolved

#362 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
