### PR TITLE
[Backport 2.x] Remove version dependency in cypress workflow (#554)

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -11,7 +11,6 @@ on:
       - "*"
 env:
   OPENSEARCH_DASHBOARDS_VERSION: '2.x'
-  OPENSEARCH_VERSION: '2.9.0-SNAPSHOT'
   OPENSEARCH_DASHBOARDS_FTREPO_VERSION: '2.x'
   ANOMALY_DETECTION_PLUGIN_VERSION: '2.x'
 jobs:
@@ -37,20 +36,6 @@ jobs:
       - name: Enable longer filenames
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --system core.longpaths true
-
-      - name: Checkout Anomaly-Detection
-        uses: actions/checkout@v2
-        with:
-          path: anomaly-detection
-          repository: opensearch-project/anomaly-detection
-          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
-
-      - name: Run OpenSearch with plugin
-        run: |
-          cd anomaly-detection
-            ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
-            timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
-        shell: bash
 
       - name: Checkout OpenSearch Dashboards
         uses: actions/checkout@v2
@@ -80,6 +65,31 @@ jobs:
 
       - run: node -v
       - run: yarn -v
+
+      # - name: Get OpenSearch version
+      #   # Need to use bash to avoid having a windows/linux specific step
+      #   shell: bash
+      #   run: |
+      #     cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
+      #     OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
+      #     echo "Using OpenSearch version $OPENSEARCH_VERSION"
+
+      - name: Checkout Anomaly-Detection
+        uses: actions/checkout@v2
+        with:
+          path: anomaly-detection
+          repository: opensearch-project/anomaly-detection
+          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
+
+      - name: Run OpenSearch with plugin
+        run: |
+          cd anomaly-detection
+          CONFIG_PATH=../OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/opensearch_dashboards.json
+          OPENSEARCH_VERSION=$(node -p "require('$CONFIG_PATH').opensearchDashboardsVersion")-SNAPSHOT
+          echo "Using OpenSearch version $OPENSEARCH_VERSION"
+          ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &
+          timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
+        shell: bash
 
       - name: Bootstrap the plugin
         run: |

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -66,14 +66,6 @@ jobs:
       - run: node -v
       - run: yarn -v
 
-      # - name: Get OpenSearch version
-      #   # Need to use bash to avoid having a windows/linux specific step
-      #   shell: bash
-      #   run: |
-      #     cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
-      #     OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
-      #     echo "Using OpenSearch version $OPENSEARCH_VERSION"
-
       - name: Checkout Anomaly-Detection
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Description

Manual backport of #554 

Includes fix of version not being assigned correctly due to how github actions env vars work across different steps. This is fixed in `main` via #556 

### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
