### PR TITLE
fixing test to pass with node 18

### DIFF
--- a/public/pages/DefineDetector/components/NameAndDescription/__tests__/NameAndDescription.test.tsx
+++ b/public/pages/DefineDetector/components/NameAndDescription/__tests__/NameAndDescription.test.tsx
@@ -29,11 +29,14 @@ describe('<NameAndDescription /> spec', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
   test('shows error for detector name input when toggling focus/blur', async () => {
-    const handleValidateName = jest.fn().mockImplementation(() => {
-      throw 'Required';
+    const handleValidateName = jest.fn().mockImplementationOnce(() => {
+      return 'Required';
     });
     const { queryByText, findByText, getByPlaceholderText } = render(
-      <Formik initialValues={{ name: '' }} onSubmit={jest.fn()}>
+      <Formik
+        initialValues={{ name: '', description: 'one' }}
+        onSubmit={jest.fn()}
+      >
         {() => (
           <div>
             <NameAndDescription onValidateDetectorName={handleValidateName} />
@@ -49,6 +52,7 @@ describe('<NameAndDescription /> spec', () => {
     expect(handleValidateName).toHaveBeenCalledTimes(1);
     expect(findByText('Required')).not.toBeNull();
   });
+
   test('shows error for detector description input when toggling focus/bur', async () => {
     const { queryByText, findByText, getByPlaceholderText } = render(
       <Formik


### PR DESCRIPTION
### Description

In order to ensure that we are able to support node 18, we want to have passing unit tests. Node 15+ doesn't support uncaught promises or errors within tests. I changed it to only return a string instead and gave a description so it only fails for the name check for the given test.

### Issues Resolved

#485 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
