### PR TITLE
Remove unnecessary sleep between test runs

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -142,21 +142,16 @@ jobs:
       - name: Finding spec files and store to output
         id: finding-files
         run: |
-          echo "::set-output name=FILELIST::$(find cypress/integration/plugins/anomaly-detection-dashboards-plugin -name '*.js' -print)"
-        working-directory: opensearch-dashboards-functional-test
-  
-      - name: Print spec files from output
-        run: |
-          IFS="," read -a myarray <<< ${{ steps.finding-files.outputs.FILELIST }}
-          for i in "${myarray[@]}"; do
-            echo "${i}"
-          done
+          {
+            echo 'FILELIST<<EOF'
+            find cypress/integration/plugins/anomaly-detection-dashboards-plugin -name '*.js' -print 
+            echo EOF
+          } >> "$GITHUB_ENV"
         working-directory: opensearch-dashboards-functional-test
 
       - name: Run spec files from output
         run: |
-          IFS="," read -a myarray <<< ${{ steps.finding-files.outputs.FILELIST }}
-          for i in "${myarray[@]}"; do
+          for i in $FILELIST; do
             yarn cypress:run-without-security --browser electron --spec "${i}"
             sleep 60
           done


### PR DESCRIPTION
### Description

The introduction of `sleep` between test runs in `dashboard_spec.js` and `detector_list_spec.js` was initially implemented to handle timing issues. However, these tests were actually failing due to a recent URL change, as detailed in https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1257.

With the root cause of the failures addressed, the delays introduced by `sleep` commands are now redundant and can potentially slow down the testing process without providing any benefit. This PR removes these unnecessary sleep intervals between test executions.

**Testing Done:**
- Confirmed that all remote Cypress tests pass without the sleep intervals.

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
