### PR TITLE
Remove `auto_expand_replicas` override in sample data indices

### DIFF
--- a/public/pages/Overview/utils/constants.tsx
+++ b/public/pages/Overview/utils/constants.tsx
@@ -14,11 +14,10 @@ import moment from 'moment';
 import React from 'react';
 import { EuiIcon } from '@elastic/eui';
 
-// same as default OpenSearch Dashboards sample data
+// We don't need to specify auto_expand_replicas - use cluster defaults instead
 export const indexSettings = {
   index: {
     number_of_shards: 1,
-    auto_expand_replicas: '0-1',
   },
 };
 


### PR DESCRIPTION
### Description

Instead of setting an explicit value for how many sample index replicas should be created based on cluster configuration (number of nodes, number of awareness attributes/AZs, etc.), we can simplify this by consuming cluster defaults. Note that we were overriding the defaults with the default value anyways (`0-1`) so by default, there will be no change if users don't override the defaults to begin with

I've confirmed changes don't change functionality, sample indices and detectors still work as expected and are able to be created.

### Issues Resolved

Closes #417 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
