### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,8 @@
-# OpenSearch Anomaly Detection Dashboards Maintainers
+## Overview
 
-## Maintainers
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
 
 | Maintainer              | GitHub ID                                               | Affiliation |
 | ----------------------- | ------------------------------------------------------- | ----------- |
@@ -9,5 +11,3 @@
 | Yizhe Liu               | [yizheliu-amazon](https://github.com/yizheliu-amazon)   | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)                 | Amazon      |
 | Sarat Vemulapalli       | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
-
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.