### PR TITLE
Resolve Moment.js CVE Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "json5": "^2.2.3",
     "@sideway/formula": "^3.0.1",
     "minimist": "^1.2.6",
-    "moment": "^2.29.4",
     "minimatch": "^3.1.2",
     "axios": "^0.21.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,11 +2631,6 @@ mkdirp@^0.5.1, mkdirp@^0.5.3:
     minimist "^1.2.5"
 
 moment@^2.24.0:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-moment@^2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==


### PR DESCRIPTION
### Description

This PR addresses a CVE related to our use of a version of moment.js that is below 2.29.2.

Modified as per the reference PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1931/files

Testing done:
1. Executed an end-to-end test to ensure that we can still create and run a detector with the updated moment.js version.

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
