### PR TITLE
update actionOption attribution for all data soure components

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -330,5 +330,5 @@ export interface ValidationSettingResponse {
 
 export interface MDSStates {
   queryParams: MDSQueryParams;
-  selectedDataSourceId: string;
+  selectedDataSourceId: string | undefined;
 }

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -93,7 +93,7 @@ export function DashboardOverview(props: OverviewProps) {
     queryParams,
     selectedDataSourceId: queryParams.dataSourceId
       ? queryParams.dataSourceId
-      : '',
+      : undefined,
   });
 
   const getDetectorOptions = (detectorsIdMap: {
@@ -267,7 +267,9 @@ export function DashboardOverview(props: OverviewProps) {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: [{ id: MDSOverviewState.selectedDataSourceId }],
+            activeOption: MDSOverviewState.selectedDataSourceId !== undefined 
+              ? [{ id: MDSOverviewState.selectedDataSourceId }]
+              : undefined,
             savedObjects: getSavedObjectsClient(),
             notifications: getNotifications(),
             onSelectedDataSources: (dataSources) =>

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -98,7 +98,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
 
   const [MDSCreateState, setMDSCreateState] = useState<MDSStates>({
     queryParams: MDSQueryParams,
-    selectedDataSourceId: dataSourceId ? dataSourceId : '',
+    selectedDataSourceId: dataSourceId ? dataSourceId : undefined,
   });
 
   // To handle backward compatibility, we need to pass some fields via
@@ -297,7 +297,9 @@ export const DefineDetector = (props: DefineDetectorProps) => {
             componentType={'DataSourceSelectable'}
             componentConfig={{
               fullWidth: false,
-              activeOption: [{ id: MDSCreateState.selectedDataSourceId }],
+              activeOption: MDSCreateState.selectedDataSourceId !== undefined 
+                ? [{ id: MDSCreateState.selectedDataSourceId }]
+                : undefined,
               savedObjects: getSavedObjectsClient(),
               notifications: getNotifications(),
               onSelectedDataSources: (dataSources) =>

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -109,7 +109,7 @@ interface ListState {
   queryParams: GetDetectorsQueryParams;
   selectedDetectorStates: DETECTOR_STATE[];
   selectedIndices: string[];
-  selectedDataSourceId: string;
+  selectedDataSourceId: string | undefined;
 }
 interface ConfirmModalState {
   isOpen: boolean;
@@ -208,7 +208,7 @@ export const DetectorList = (props: ListProps) => {
       : ALL_INDICES,
     selectedDataSourceId: queryParams.dataSourceId
       ? queryParams.dataSourceId
-      : '',
+      : undefined,
   });
 
   // Set breadcrumbs on page initialization
@@ -681,7 +681,9 @@ export const DetectorList = (props: ListProps) => {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: [{ id: state.selectedDataSourceId }],
+            activeOption: state.selectedDataSourceId !== undefined 
+              ? [{ id: state.selectedDataSourceId }]
+              : undefined,
             savedObjects: getSavedObjectsClient(),
             notifications: getNotifications(),
             onSelectedDataSources: (dataSources) =>

--- a/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
+++ b/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
@@ -104,7 +104,7 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
     queryParams,
     selectedDataSourceId: queryParams.dataSourceId
       ? queryParams.dataSourceId
-      : '',
+      : undefined,
   });
 
   // Set breadcrumbs on page initialization
@@ -242,7 +242,9 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: [{ id: MDSOverviewState.selectedDataSourceId }],
+            activeOption: MDSOverviewState.selectedDataSourceId !== undefined 
+              ? [{ id: MDSOverviewState.selectedDataSourceId }]
+              : undefined,
             savedObjects: getSavedObjectsClient(),
             notifications: getNotifications(),
             onSelectedDataSources: (dataSources) =>

--- a/public/pages/utils/helpers.ts
+++ b/public/pages/utils/helpers.ts
@@ -119,7 +119,7 @@ export const formatNumber = (data: any) => {
 };
 
 export const getAllDetectorsQueryParamsWithDataSourceId = (
-  dataSourceId: string
+  dataSourceId: string = ''
 ) => ({
   from: 0,
   search: '',
@@ -131,7 +131,7 @@ export const getAllDetectorsQueryParamsWithDataSourceId = (
 });
 
 export const getSampleDetectorsQueryParamsWithDataSouceId = (
-  dataSourceId: string
+  dataSourceId: string = ''
 ) => ({
   from: 0,
   search: 'sample',
@@ -152,7 +152,7 @@ export const getDataSourceFromURL = (location: {
 
 export const constructHrefWithDataSourceId = (
   basePath: string,
-  dataSourceId: string,
+  dataSourceId: string = '',
   withHash: Boolean
 ): string => {
   const dataSourceEnabled = getDataSourcePlugin()?.dataSourceEnabled || false;

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -371,7 +371,7 @@ const reducer = handleActions<Detectors>(
 
 export const createDetector = (
   requestBody: Detector,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const url = dataSourceId
     ? `..${AD_NODE_API.DETECTOR}/${dataSourceId}`
@@ -389,7 +389,7 @@ export const createDetector = (
 export const validateDetector = (
   requestBody: Detector,
   validationType: string,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/_validate/${validationType}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -405,7 +405,7 @@ export const validateDetector = (
 
 export const getDetector = (
   detectorId: string,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorId}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -420,9 +420,11 @@ export const getDetector = (
 export const getDetectorList = (
   queryParams: GetDetectorsQueryParams
 ): APIAction => {
+  const dataSourceId = queryParams.dataSourceId || '';
+
   const baseUrl = `..${AD_NODE_API.DETECTOR}/_list`;
-  const url = queryParams.dataSourceId
-    ? `${baseUrl}/${queryParams.dataSourceId}`
+  const url = dataSourceId
+    ? `${baseUrl}/${dataSourceId}`
     : baseUrl;
 
   return {
@@ -442,7 +444,7 @@ export const searchDetector = (requestBody: any): APIAction => ({
 export const updateDetector = (
   detectorId: string,
   requestBody: Detector,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorId}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -459,7 +461,7 @@ export const updateDetector = (
 
 export const deleteDetector = (
   detectorId: string,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorId}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -473,7 +475,7 @@ export const deleteDetector = (
 
 export const startDetector = (
   detectorId: string,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorId}/start`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -487,7 +489,7 @@ export const startDetector = (
 
 export const startHistoricalDetector = (
   detectorId: string,
-  dataSourceId: string,
+  dataSourceId: string = '',
   startTime: number,
   endTime: number
 ): APIAction => {
@@ -513,7 +515,7 @@ export const startHistoricalDetector = (
 
 export const stopDetector = (
   detectorId: string,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorId}/stop/${false}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -527,7 +529,7 @@ export const stopDetector = (
 
 export const stopHistoricalDetector = (
   detectorId: string,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorId}/stop/${true}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -548,7 +550,8 @@ export const getDetectorProfile = (detectorId: string): APIAction => ({
 
 export const matchDetector = (
   detectorName: string, 
-  dataSourceId: string): APIAction => {
+  dataSourceId: string = ''
+): APIAction => {
     const baseUrl = `..${AD_NODE_API.DETECTOR}/${detectorName}/_match`;
     const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
 
@@ -558,7 +561,7 @@ export const matchDetector = (
   };
 };
 
-export const getDetectorCount = (dataSourceId: string): APIAction => {
+export const getDetectorCount = (dataSourceId: string = ''): APIAction => {
   const url = dataSourceId ? 
     `..${AD_NODE_API.DETECTOR}/_count/${dataSourceId}` : 
     `..${AD_NODE_API.DETECTOR}/_count`;

--- a/public/redux/reducers/alerting.ts
+++ b/public/redux/reducers/alerting.ts
@@ -94,7 +94,7 @@ const reducer = handleActions<Monitors>(
   initialDetectorsState
 );
 
-export const searchMonitors = (dataSourceId: string): APIAction => {
+export const searchMonitors = (dataSourceId: string = ''): APIAction => {
   const baseUrl = `..${ALERTING_NODE_API._SEARCH}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
 
@@ -108,7 +108,7 @@ export const searchAlerts = (
   monitorId: string,
   startTime: number,
   endTime: number,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${ALERTING_NODE_API.ALERTS}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;

--- a/public/redux/reducers/anomalyResults.ts
+++ b/public/redux/reducers/anomalyResults.ts
@@ -94,7 +94,7 @@ const reducer = handleActions<Anomalies>(
 
 export const getDetectorResults = (
   id: string,
-  dataSourceId: string,
+  dataSourceId: string = '',
   queryParams: any,
   isHistorical: boolean,
   resultIndex: string,
@@ -119,7 +119,7 @@ export const getDetectorResults = (
 export const searchResults = (
   requestBody: any,
   resultIndex: string,
-  dataSourceId: string,
+  dataSourceId: string = '',
   onlyQueryCustomResultIndex: boolean
 ): APIAction => {
   let baseUrl = `..${AD_NODE_API.DETECTOR}/results/_search`;

--- a/public/redux/reducers/opensearch.ts
+++ b/public/redux/reducers/opensearch.ts
@@ -21,6 +21,7 @@ import { getPathsPerDataType } from './mapper';
 import { CatIndex, IndexAlias } from '../../../server/models/types';
 import { AD_NODE_API } from '../../../utils/constants';
 import { get } from 'lodash';
+import { data } from 'jquery';
 
 const GET_INDICES = 'opensearch/GET_INDICES';
 const GET_ALIASES = 'opensearch/GET_ALIASES';
@@ -246,7 +247,7 @@ const reducer = handleActions<OpenSearchState>(
   initialState
 );
 
-export const getIndices = (searchKey = '', dataSourceId: string) => {
+export const getIndices = (searchKey = '', dataSourceId: string = '') => {
   const baseUrl = `..${AD_NODE_API._INDICES}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
 
@@ -259,7 +260,7 @@ export const getIndices = (searchKey = '', dataSourceId: string) => {
 
 export const getAliases = (
   searchKey: string = '',
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const baseUrl = `..${AD_NODE_API._ALIASES}`;
   const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
@@ -271,7 +272,7 @@ export const getAliases = (
   };
 };
 
-export const getMappings = (searchKey: string = '', dataSourceId: string): APIAction => {
+export const getMappings = (searchKey: string = '', dataSourceId: string = ''): APIAction => {
   const url = dataSourceId ? `${AD_NODE_API._MAPPINGS}/${dataSourceId}` : AD_NODE_API._MAPPINGS;
 
   return {
@@ -291,7 +292,7 @@ export const searchOpenSearch = (requestData: any): APIAction => ({
     }),
 });
 
-export const createIndex = (indexConfig: any, dataSourceId: string): APIAction => {
+export const createIndex = (indexConfig: any, dataSourceId: string = ''): APIAction => {
   const url = dataSourceId
     ? `${AD_NODE_API.CREATE_INDEX}/${dataSourceId}`
     : AD_NODE_API.CREATE_INDEX;
@@ -304,7 +305,7 @@ export const createIndex = (indexConfig: any, dataSourceId: string): APIAction =
   };
 };
 
-export const bulk = (body: any, dataSourceId: string): APIAction => {
+export const bulk = (body: any, dataSourceId: string = ''): APIAction => {
   const url = dataSourceId
     ? `${AD_NODE_API.BULK}/${dataSourceId}`
     : AD_NODE_API.BULK;
@@ -322,7 +323,7 @@ export const deleteIndex = (index: string): APIAction => ({
 });
 
 export const getPrioritizedIndices =
-  (searchKey: string, dataSourceId: string): ThunkAction =>
+  (searchKey: string, dataSourceId: string = ''): ThunkAction =>
   async (dispatch, getState) => {
     //Fetch Indices and Aliases with text provided
     await dispatch(getIndices(searchKey, dataSourceId));

--- a/public/redux/reducers/previewAnomalies.ts
+++ b/public/redux/reducers/previewAnomalies.ts
@@ -59,7 +59,7 @@ const reducer = handleActions<PreviewAnomalies>(
   initialDetectorsState
 );
 
-export const previewDetector = (requestBody: any, dataSourceId: string): APIAction => {
+export const previewDetector = (requestBody: any, dataSourceId: string = ''): APIAction => {
   const baseUrl = `..${AD_NODE_API.DETECTOR}/preview`;
   const url =  dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
 

--- a/public/redux/reducers/sampleData.ts
+++ b/public/redux/reducers/sampleData.ts
@@ -56,7 +56,7 @@ const reducer = handleActions<SampleDataState>(
 
 export const createSampleData = (
   sampleDataType: SAMPLE_TYPE,
-  dataSourceId: string
+  dataSourceId: string = ''
 ): APIAction => {
   const url = dataSourceId
     ? `..${AD_NODE_API.CREATE_SAMPLE_DATA}/${sampleDataType}/${dataSourceId}`


### PR DESCRIPTION
### Description

Previously, we define dataSourceId as empty if it doesn't exist url. However, mds team introduced a change that treats empty dataSourceId as the local cluster scenario, and only undefined actionOption will render the default remote data source. Therefore, we have to adopt this change and assign dataSourceId as undefined when it's not presented in the url.

### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/721

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
