### PR TITLE
Optimize fetching of `augment-vis` saved objects 

### DIFF
--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -204,28 +204,32 @@ function AddAnomalyDetector({
             const maxAssociatedCount = uiSettings.get(
               PLUGIN_AUGMENTATION_MAX_OBJECTS_SETTING
             );
-            await savedObjectLoader.findAll().then(async (resp) => {
-              if (resp !== undefined) {
-                const savedAugmentObjects = get(resp, 'hits', []);
-                // gets all the saved object for this visualization
-                const savedObjectsForThisVisualization =
-                  savedAugmentObjects.filter(
-                    (savedObj) =>
-                      get(savedObj, 'visId', '') === embeddable.vis.id
+            await savedObjectLoader
+              .findAll('', 100, [], {
+                type: 'visualization',
+                id: embeddable.vis.id as string,
+              })
+              .then(async (resp) => {
+                if (resp !== undefined) {
+                  const savedObjectsForThisVisualization = get(
+                    resp,
+                    'hits',
+                    []
                   );
-                if (
-                  maxAssociatedCount <= savedObjectsForThisVisualization.length
-                ) {
-                  notifications.toasts.addDanger(
-                    `Cannot create the detector and associate it to the visualization due to the limit of the max
+                  if (
+                    maxAssociatedCount <=
+                    savedObjectsForThisVisualization.length
+                  ) {
+                    notifications.toasts.addDanger(
+                      `Cannot create the detector and associate it to the visualization due to the limit of the max
                     amount of associated plugin resources (${maxAssociatedCount}) with
                     ${savedObjectsForThisVisualization.length} associated to the visualization`
-                  );
-                } else {
-                  handleSubmit(formikProps);
+                    );
+                  } else {
+                    handleSubmit(formikProps);
+                  }
                 }
-              }
-            });
+              });
           }
         }
       });
@@ -244,20 +248,21 @@ function AddAnomalyDetector({
 
   useEffect(async () => {
     // Gets all augmented saved objects
-    await savedObjectLoader.findAll().then(async (resp) => {
-      if (resp !== undefined) {
-        const savedAugmentObjects = get(resp, 'hits', []);
-        // gets all the saved object for this visualization
-        const savedObjectsForThisVisualization = savedAugmentObjects.filter(
-          (savedObj) => get(savedObj, 'visId', '') === embeddable.vis.id
-        );
-        if (maxAssociatedCount <= savedObjectsForThisVisualization.length) {
-          setAssociationLimitReached(true);
-        } else {
-          setAssociationLimitReached(false);
+    await savedObjectLoader
+      .findAll('', 100, [], {
+        type: 'visualization',
+        id: embeddable.vis.id as string,
+      })
+      .then(async (resp) => {
+        if (resp !== undefined) {
+          const savedObjectsForThisVisualization = get(resp, 'hits', []);
+          if (maxAssociatedCount <= savedObjectsForThisVisualization.length) {
+            setAssociationLimitReached(true);
+          } else {
+            setAssociationLimitReached(false);
+          }
         }
-      }
-    });
+      });
   }, []);
 
   const getEmbeddableSection = () => {


### PR DESCRIPTION
### Description

Updates saved object loader `findAll()` calls to include a `hasReference` argument so only objects that include the desired vis ID as a reference will be fetched. Part of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4595.

Other line changes are formatting done by `prettier`.

Tested against cluster with the change in OSD, works as expected.

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
