### PR TITLE
Remove global OUI style override

### DIFF
--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -171,6 +171,9 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
       }}
       isPaused={true}
       commonlyUsedRanges={DATE_PICKER_QUICK_OPTIONS}
+      updateButtonProps={{
+        fill: false,
+      }}
     />
   );
 

--- a/public/pages/AnomalyCharts/index.scss
+++ b/public/pages/AnomalyCharts/index.scss
@@ -10,8 +10,3 @@
  */
 
 @import 'components/AlertsFlyout/alertsFlyout.scss';
-
-.euiSuperUpdateButton {
-  background-color: transparent !important;
-  color: #006bb4 !important;
-}


### PR DESCRIPTION
### Description

Remove styling that overrides OUI styles globally and replaces it with props that replicate the removed styling. There is no visual change, apart from parts of Dashboards outside of anomaly detection that were caught in this styling.

### Issues Resolved

Closes #509

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
