### PR TITLE
Add workflow to verify binary installation works

### DIFF
--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -43,7 +43,7 @@ jobs:
           cd ./OpenSearch-Dashboards/
           su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
                                cd ./plugins/anomaly-detection-dashboards-plugin &&
-                               whoami && yarn osd bootstrap && yarn build && yarn run test:jest --coverage"
+                               whoami && yarn osd bootstrap --single-version=loose && yarn build && yarn run test:jest --coverage"
       - name: Uploads coverage
         uses: codecov/codecov-action@v1
 
@@ -87,7 +87,7 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
       - name: Build the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Bootstrap the plugin
         run: |
           cd OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
 
       - name: Run OpenSearch Dashboards server
         run: |

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -1,0 +1,54 @@
+name: 'Install Dashboards with Plugin via Binary'
+
+on: [push, pull_request]
+env:
+  OPENSEARCH_VERSION: '3.0.0'
+  CI: 1
+  # avoid warnings like "tput: No value for $TERM and no -T specified"
+  TERM: xterm
+
+jobs:
+  verify-binary-installation:
+    name: Run binary installation
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # TODO: add windows support when OSD core is stable on windows
+    runs-on: ${{ matrix.os }}
+    steps:  
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./opensearch_dashboards.json').opensearchDashboardsVersion")
+          plugin_version=$(node -p "require('./opensearch_dashboards.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Run Opensearch
+        uses: derek-ho/start-opensearch@v2
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          security-enabled: false
+
+      - name: Run Dashboard
+        id: setup-dashboards
+        uses: derek-ho/setup-opensearch-dashboards@v1
+        with:
+          plugin_name: anomaly-detection-dashboards-plugin
+          built_plugin_name: anomalyDetectionDashboards
+          install_zip: true
+
+      - name: Start the binary
+        run: | 
+          nohup ./bin/opensearch-dashboards &
+        working-directory: ${{ steps.setup-dashboards.outputs.dashboards-binary-directory }}
+        shell: bash
+
+      - name: Health check 
+        run: |
+          timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+        shell: bash

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -39,7 +39,7 @@ jobs:
         uses: derek-ho/setup-opensearch-dashboards@v1
         with:
           plugin_name: anomaly-detection-dashboards-plugin
-          built_plugin_name: anomalyDetectionDashboards
+          built_plugin_name: anomaly-detection-dashboards
           install_zip: true
 
       - name: Start the binary


### PR DESCRIPTION
### Description

I have observed some issues within other plugins of issues being only caught at run time. This is because several things can go wrong during the build process, which may not be caught in a dev setup. This adds a workflow to verify that building and installing into OSD works on every PR.

Related issues:
https://github.com/opensearch-project/security-dashboards-plugin/issues/1709
https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/875
https://github.com/opensearch-project/dashboards-observability/pull/309
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5952

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
