### PR TITLE
Populate selected indices from query params on initial load

### DIFF
--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -14,7 +14,6 @@ import {
   EuiBasicTable,
   EuiButton,
   EuiComboBoxOptionProps,
-  EuiHorizontalRule,
   EuiPage,
   EuiPageBody,
   EuiSpacer,
@@ -191,11 +190,14 @@ export const DetectorList = (props: ListProps) => {
   const visibleAliases = get(opensearchState, 'aliases', []) as IndexAlias[];
   const indexOptions = getVisibleOptions(visibleIndices, visibleAliases);
 
+  const queryParams = getURLQueryParams(props.location);
   const [state, setState] = useState<ListState>({
     page: 0,
-    queryParams: getURLQueryParams(props.location),
+    queryParams,
     selectedDetectorStates: ALL_DETECTOR_STATES,
-    selectedIndices: ALL_INDICES,
+    selectedIndices: queryParams.indices
+      ? queryParams.indices.split(',')
+      : ALL_INDICES,
   });
 
   // Set breadcrumbs on page initialization
@@ -211,7 +213,7 @@ export const DetectorList = (props: ListProps) => {
     const { history, location } = props;
     const updatedParams = {
       ...state.queryParams,
-      indices: state.selectedIndices.join(' '),
+      indices: state.selectedIndices.join(','),
       from: state.page * state.queryParams.size,
     };
 


### PR DESCRIPTION
### Description

Previously, the selected indices in the URL query params was not getting assigned to the page state on initial load. This fixes that.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
