### PR TITLE
Remove version dependency in cypress workflow

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -70,6 +70,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
           OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
+          echo "Using OpenSearch version $OPENSEARCH_VERSION"
 
       - name: Checkout Anomaly-Detection
         uses: actions/checkout@v2

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -67,6 +67,8 @@ jobs:
       - run: yarn -v
 
       - name: Get OpenSearch version
+        # Need to use bash to avoid having a windows/linux specific step
+        shell: bash
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
           OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run OpenSearch with plugin
         run: |
-          OPENSEARCH_VERSION=$(node -p "require('../../opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
+          OPENSEARCH_VERSION=$(node -p "require('../opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
           echo "Using OpenSearch version $OPENSEARCH_VERSION"
           cd anomaly-detection
             ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -37,22 +37,6 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --system core.longpaths true
 
-      - name: Checkout Anomaly-Detection
-        uses: actions/checkout@v2
-        with:
-          path: anomaly-detection
-          repository: opensearch-project/anomaly-detection
-          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
-
-      - name: Run OpenSearch with plugin
-        run: |
-          OPENSEARCH_VERSION=$(node -p "require('../opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
-          echo "Using OpenSearch version $OPENSEARCH_VERSION"
-          cd anomaly-detection
-            ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &
-            timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
-        shell: bash
-
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
         with:
@@ -81,6 +65,25 @@ jobs:
 
       - run: node -v
       - run: yarn -v
+
+      - name: Get OpenSearch version
+      - run: |
+          cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
+          OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
+
+      - name: Checkout Anomaly-Detection
+        uses: actions/checkout@v2
+        with:
+          path: anomaly-detection
+          repository: opensearch-project/anomaly-detection
+          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
+
+      - name: Run OpenSearch with plugin
+        run: |
+          cd anomaly-detection
+            ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &
+            timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
+        shell: bash
 
       - name: Bootstrap the plugin
         run: |

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -67,7 +67,7 @@ jobs:
       - run: yarn -v
 
       - name: Get OpenSearch version
-      - run: |
+        run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
           OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
 

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run OpenSearch with plugin
         run: |
-          OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
+          OPENSEARCH_VERSION=$(node -p "require('../../opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
           echo "Using OpenSearch version $OPENSEARCH_VERSION"
           cd anomaly-detection
             ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -11,7 +11,6 @@ on:
       - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
   OPENSEARCH_DASHBOARDS_FTREPO_VERSION: 'main'
   ANOMALY_DETECTION_PLUGIN_VERSION: 'main'
 jobs:
@@ -47,8 +46,10 @@ jobs:
 
       - name: Run OpenSearch with plugin
         run: |
+          OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
+          echo "Using OpenSearch version $OPENSEARCH_VERSION"
           cd anomaly-detection
-            ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
+            ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &
             timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
         shell: bash
 


### PR DESCRIPTION
### Description

Remove version dependency in cypress workflow by fetching the OpenSearch version value from config file. Now, the auto-created version bump PRs should be sufficient to update all places where versions need bumped.

Moved around steps a bit so the version could be fetched before spinning up OpenSearch cluster

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
