### PR TITLE
make feature anywhere formatted detector name an assgiend value

### DIFF
--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/helpers.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/helpers.tsx
@@ -30,10 +30,10 @@ export function visFeatureListToFormik(
 }
 
 export function formikToDetectorName(title) {
-  const detectorName =
+  let detectorName =
     title + '_anomaly_detector_' + Math.floor(100000 + Math.random() * 900000);
-  detectorName.replace(/[^a-zA-Z0-9-_]/g, '_');
-  return detectorName;
+  const formattedName = detectorName.replace(/[^a-zA-Z0-9\-_]/g, '_');
+  return formattedName;
 }
 
 const getFeatureNameFromVisParams = (id, seriesParams) => {
@@ -43,7 +43,8 @@ const getFeatureNameFromVisParams = (id, seriesParams) => {
     }
   });
 
-  return name.data.label.replace(/[^a-zA-Z0-9-_]/g, '_');
+  const formaedFeatureName = name.data.label.replace(/[^a-zA-Z0-9-_]/g, '_');
+  return formaedFeatureName
 };
 
 function visAggregationToFormik(value) {

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/helpers.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/helpers.tsx
@@ -43,8 +43,8 @@ const getFeatureNameFromVisParams = (id, seriesParams) => {
     }
   });
 
-  const formaedFeatureName = name.data.label.replace(/[^a-zA-Z0-9-_]/g, '_');
-  return formaedFeatureName
+  const formatedFeatureName = name.data.label.replace(/[^a-zA-Z0-9-_]/g, '_');
+  return formatedFeatureName
 };
 
 function visAggregationToFormik(value) {

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/helpers.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/helpers.tsx
@@ -30,21 +30,21 @@ export function visFeatureListToFormik(
 }
 
 export function formikToDetectorName(title) {
-  let detectorName =
+  const detectorName =
     title + '_anomaly_detector_' + Math.floor(100000 + Math.random() * 900000);
   const formattedName = detectorName.replace(/[^a-zA-Z0-9\-_]/g, '_');
   return formattedName;
 }
 
 const getFeatureNameFromVisParams = (id, seriesParams) => {
-  let name = find(seriesParams, function (param) {
+  const name = find(seriesParams, function (param) {
     if (param.data.id === id) {
       return true;
     }
   });
 
-  const formatedFeatureName = name.data.label.replace(/[^a-zA-Z0-9-_]/g, '_');
-  return formatedFeatureName
+  const formattedFeatureName = name.data.label.replace(/[^a-zA-Z0-9-_]/g, '_');
+  return formattedFeatureName
 };
 
 function visAggregationToFormik(value) {

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -59,6 +59,9 @@ export const AD_DOCS_LINK =
 export const AD_HIGH_CARDINALITY_LINK =
   'https://opensearch.org/docs/latest/observing-your-data/ad/index/#optional-set-category-fields-for-high-cardinality';
 
+export const AD_FEATURE_ANYWHERE_LINK =
+  'https://opensearch.org/docs/latest/observing-your-data/ad/dashboards-anomaly-detection/';
+
 export const MAX_DETECTORS = 1000;
 
 export const MAX_ANOMALIES = 10000;

--- a/public/utils/contextMenu/getActions.tsx
+++ b/public/utils/contextMenu/getActions.tsx
@@ -13,7 +13,7 @@ import AnywhereParentFlyout from '../../components/FeatureAnywhereContextMenu/An
 import { Provider } from 'react-redux';
 import configureStore from '../../redux/configureStore';
 import DocumentationTitle from '../../components/FeatureAnywhereContextMenu/DocumentationTitle/containers/DocumentationTitle';
-import { AD_DOCS_LINK, APM_TRACE } from '../constants';
+import { AD_FEATURE_ANYWHERE_LINK, APM_TRACE } from '../constants';
 import { getClient, getOverlays } from '../../../public/services';
 import { FLYOUT_MODES } from '../../../public/components/FeatureAnywhereContextMenu/AnywhereParentFlyout/constants';
 
@@ -80,7 +80,7 @@ export const getActions = () => {
       icon: 'documentation' as EuiIconType,
       order: 98,
       onClick: () => {
-        window.open(AD_DOCS_LINK, '_blank');
+        window.open(AD_FEATURE_ANYWHERE_LINK, '_blank');
       },
     },
   ].map((options) => createADAction({ ...options, grouping }));


### PR DESCRIPTION
### Description

- Previously the detector name and feature name formatting regex was not in effective because the formatted value was not store or assign the variable, need to assign the return value of the replace function to the variable. Now we are replacing not allowed characters from vis to `_` when prefilling detector name and feature name

- updated feature anywhere documentation link to https://opensearch.org/docs/latest/observing-your-data/ad/dashboards-anomaly-detection/

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
