### PR TITLE
Fix undefined entity list when heatmap is empty

### DIFF
--- a/public/pages/utils/anomalyResultUtils.ts
+++ b/public/pages/utils/anomalyResultUtils.ts
@@ -1767,10 +1767,17 @@ export const convertToCategoryFieldAndEntityString = (
       if (index > 0) {
         entityString += delimiter;
       }
+
+      // It is possible that entity.name is undefined when we artificially add
+      // whitespace strings as the entity values when the heatmap is empty (see
+      // getSampleAnomaliesHeatmapData())
+      // If true, set the entire string as 'None'
       entityString +=
-        entity.name +
-        `${HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER}` +
-        entity.value;
+        entity.name !== undefined
+          ? entity.name +
+            `${HEATMAP_CALL_ENTITY_KEY_VALUE_DELIMITER}` +
+            entity.value
+          : 'None';
     });
   }
   return entityString;


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

It is possible that entity.name is undefined when we artificially add whitespace strings as the entity values when the heatmap is empty (see [getSampleAnomaliesHeatmapData()](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx#L240-L248)). If true, set the entire string as 'None'

Confirmed populated entities still show as expected, and 'None' shows for empty charts.

Screenshots:
<img width="412" alt="Screen Shot 2023-01-04 at 10 17 44 AM" src="https://user-images.githubusercontent.com/62119629/210623069-66ed45f9-a96e-4d29-97ab-fbae8437c50d.png">

<img width="251" alt="Screen Shot 2023-01-04 at 10 16 39 AM" src="https://user-images.githubusercontent.com/62119629/210623132-817949bb-44d9-41be-8834-6d5921b96a3b.png">

### Issues Resolved

Closes #152 

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
