### PR TITLE
[Feature Anywhere] Change to anomaly start time; add test ids

### DIFF
--- a/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/containers/AssociatedDetectors.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/containers/AssociatedDetectors.tsx
@@ -308,6 +308,7 @@ function AssociatedDetectors({ embeddable, closeFlyout, setMode }) {
             <EuiFlexItem grow={false}>
               <div>
                 <EuiButton
+                  data-test-subj="associateDetectorButton"
                   fill
                   iconType="link"
                   onClick={() => {

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -566,7 +566,7 @@ function AddAnomalyDetector({
                     <EuiSpacer size="m" />
 
                     <EnhancedAccordion
-                      id="detectorDetails"
+                      id="detectorDetailsAccordion"
                       title={detectorNameFromVis}
                       isOpen={accordionsOpen.detectorDetails}
                       onToggle={() => onAccordionToggle('detectorDetails')}
@@ -671,7 +671,7 @@ function AddAnomalyDetector({
                     <EuiSpacer size="m" />
 
                     <EnhancedAccordion
-                      id="advancedConfiguration"
+                      id="advancedConfigurationAccordion"
                       title="Advanced configuration"
                       isOpen={accordionsOpen.advancedConfiguration}
                       onToggle={() =>
@@ -824,7 +824,7 @@ function AddAnomalyDetector({
                     <EuiSpacer size="m" />
 
                     <EnhancedAccordion
-                      id="modelFeatures"
+                      id="modelFeaturesAccordion"
                       title="Features"
                       isOpen={accordionsOpen.modelFeatures}
                       onToggle={() => onAccordionToggle('modelFeatures')}
@@ -896,7 +896,7 @@ function AddAnomalyDetector({
                   {mode === FLYOUT_MODES.existing ? (
                     <EuiButton
                       fill={true}
-                      data-test-subj="adAnywhereCreateDetectorButton"
+                      data-test-subj="adAnywhereAssociateDetectorButton"
                       isLoading={formikProps.isSubmitting}
                       onClick={() => handleAssociate(selectedDetector)}
                     >

--- a/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/EnhancedAccordion.tsx
+++ b/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/EnhancedAccordion.tsx
@@ -51,6 +51,7 @@ const EnhancedAccordion = ({
           buttonContent={
             <div className="enhanced-accordion__title">
               <EuiTitle
+                data-test-subj="accordionTitleButton"
                 size="s"
                 onClick={onToggle}
                 role="button"

--- a/public/expressions/helpers.ts
+++ b/public/expressions/helpers.ts
@@ -74,7 +74,7 @@ export const convertAnomaliesToPointInTimeEventsVisLayer = (
 ): PointInTimeEventsVisLayer => {
   const events = anomalies.map((anomaly: AnomalyData) => {
     return {
-      timestamp: anomaly.startTime + (anomaly.endTime - anomaly.startTime) / 2,
+      timestamp: anomaly.startTime,
       metadata: {},
     };
   });

--- a/public/pages/DetectorConfig/containers/Features.tsx
+++ b/public/pages/DetectorConfig/containers/Features.tsx
@@ -234,6 +234,7 @@ export const Features = (props: FeaturesProps) => {
             titleSize="s"
           >
             <EuiBasicTable
+              data-test-subj="featureTable"
               items={sortedItems}
               columns={columns}
               cellProps={getCellProps}


### PR DESCRIPTION
### Description

2 updates:
1. Updates the event time in the anomaly results to be start time
2. Adds `data-test-subj` fields to several components when used in integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
