### PR TITLE
Adding expression function to retrieve anomalies 

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -3,12 +3,12 @@
   "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["anomaly_detection_dashboards"],
-  "requiredPlugins": ["navigation", 
+  "requiredPlugins": [
     "opensearchDashboardsUtils",
     "expressions",
-    "data"
+    "data",
+    "visAugmenter"
   ],
-  "optionalPlugins":[],  
   "server": true,
   "ui": true
 }

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -3,8 +3,12 @@
   "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["anomaly_detection_dashboards"],
-  "requiredPlugins": ["navigation"],
-  "optionalPlugins": [],
+  "requiredPlugins": ["navigation", 
+    "opensearchDashboardsUtils",
+    "expressions",
+    "data"
+  ],
+  "optionalPlugins":[],  
   "server": true,
   "ui": true
 }

--- a/public/expressions/constants.ts
+++ b/public/expressions/constants.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const ORIGIN_PLUGIN_VIS_LAYER = 'anomalyDetectionDashboards';
+
+// Defines the header used when categorizing and grouping the VisLayers on the view event flyout in OSD.
+export const VIS_LAYER_PLUGIN_TYPE = 'Anomaly Detectors';
+
+export const TYPE_OF_EXPR_VIS_LAYERS = 'vis_layers';

--- a/public/expressions/overlay_anomalies.ts
+++ b/public/expressions/overlay_anomalies.ts
@@ -1,0 +1,193 @@
+// /*
+//  * SPDX-License-Identifier: Apache-2.0
+//  *
+//  * The OpenSearch Contributors require contributions made to
+//  * this file be licensed under the Apache-2.0 license or a
+//  * compatible open source license.
+//  *
+//  * Any modifications Copyright OpenSearch Contributors. See
+//  * GitHub history for details.
+//  */
+
+import { get } from 'lodash';
+import { i18n } from '@osd/i18n';
+import { ExpressionFunctionDefinition } from '../../../../src/plugins/expressions/public';
+import {
+  VisLayerTypes,
+  VisLayers,
+  ExprVisLayers,
+  PluginResource,
+} from '../../../../src/plugins/vis_augmenter/public';
+import {
+  TimeRange,
+  calculateBounds,
+} from '../../../../src/plugins/data/common';
+import {
+  getAnomalySummaryQuery,
+  parsePureAnomalies,
+} from '../pages/utils/anomalyResultUtils';
+import { AD_NODE_API } from '../../utils/constants';
+import { AnomalyData } from '../models/interfaces';
+import { getClient } from '../services';
+import {
+  PointInTimeEventsVisLayer,
+  VisLayerError,
+  VisLayerErrorTypes,
+} from '../../../../src/plugins/vis_augmenter/public';
+import { PLUGIN_NAME } from '../../public/utils/constants';
+import { NO_PERMISSIONS_KEY_WORD } from '../../server/utils/helpers';
+
+type Input = ExprVisLayers;
+type Output = Promise<ExprVisLayers>;
+
+interface Arguments {
+  detectorId: string;
+}
+
+const name = 'overlay_anomalies';
+
+export type OverlayAnomaliesExpressionFunctionDefinition =
+  ExpressionFunctionDefinition<'overlay_anomalies', Input, Arguments, Output>;
+
+// This gets all the needed anomalies for the given detector ID and time range
+const getAnomalies = async (
+  detectorId: string,
+  startTime: number,
+  endTime: number
+): Promise<AnomalyData[]> => {
+  const anomalySummaryQuery = getAnomalySummaryQuery(
+    startTime,
+    endTime,
+    detectorId,
+    undefined,
+    false
+  );
+
+  // We set the http client in the plugin.ts setup() fn. We pull it in here to make a
+  // server-side call directly.
+  // Note we can't use the redux fns here (e.g., searchResults()) since it requires
+  // hooks (e.g., useDispatch()) which doesn't make sense in this context, plus is not allowed by React.
+  const anomalySummaryResponse = await getClient().post(
+    `..${AD_NODE_API.DETECTOR}/results/_search`,
+    {
+      body: JSON.stringify(anomalySummaryQuery),
+    }
+  );
+
+  return parsePureAnomalies(anomalySummaryResponse);
+};
+
+// This takes anomalies and returns them as vis layer of type PointInTimeEvents
+const convertAnomaliesToLayer = (
+  anomalies: AnomalyData[],
+  ADPluginResource: PluginResource
+): PointInTimeEventsVisLayer => {
+  const events = anomalies.map((anomaly: AnomalyData) => {
+    return {
+      timestamp: anomaly.startTime + (anomaly.endTime - anomaly.startTime) / 2,
+      metadata: {},
+    };
+  });
+  return {
+    originPlugin: 'anomaly-detection',
+    type: VisLayerTypes.PointInTimeEvents,
+    pluginResource: ADPluginResource,
+    events: events,
+  } as PointInTimeEventsVisLayer;
+};
+
+export const overlayAnomaliesFunction =
+  (): OverlayAnomaliesExpressionFunctionDefinition => ({
+    name,
+    type: 'vis_layers',
+    inputTypes: ['vis_layers'],
+    help: i18n.translate('data.functions.overlay_anomalies.help', {
+      defaultMessage: 'Add an anomaly vis layer',
+    }),
+    args: {
+      detectorId: {
+        types: ['string'],
+        default: '""',
+        help: '',
+      },
+    },
+
+    async fn(input, args, context): Promise<ExprVisLayers> {
+      // Parsing all of the args & input
+      const detectorId = get(args, 'detectorId', '');
+      const timeRange = get(
+        context,
+        'searchContext.timeRange',
+        ''
+      ) as TimeRange;
+      const origVisLayers = get(input, 'layers', [] as VisLayers) as VisLayers;
+      const parsedTimeRange = timeRange ? calculateBounds(timeRange) : null;
+      const startTimeInMillis = parsedTimeRange?.min?.unix()
+        ? parsedTimeRange?.min?.unix() * 1000
+        : undefined;
+      const endTimeInMillis = parsedTimeRange?.max?.unix()
+        ? parsedTimeRange?.max?.unix() * 1000
+        : undefined;
+      const ADPluginResource = {
+        type: 'anomaly-detection-type',
+        id: detectorId,
+        name: PLUGIN_NAME,
+        urlPath: `${PLUGIN_NAME}#/detectors`,
+      };
+      try {
+        if (startTimeInMillis === undefined || endTimeInMillis === undefined) {
+          throw new RangeError('start or end time invalid');
+        }
+        const anomalies: AnomalyData[] = await getAnomalies(
+          detectorId,
+          startTimeInMillis,
+          endTimeInMillis
+        );
+        const anomalyLayer = convertAnomaliesToLayer(
+          anomalies,
+          ADPluginResource
+        );
+        return {
+          type: 'vis_layers',
+          layers: origVisLayers
+            ? origVisLayers.concat(anomalyLayer)
+            : ([anomalyLayer] as VisLayers),
+        };
+      } catch (error) {
+        console.log('Anomaly Detector - Unable to get anomalies: ', error);
+        let visLayerError: VisLayerError = {} as VisLayerError;
+        if (
+          typeof error === 'string' &&
+          error.includes(NO_PERMISSIONS_KEY_WORD)
+        ) {
+          visLayerError = {
+            type: VisLayerErrorTypes.PERMISSIONS_FAILURE,
+            message: error, // might just change this to a generic message like rest of AD plugin
+          };
+        } else {
+          visLayerError = {
+            type: VisLayerErrorTypes.FETCH_FAILURE,
+            message:
+              error === 'string'
+                ? error
+                : error instanceof Error
+                ? error.message
+                : '',
+          };
+        }
+        const anomalyErrorLayer = {
+          type: VisLayerTypes.PointInTimeEvents,
+          originPlugin: PLUGIN_NAME,
+          pluginResource: ADPluginResource,
+          events: [],
+          error: visLayerError,
+        } as PointInTimeEventsVisLayer;
+        return {
+          type: 'vis_layers',
+          layers: origVisLayers
+            ? origVisLayers.concat(anomalyErrorLayer)
+            : ([anomalyErrorLayer] as VisLayers),
+        };
+      }
+    },
+  });

