### PR TITLE
add group category and order for context menu

### DIFF
--- a/public/utils/contextMenu/getActions.tsx
+++ b/public/utils/contextMenu/getActions.tsx
@@ -23,6 +23,8 @@ const grouping: Action['grouping'] = [
     id: 'ad-dashboard-context-menu',
     getDisplayName: () => 'Anomaly Detector',
     getIconType: () => APM_TRACE,
+    category: 'vis_augmenter',
+    order: 20,
   },
 ];
 


### PR DESCRIPTION
### Description

Adds a category and order to the context menu group for the dashboard integration. This allows the context menu to be grouped with Anomalies and View Event.

### Issues Resolved

https://github.com/opensearch-project/ux/issues/66

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
