### PR TITLE
Remove invalid link

### DIFF
--- a/public/pages/Dashboard/utils/utils.tsx
+++ b/public/pages/Dashboard/utils/utils.tsx
@@ -313,7 +313,6 @@ export const buildColors = palleteBuilder(
   rgbColors.map(([r, g, b]) => [r, g, b, 0.8])
 );
 
-// referred to here: https://tiny.amazon.com/337xpvcq/githelaselasblobv1822stor
 export const fillOutColors = (d: any, i: number, a: any[]) => {
   return buildColors(i / (a.length + 1));
 };


### PR DESCRIPTION
### Description
https://tiny.amazon.com isn't available outside of Amazon.com's internal network, there shouldn't be any links to that service.  When looking where the link resolved to, it didn't seem to provide any insight into the current codebase, so I'm removing.

### Issues
- Related https://github.com/opensearch-project/security-dashboards-plugin/pull/1420

### Check List

- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
