### PR TITLE
Updating maintainers and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/anomaly-detection
+*   @ohltyler @kaituo @jackiehanyang @amitgalitz @sean-zheng-amazon

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,9 +4,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer              | GitHub ID                                               | Affiliation |
-| ----------------------- | ------------------------------------------------------- | ----------- |
-| Tyler Ohlsen            | [ohltyler](https://github.com/ohltyler)                 | Amazon      |
+| Maintainer              | GitHub ID                                                | Affiliation |
+| ----------------------- | -------------------------------------------------------- | ----------- |
+| Tyler Ohlsen            | [ohltyler](https://github.com/ohltyler)                  | Amazon      |
+| Kaituo Li               | [kaituo](https://github.com/kaituo)                      | Amazon      |
+| Jackie Han              | [jackiehanyang](https://github.com/jackiehanyang)        | Amazon      |
+| Amit Galitzky           | [amitgalitz](https://github.com/amitgalitz)              | Amazon      |
+| Sean Zheng              | [sean-zheng-amazon](https://github.com/sean-zheng-amazon)| Amazon      |
+
+## Emeritus Maintainers
+
+| Maintainer        | GitHub ID                                               | Affiliation |
+| ----------------- | ------------------------------------------------------- | ----------- |
 | Yaliang                 | [ylwu-amzn](https://github.com/ylwu-amzn)               | Amazon      |
 | Yizhe Liu               | [yizheliu-amazon](https://github.com/yizheliu-amazon)   | Amazon      |
 | Vijayan Balasubramanian | [VijayanB](https://github.com/VijayanB)                 | Amazon      |


### PR DESCRIPTION
### Description

updating the list of maintainers and code owners for ad-dashboards

### issues resolved

resolves #421 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
