### PR TITLE
Changed required minimum intervals in cold start message

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -66,6 +66,7 @@ import { detectorIsSample } from '../../Overview/utils/helpers';
 import { SampleIndexDetailsCallout } from '../../Overview/components/SampleIndexDetailsCallout/SampleIndexDetailsCallout';
 import { CoreStart } from '../../../../../../src/core/public';
 import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
+import { DEFAULT_SHINGLE_SIZE } from '../../../utils/constants';
 
 interface AnomalyResultsProps extends RouteComponentProps {
   detectorId: string;
@@ -313,7 +314,8 @@ export function AnomalyResults(props: AnomalyResultsProps) {
               <p>
                 Attempting to initialize the detector with historical data.
                 This initializing process takes approximately 1 minute if
-                 you have data in each of the last 40 consecutive intervals.
+                you have data in each of the last{' '}
+                {32+get(detector, 'shingleSize', DEFAULT_SHINGLE_SIZE)}{' '} consecutive intervals.
               </p>
             </EuiText>
           </EuiFlexGroup>


### PR DESCRIPTION
### Description

Required minimum intervals to finish cold start is related to shingle size. This PR adds the shingle size in the computation and puts the result in the cold start message.

Testing done:
1. verified changing shingle size will change the message.

![Screen Shot 2023-02-08 at 11 38 22 PM](https://user-images.githubusercontent.com/5303417/217870796-a246cc96-2bcd-4e5c-8216-2d10b9a950c2.png)


Signed-off-by: Kaituo Li <kaituo@amazon.com>

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
