### PR TITLE
clean selected field values when switching data source on create page

### DIFF
--- a/public/pages/DefineDetector/components/Datasource/DataSource.tsx
+++ b/public/pages/DefineDetector/components/Datasource/DataSource.tsx
@@ -10,7 +10,7 @@
  */
 
 import { EuiComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
-import { Field, FieldProps, FormikProps } from 'formik';
+import { Field, FieldProps, FormikProps, useFormikContext } from 'formik';
 import { debounce, get } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -58,7 +58,13 @@ export function DataSource(props: DataSourceProps) {
   );
   const [queryText, setQueryText] = useState('');
   const opensearchState = useSelector((state: AppState) => state.opensearch);
+  const { setFieldValue } = useFormikContext();
+
   useEffect(() => {
+    setFieldValue('index', []);
+    setFieldValue('timeField', undefined);
+    setFieldValue('filters', []);
+
     const getInitialIndices = async () => {
       await dispatch(getIndices(queryText, dataSourceId));
     };
@@ -102,7 +108,7 @@ export function DataSource(props: DataSourceProps) {
   const visibleAliases = get(opensearchState, 'aliases', []) as IndexAlias[];
 
   return (
-    <ContentPanel title="Data Source" titleSize="s">
+    <ContentPanel title="Select Data" titleSize="s">
       {props.isEdit && isDifferentIndex() ? (
         <div>
           <EuiCallOut

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -165,14 +165,16 @@ export const DefineDetector = (props: DefineDetectorProps) => {
 
   // If no detector found with ID, redirect it to list
   useEffect(() => {
-    const { history, location } = props;
-    const updatedParams = {
-      dataSourceId: MDSCreateState.selectedDataSourceId,
-    };
-    history.replace({
-      ...location,
-      search: queryString.stringify(updatedParams),
-    });
+    if (dataSourceEnabled) {
+      const { history, location } = props;
+      const updatedParams = {
+        dataSourceId: MDSCreateState.selectedDataSourceId,
+      };
+      history.replace({
+        ...location,
+        search: queryString.stringify(updatedParams),
+      });
+    }
     if (props.isEdit && hasError) {
       core.notifications.toasts.addDanger(
         'Unable to find the detector for editing'

--- a/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
+++ b/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
             class="euiTitle euiTitle--small"
             data-test-subj="contentPanelTitle"
           >
-            Data Source
+            Select Data
           </h3>
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -528,11 +528,11 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
-                      <span
-                        class="euiComboBoxPill euiComboBoxPill--plainText"
+                      <p
+                        class="euiComboBoxPlaceholder"
                       >
-                        timestamp
-                      </span>
+                        Find timestamp
+                      </p>
                       <div
                         class="euiComboBox__input"
                         style="font-size: 14px; display: inline-block;"
@@ -1175,7 +1175,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
             class="euiTitle euiTitle--small"
             data-test-subj="contentPanelTitle"
           >
-            Data Source
+            Select Data
           </h3>
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
@@ -2152,7 +2152,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
             class="euiTitle euiTitle--small"
             data-test-subj="contentPanelTitle"
           >
-            Data Source
+            Select Data
           </h3>
           <div
             class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"


### PR DESCRIPTION
### Description

This pr includes three things:
- update Data Source card title to Select Data on create page to avoid confusion with MDS support
- clean selections on create page when switching data sources
- only append dataSourceId to the create page url when MDS is enabled


https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/assets/41348518/e9c3e6f4-bcb3-47d4-a772-113c913a7ede


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
