### PR TITLE
Prevent empty task IDs passed to server side

### DIFF
--- a/public/pages/DetectorResults/containers/AnomalyHistory.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyHistory.tsx
@@ -173,6 +173,12 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   const backgroundColor = darkModeEnabled() ? '#29017' : '#F7F7F7';
   const resultIndex = get(props, 'detector.resultIndex', '');
 
+  // Utility fn to only fetch data when either it is non-historical, or historical and
+  // there is a populated task ID which will be used to fetch the historical results
+  const isValidToFetch = () => {
+    return !props.isHistorical || (props.isHistorical && taskId.current);
+  };
+
   // Tracking which parent category fields the user has selected to filter by.
   const [selectedCategoryFields, setSelectedCategoryFields] = useState(
     getCategoryFieldOptions(detectorCategoryField)
@@ -325,7 +331,8 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   useEffect(() => {
     if (
       !isEmpty(bucketizedAnomalyResults) &&
-      !isDateRangeOversize(zoomRange, detectorInterval, MAX_ANOMALIES)
+      !isDateRangeOversize(zoomRange, detectorInterval, MAX_ANOMALIES) &&
+      isValidToFetch()
     ) {
       setBucketizedAnomalyResults(undefined);
       if (isHCDetector && selectedHeatmapCell) {
@@ -350,14 +357,16 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   }, [zoomRange]);
 
   useEffect(() => {
-    fetchRawAnomalyResults(isHCDetector);
-    if (
-      !isHCDetector &&
-      isDateRangeOversize(dateRange, detectorInterval, MAX_ANOMALIES)
-    ) {
-      getBucketizedAnomalyResults();
-    } else {
-      setBucketizedAnomalyResults(undefined);
+    if (isValidToFetch()) {
+      fetchRawAnomalyResults(isHCDetector);
+      if (
+        !isHCDetector &&
+        isDateRangeOversize(dateRange, detectorInterval, MAX_ANOMALIES)
+      ) {
+        getBucketizedAnomalyResults();
+      } else {
+        setBucketizedAnomalyResults(undefined);
+      }
     }
   }, [dateRange, props.detector]);
 
@@ -399,13 +408,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
       );
       const detectorResultResponse = props.isHistorical
         ? await dispatch(
-            getDetectorResults(
-              taskId.current || '',
-              params,
-              true,
-              resultIndex,
-              true
-            )
+            getDetectorResults(taskId.current, params, true, resultIndex, true)
           ).catch((error: any) => {
             setIsLoading(false);
             setIsLoadingAnomalyResults(false);
@@ -457,17 +460,19 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
   useEffect(() => {
     // For any change, we will want to clear any selected heatmap cell to clear any populated charts / graphs
     setSelectedHeatmapCell(undefined);
-    fetchHCAnomalySummaries();
+    if (isValidToFetch()) {
+      fetchHCAnomalySummaries();
+    }
   }, [selectedCategoryFields]);
 
   useEffect(() => {
-    if (isHCDetector) {
+    if (isHCDetector && isValidToFetch()) {
       fetchHCAnomalySummaries();
     }
   }, [dateRange, heatmapDisplayOption]);
 
   useEffect(() => {
-    if (selectedHeatmapCell) {
+    if (selectedHeatmapCell && isValidToFetch()) {
       if (
         isMultiCategory &&
         get(selectedCategoryFields, 'length', 0) <
@@ -491,7 +496,7 @@ export const AnomalyHistory = (props: AnomalyHistoryProps) => {
 
   // Getting the latest sets of time series based on the selected parent + child entities
   useEffect(() => {
-    if (selectedHeatmapCell) {
+    if (selectedHeatmapCell && isValidToFetch()) {
       // Get a list of entity lists, where each list represents a unique entity combination of
       // all parent + child entities (a single model). And, for each one of these lists, fetch the time series data.
       const entityCombosToFetch = getAllEntityCombos(

--- a/release-notes/opensearch-anomaly-detection-dashboards.release-notes-2.11.0.0.md
+++ b/release-notes/opensearch-anomaly-detection-dashboards.release-notes-2.11.0.0.md
@@ -1,0 +1,4 @@
+Compatible with OpenSearch Dashboards 2.11.0.
+
+### Bug Fixes
+* Prevent empty task IDs passed to server side ([#616](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/616))


### PR DESCRIPTION
### Description

This PR improves the intermediate loading state on the historical results page. Before, an initial load of the page would send requests to the server-side with an empty task ID, which would return a 404 not found due to the path not existing, and show empty results. This is because there would be a double slash `//` where the task ID was supposed to be in between- e.g., `/api/anomaly_detectors/detectors//results/` (_note this would only happen if the page was directed via direct URL or refresh, or from the 'View results' button on the detector list page. If navigating from the detector results tab to the historical tab, the issue was not seen since the detector details were already populated in redux store_). Typically, this was quickly re-executed with a populated task ID after it was asynchronously fetched, and re-render the page with populated results. Because of this, it was not found as an issue, and was only noticeable when analyzing the network requests from a browser dev tools extension.

To simply prevent these requests from happening at all, we wrap all network requests with an `isValidToFetch()` fn to prevent empty task IDs from being propagated.

#### Testing
I've confirmed that results load as normally for HC and non-HC, real-time and historical. Now, the 404 errors are never seen from dev tools since the invalid requests are blocked from occurring in the first place.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