--- a/public/expressions/overlay_anomalies.ts
+++ b/public/expressions/overlay_anomalies.ts
@@ -74,12 +74,7 @@ const getAnomalies = async (
 
 const getDetectorName = async (detectorId: string) => {
   const resp = await getClient().get(`..${AD_NODE_API.DETECTOR}/${detectorId}`);
-  if (!isEmpty(Object.keys(resp.response))) {
-    const detectorName = get(resp.response, 'name', '');
-    return detectorName;
-  } else {
-    return '';
-  }
+  return get(resp.response, 'name', '');
 };
 
 // This takes anomalies and returns them as vis layer of type PointInTimeEvents
@@ -149,14 +144,19 @@ export const overlayAnomaliesFunction =
       const endTimeInMillis = parsedTimeRange?.max?.unix()
         ? parsedTimeRange?.max?.unix() * 1000
         : undefined;
-      const detectorName: string = await getDetectorName(detectorId);
-      const ADPluginResource = {
+      var ADPluginResource = {
         type: VIS_LAYER_PLUGIN_TYPE,
         id: detectorId,
-        name: detectorName,
+        name: '',
         urlPath: `${PLUGIN_NAME}#/detectors/${detectorId}/results`, //details page for detector in AD plugin
       };
       try {
+        const detectorName = await getDetectorName(detectorId);
+        if (detectorName === '') {
+          throw new Error('Anomaly Detector - Unable to get detector');
+        }
+        ADPluginResource.name = detectorName;
+
         if (startTimeInMillis === undefined || endTimeInMillis === undefined) {
           throw new RangeError('start or end time invalid');
         }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -20,6 +20,8 @@ import {
   AnomalyDetectionOpenSearchDashboardsPluginSetup,
   AnomalyDetectionOpenSearchDashboardsPluginStart,
 } from '.';
+import { overlayAnomaliesFunction } from './expressions/overlay_anomalies';
+import { setClient } from './services';
 
 export class AnomalyDetectionOpenSearchDashboardsPlugin
   implements
@@ -33,7 +35,8 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
   }
 
   public setup(
-    core: CoreSetup
+    core: CoreSetup,
+    plugins
   ): AnomalyDetectionOpenSearchDashboardsPluginSetup {
     core.application.register({
       id: 'anomaly-detection-dashboards',
@@ -50,6 +53,13 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
         return renderApp(coreStart, params);
       },
     });
+
+    // Set the HTTP client so it can be pulled into expression fns to make
+    // direct server-side calls
+    setClient(core.http);
+
+    // registers the expression function used to render anomalies on an Augmented Visualization
+    plugins.expressions.registerFunction(overlayAnomaliesFunction);
     return {};
   }
 

--- a/public/services.ts
+++ b/public/services.ts
@@ -1,12 +1,6 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Any modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 import { CoreStart } from '../../../src/core/public';

--- a/public/services.ts
+++ b/public/services.ts
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { CoreStart } from '../../../src/core/public';
+import { createGetterSetter } from '../../../src/plugins/opensearch_dashboards_utils/public';
+import { SavedObjectLoader } from '../../../src/plugins/saved_objects/public';
+
+export const [getSavedFeatureAnywhereLoader, setSavedFeatureAnywhereLoader] =
+  createGetterSetter<SavedObjectLoader>('savedFeatureAnywhereLoader');
+
+export const [getClient, setClient] =
+  createGetterSetter<CoreStart['http']>('http');


### PR DESCRIPTION
### Description

Creates and registers an expression function to retrieve anomalies from AD as a vis-layer to be rendered on top of visualizations in OSD.

The expression function takes a detectorId argument and utilizes the date range in the context to fetch anomalies. The anomalies are then returned as vis-layer which visualize_embeddable in OSD renders onto the given visualization.

This PR is rebased directly from the featureAnywhere project. It doesn't have the changes to public/plugins.tsx as that code is yet unmerged. The only lines added there are: 

```
plugins.expressions.registerFunction(overlayAnomaliesFunction);
setClient(core.http);
```

### Issues Resolved

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
