### PR TITLE
Fix display of detector names

### DIFF
--- a/public/pages/DetectorsList/containers/ConfirmActionModals/utils/helpers.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/utils/helpers.tsx
@@ -27,7 +27,7 @@ const getNames = (detectors: DetectorListItem[]) => {
           href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
           target="_blank"
         >
-          {detectors[i].name} />
+          {detectors[i].name}
         </EuiLink>
       ),
     });
@@ -49,7 +49,7 @@ const getNamesAndMonitors = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} />
+            {detectors[i].name}
           </EuiLink>
         ),
         Monitor: (
@@ -57,7 +57,7 @@ const getNamesAndMonitors = (
             href={`${getAlertingMonitorListLink()}/${relatedMonitor.id}`}
             target="_blank"
           >
-            {relatedMonitor.name} />
+            {relatedMonitor.name}
           </EuiLink>
         ),
       });
@@ -68,7 +68,7 @@ const getNamesAndMonitors = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} />
+            {detectors[i].name}
           </EuiLink>
         ),
         Monitor: '-',
@@ -95,7 +95,7 @@ const getNamesAndMonitorsAndStates = (
             href={`${PLUGIN_NAME}#/detectors/${detectors[i].id}`}
             target="_blank"
           >
-            {detectors[i].name} />
+            {detectors[i].name}
           </EuiLink>
         ),
         Monitor: (
@@ -103,7 +103,7 @@ const getNamesAndMonitorsAndStates = (
             href={`${getAlertingMonitorListLink()}/${relatedMonitor.id}`}
             target="_blank"
           >
-            {relatedMonitor.name} />
+            {relatedMonitor.name}
           </EuiLink>
         ),
         Running: <EuiText>{isRunning ? 'Yes' : 'No'}</EuiText>,


### PR DESCRIPTION
When starting or stopping detectors, the pop-up window shows the detector names as `DETECTOR_NAME />` where "DETECTOR\_NAME" is the name of the detector.

The markup seems to have residual `/>` that are rendered to the user. Remove them to ensure they do not appear between the opening and the closing EuiLink tags.

![screenshot of the issue](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/assets/148721/823d2dad-a16d-49a2-93dc-6de817f79873)

To reproduce:
1. Visit https://playground.opensearch.org/app/anomaly-detection-dashboards#/detectors?from=0&size=20&search=&indices=&sortField=name&sortDirection=asc
2. Check a few detectors
3. Click on Actions > Stop real-time detectors