### PR TITLE
Fetch OpenSearch version in same step

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -66,14 +66,6 @@ jobs:
       - run: node -v
       - run: yarn -v
 
-      - name: Get OpenSearch version
-        # Need to use bash to avoid having a windows/linux specific step
-        shell: bash
-        run: |
-          cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
-          OPENSEARCH_VERSION=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")-SNAPSHOT
-          echo "Using OpenSearch version $OPENSEARCH_VERSION"
-
       - name: Checkout Anomaly-Detection
         uses: actions/checkout@v2
         with:
@@ -84,8 +76,11 @@ jobs:
       - name: Run OpenSearch with plugin
         run: |
           cd anomaly-detection
-            ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &
-            timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
+          CONFIG_PATH=../OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/opensearch_dashboards.json
+          OPENSEARCH_VERSION=$(node -p "require('$CONFIG_PATH').opensearchDashboardsVersion")-SNAPSHOT
+          echo "Using OpenSearch version $OPENSEARCH_VERSION"
+          ./gradlew run -Dopensearch.version=$OPENSEARCH_VERSION &
+          timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
         shell: bash
 
       - name: Bootstrap the plugin


### PR DESCRIPTION
### Description

Fetch version in the same step so the env variable is always resolved. Previous PR #554  this was not guaranteed and could fail.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
