### PR TITLE
MDS local cluster scanrio bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "devDependencies": {
     "@testing-library/user-event": "^12.1.6",
     "@types/react-plotly.js": "^2.6.0",
-    "@types/redux-mock-store": "^1.0.1",
+    "@types/redux-mock-store": "^1.0.6",
     "babel-polyfill": "^6.26.0",
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "lint-staged": "^9.2.0",
     "moment": "^2.24.0",
-    "redux-mock-store": "^1.5.3",
+    "redux-mock-store": "^1.5.4",
     "start-server-and-test": "^1.11.7"
   },
   "dependencies": {

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -68,6 +68,7 @@ import { RouteComponentProps } from 'react-router-dom';
 
 interface OverviewProps extends RouteComponentProps {
   setActionMenu: (menuMount: MountPoint | undefined) => void;
+  landingDataSourceId: string | undefined;
 }
 
 export function DashboardOverview(props: OverviewProps) {
@@ -91,11 +92,11 @@ export function DashboardOverview(props: OverviewProps) {
   const queryParams = getDataSourceFromURL(props.location);
   const [MDSOverviewState, setMDSOverviewState] = useState<MDSStates>({
     queryParams,
-    selectedDataSourceId: queryParams.dataSourceId
-      ? queryParams.dataSourceId
-      : undefined,
+    selectedDataSourceId: queryParams.dataSourceId === undefined 
+      ? undefined 
+      : queryParams.dataSourceId,
   });
-
+  
   const getDetectorOptions = (detectorsIdMap: {
     [key: string]: DetectorListItem;
   }) => {
@@ -215,13 +216,15 @@ export function DashboardOverview(props: OverviewProps) {
 
   useEffect(() => {
     const { history, location } = props;
-    const updatedParams = {
-      dataSourceId: MDSOverviewState.selectedDataSourceId,
-    };
-    history.replace({
-      ...location,
-      search: queryString.stringify(updatedParams),
-    });
+    if (dataSourceEnabled) {
+      const updatedParams = {
+        dataSourceId: MDSOverviewState.selectedDataSourceId,
+      };
+      history.replace({
+        ...location,
+        search: queryString.stringify(updatedParams),
+      });
+    }
     intializeDetectors();
   }, [MDSOverviewState]);
 
@@ -274,9 +277,10 @@ export function DashboardOverview(props: OverviewProps) {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: MDSOverviewState.selectedDataSourceId !== undefined 
-              ? [{ id: MDSOverviewState.selectedDataSourceId }]
-              : undefined,
+            activeOption: props.landingDataSourceId === undefined 
+              || MDSOverviewState.selectedDataSourceId === undefined
+                ? undefined
+                : [{ id: MDSOverviewState.selectedDataSourceId }],
             savedObjects: getSavedObjectsClient(),
             notifications: getNotifications(),
             onSelectedDataSources: (dataSources) =>

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -98,7 +98,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
 
   const [MDSCreateState, setMDSCreateState] = useState<MDSStates>({
     queryParams: MDSQueryParams,
-    selectedDataSourceId: dataSourceId ? dataSourceId : undefined,
+    selectedDataSourceId: dataSourceId === undefined? undefined : dataSourceId,
   });
 
   // To handle backward compatibility, we need to pass some fields via

--- a/public/pages/DetectorsList/utils/__tests__/helpers.test.ts
+++ b/public/pages/DetectorsList/utils/__tests__/helpers.test.ts
@@ -30,7 +30,7 @@ describe('helpers spec', () => {
         indices: '',
         sortField: 'name',
         sortDirection: SORT_DIRECTION.ASC,
-        dataSourceId: '',
+        dataSourceId: undefined,
       });
     });
     test('should  default values if missing from queryParams', () => {
@@ -43,7 +43,7 @@ describe('helpers spec', () => {
         indices: '',
         sortField: 'name',
         sortDirection: SORT_DIRECTION.ASC,
-        dataSourceId:'',
+        dataSourceId: undefined,
       });
     });
     test('should return queryParams from location', () => {
@@ -59,7 +59,7 @@ describe('helpers spec', () => {
         indices: 'someIndex',
         sortField: 'name',
         sortDirection: SORT_DIRECTION.DESC,
-        dataSourceId:'',
+        dataSourceId: undefined,
       });
     });
   });

--- a/public/pages/DetectorsList/utils/helpers.ts
+++ b/public/pages/DetectorsList/utils/helpers.ts
@@ -47,9 +47,11 @@ export const getURLQueryParams = (location: {
       typeof sortDirection !== 'string'
         ? DEFAULT_QUERY_PARAMS.sortDirection
         : (sortDirection as SORT_DIRECTION),
-    dataSourceId: typeof dataSourceId !== 'string' ? '' : dataSourceId,
+    dataSourceId: dataSourceId === undefined ? undefined : dataSourceId,
   };
 };
+
+
 
 // For realtime detectors: cannot have 'Finished' state
 export const getDetectorStateOptions = () => {

--- a/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
+++ b/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
@@ -70,6 +70,7 @@ import { MDSStates } from '../../../models/interfaces';
 
 interface AnomalyDetectionOverviewProps extends RouteComponentProps {
   setActionMenu: (menuMount: MountPoint | undefined) => void;
+  landingDataSourceId: string | undefined;
 }
 
 export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
@@ -103,9 +104,9 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
   const queryParams = getDataSourceFromURL(props.location);
   const [MDSOverviewState, setMDSOverviewState] = useState<MDSStates>({
     queryParams,
-    selectedDataSourceId: queryParams.dataSourceId
-      ? queryParams.dataSourceId
-      : undefined,
+    selectedDataSourceId: queryParams.dataSourceId === undefined 
+      ? undefined 
+      : queryParams.dataSourceId,
   });
 
   // Set breadcrumbs on page initialization
@@ -120,14 +121,16 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
   // Getting all initial sample detectors & indices
   useEffect(() => {
     const { history, location } = props;
-    const updatedParams = {
-      dataSourceId: MDSOverviewState.selectedDataSourceId,
-    };
-    history.replace({
-      ...location,
-      search: queryString.stringify(updatedParams),
-    });
+    if (dataSourceEnabled && props.landingDataSourceId !== undefined) {
+      const updatedParams = {
+        dataSourceId: MDSOverviewState.selectedDataSourceId,
+      };
 
+      history.replace({
+        ...location,
+        search: queryString.stringify(updatedParams),
+      });
+    } 
     fetchData();
   }, [MDSOverviewState]);
 
@@ -247,9 +250,10 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: MDSOverviewState.selectedDataSourceId !== undefined 
-              ? [{ id: MDSOverviewState.selectedDataSourceId }]
-              : undefined,
+            activeOption: props.landingDataSourceId === undefined 
+              || MDSOverviewState.selectedDataSourceId === undefined
+                ? undefined
+                : [{ id: MDSOverviewState.selectedDataSourceId }],
             savedObjects: getSavedObjectsClient(),
             notifications: getNotifications(),
             onSelectedDataSources: (dataSources) =>

--- a/public/pages/main/Main.tsx
+++ b/public/pages/main/Main.tsx
@@ -48,8 +48,8 @@ export function Main(props: MainProps) {
   const adState = useSelector((state: AppState) => state.ad);
   const totalDetectors = adState.totalDetectors;
   const queryParams = getURLQueryParams(props.location);
-  const dataSourceId = queryParams.dataSourceId ? queryParams.dataSourceId : '';
-
+  const dataSourceId = queryParams.dataSourceId === undefined ? undefined : queryParams.dataSourceId;
+  
   const sideNav = [
     {
       name: Navigation.AnomalyDetection,
@@ -99,6 +99,7 @@ export function Main(props: MainProps) {
                   render={(props: RouteComponentProps) => (
                     <DashboardOverview
                       setActionMenu={setHeaderActionMenu}
+                      landingDataSourceId={dataSourceId}
                       {...props}
                     />
                   )}
@@ -155,6 +156,7 @@ export function Main(props: MainProps) {
                   render={(props: RouteComponentProps) => (
                     <AnomalyDetectionOverview
                       setActionMenu={setHeaderActionMenu}
+                      landingDataSourceId={dataSourceId}
                       {...props}
                     />
                   )}
@@ -165,11 +167,13 @@ export function Main(props: MainProps) {
                     totalDetectors > 0 ? (
                       <DashboardOverview
                         setActionMenu={setHeaderActionMenu}
+                        landingDataSourceId={dataSourceId}
                         {...props}
                       />
                     ) : (
                       <AnomalyDetectionOverview
                         setActionMenu={setHeaderActionMenu}
+                        landingDataSourceId={dataSourceId}
                         {...props}
                       />
                     )

--- a/public/pages/utils/helpers.ts
+++ b/public/pages/utils/helpers.ts
@@ -165,10 +165,13 @@ export const constructHrefWithDataSourceId = (
     url.set(DETECTORS_QUERY_PARAMS.SEARCH, DEFAULT_QUERY_PARAMS.search);
     url.set(DETECTORS_QUERY_PARAMS.INDICES, DEFAULT_QUERY_PARAMS.indices);
     url.set(DETECTORS_QUERY_PARAMS.SORT_FIELD, DEFAULT_QUERY_PARAMS.sortField);
-    url.set(DETECTORS_QUERY_PARAMS.SORT_DIRECTION, SORT_DIRECTION.ASC);
+    url.set(DETECTORS_QUERY_PARAMS.SORT_DIRECTION, SORT_DIRECTION.ASC)
+    if (dataSourceEnabled) {
+      url.set(DETECTORS_QUERY_PARAMS.DATASOURCEID, '');
+    }
   }
 
-  if (dataSourceEnabled && dataSourceId) {
+  if (dataSourceEnabled && dataSourceId !== undefined) {
     url.set('dataSourceId', dataSourceId);
   }
 

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -54,6 +54,7 @@ export enum DETECTORS_QUERY_PARAMS {
   SORT_FIELD = 'sortField',
   SORT_DIRECTION = 'sortDirection',
   NAME = 'name',
+  DATASOURCEID = 'dataSourceId',
 }
 
 export enum AD_DOC_FIELDS {

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,10 +136,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/redux-mock-store@^1.0.1":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/redux-mock-store/-/redux-mock-store-1.0.3.tgz#895de4a364bc4836661570aec82f2eef5989d1fb"
-  integrity sha512-Wqe3tJa6x9MxMN4DJnMfZoBRBRak1XTPklqj4qkVm5VBpZnC8PSADf4kLuFQ9NAdHaowfWoEeUMz7NWc2GMtnA==
+"@types/redux-mock-store@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/redux-mock-store/-/redux-mock-store-1.0.6.tgz#0a03b2655028b7cf62670d41ac1de5ca1b1f5958"
+  integrity sha512-eg5RDfhJTXuoJjOMyXiJbaDb1B8tfTaJixscmu+jOusj6adGC0Krntz09Tf4gJgXeCqCrM5bBMd+B7ez0izcAQ==
   dependencies:
     redux "^4.0.5"
 
@@ -1432,7 +1432,7 @@ readable-stream@^3.6.0, readable-stream@^3.6.2:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-redux-mock-store@^1.5.3:
+redux-mock-store@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.4.tgz#90d02495fd918ddbaa96b83aef626287c9ab5872"
   integrity sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==


### PR DESCRIPTION
### Description

This PR includes the following bug fixes:
- side navigation bar link doesn't work when data source is local cluster
- when local cluster is selected, it always jump back to default data source selection on fresh 
- the first breadcrumb doesn't work on list page when local cluster is selected

The above two bugs are fixed by making the following changes:
- update breadcrumbs setting on list page. The previous implementation inverted MDS enabled case and MDS disabled case
- make sure when checking if dataSourceId is set in the url, only set dataSourceId as undefined when the query param dataSourceId is undefined
- introduce a new prop - landingDataSourceId that keeps track of if dataSourceId exist in the url on landing pages (Overview page and Dashboard page). In this way, default data source will be selected when opening AD from OSD side navigation bar but select the data source in the url when fresh the page. 

All bugs can be reproduced on future playground side, and here's a screen record that shows the result after this bug fixes. The screen record was tested with turning on/off `data_source.enabled` setting and `data_source.hideLocalCluster` setting

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/assets/41348518/a8047e83-d3ce-4050-8a7a-2ff4b469f54b




### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
