### PR TITLE
Fix Warning Message About Custom Result Index Despite Existing Indices

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-polyfill": "^6.26.0",
     "eslint-plugin-no-unsanitized": "^3.0.2",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
+    "jest-canvas-mock": "^2.5.2",
     "lint-staged": "^9.2.0",
     "moment": "^2.24.0",
     "redux-mock-store": "^1.5.4",

--- a/public/pages/DetectorDetail/containers/__tests__/CustomIndexErrorMsg.test.tsx
+++ b/public/pages/DetectorDetail/containers/__tests__/CustomIndexErrorMsg.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DetectorDetail, DetectorRouterProps } from '../DetectorDetail';
+import { Provider } from 'react-redux';
+import {
+  HashRouter as Router,
+  RouteComponentProps,
+  Route,
+  Switch,
+  Redirect,
+} from 'react-router-dom';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { httpClientMock, coreServicesMock } from '../../../../../test/mocks';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+import { getRandomDetector } from '../../../../redux/reducers/__tests__/utils';
+import { useFetchDetectorInfo } from '../../../CreateDetectorSteps/hooks/useFetchDetectorInfo';
+
+jest.mock('../../hooks/useFetchMonitorInfo');
+
+//jest.mock('../../../CreateDetectorSteps/hooks/useFetchDetectorInfo');
+jest.mock('../../../CreateDetectorSteps/hooks/useFetchDetectorInfo', () => ({
+  // The jest.mock function is used at the top level of the test file to mock the entire module.
+  // Within each test, the mock implementation for useFetchDetectorInfo is set using jest.Mock.
+  // This ensures that the hook returns the desired values for each test case.
+  useFetchDetectorInfo: jest.fn(),
+}));
+
+jest.mock('../../../../services', () => ({
+  ...jest.requireActual('../../../../services'),
+
+  getDataSourceEnabled: () => ({
+    enabled: false,
+  }),
+}));
+
+const detectorId = '4QY4YHEB5W9C7vlb3Mou';
+
+// Configure the mock store
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+const renderWithRouter = (detectorId: string, initialState: any) => ({
+  ...render(
+    <Provider store={mockStore(initialState)}>
+      <Router>
+        <Switch>
+          <Route
+            path={`/detectors/${detectorId}/results`}
+            render={(props: RouteComponentProps<DetectorRouterProps>) => {
+              const testProps = {
+                ...props,
+                match: {
+                  params: { detectorId: detectorId },
+                  isExact: false,
+                  path: '',
+                  url: '',
+                },
+              };
+              return (
+                <CoreServicesContext.Provider value={coreServicesMock}>
+                  <DetectorDetail {...testProps} />
+                </CoreServicesContext.Provider>
+              );
+            }}
+          />
+          <Redirect from="/" to={`/detectors/${detectorId}/results`} />
+        </Switch>
+      </Router>
+    </Provider>
+  ),
+});
+
+const resultIndex = 'opensearch-ad-plugin-result-test-query2';
+
+describe('detector detail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('detector info still loading', () => {
+    const detectorInfo = {
+      detector: getRandomDetector(true, resultIndex),
+      hasError: false,
+      isLoadingDetector: true,
+      errorMessage: undefined,
+    };
+
+    (useFetchDetectorInfo as jest.Mock).mockImplementation(() => detectorInfo);
+
+    const initialState = {
+      opensearch: {
+        indices: [{ health: 'green', index: resultIndex }],
+        requesting: false,
+      },
+      ad: {
+        detectors: {},
+      },
+      alerting: {
+        monitors: {},
+      },
+    };
+
+    renderWithRouter(detectorId, initialState);
+    const element = screen.queryByTestId('missingResultIndexCallOut');
+
+    // Assert that the element is not in the document
+    expect(element).toBeNull();
+  });
+
+  test('detector has no result index', () => {
+    const detectorInfo = {
+      detector: getRandomDetector(true, undefined),
+      hasError: false,
+      isLoadingDetector: true,
+      errorMessage: undefined,
+    };
+
+    (useFetchDetectorInfo as jest.Mock).mockImplementation(() => detectorInfo);
+
+    const initialState = {
+      opensearch: {
+        indices: [{ health: 'green', index: resultIndex }],
+        requesting: false,
+      },
+      ad: {
+        detectors: {},
+      },
+      alerting: {
+        monitors: {},
+      },
+    };
+
+    renderWithRouter(detectorId, initialState);
+    const element = screen.queryByTestId('missingResultIndexCallOut');
+
+    // Assert that the element is not in the document
+    expect(element).toBeNull();
+  });
+
+  test('cat indices are being requested', () => {
+    const detectorInfo = {
+      detector: getRandomDetector(true, resultIndex),
+      hasError: false,
+      isLoadingDetector: false,
+      errorMessage: undefined,
+    };
+
+    (useFetchDetectorInfo as jest.Mock).mockImplementation(() => detectorInfo);
+
+    const initialState = {
+      opensearch: {
+        indices: [],
+        requesting: true,
+      },
+      ad: {
+        detectors: {},
+      },
+      alerting: {
+        monitors: {},
+      },
+    };
+
+    renderWithRouter(detectorId, initialState);
+    const element = screen.queryByTestId('missingResultIndexCallOut');
+
+    // Assert that the element is not in the document
+    expect(element).toBeNull();
+  });
+
+  test('visible indices are empty', () => {
+    const detectorInfo = {
+      detector: getRandomDetector(true, resultIndex),
+      hasError: false,
+      isLoadingDetector: false,
+      errorMessage: undefined,
+    };
+
+    (useFetchDetectorInfo as jest.Mock).mockImplementation(() => detectorInfo);
+
+    const initialState = {
+      opensearch: {
+        indices: [],
+        requesting: false,
+      },
+      ad: {
+        detectors: {},
+      },
+      alerting: {
+        monitors: {},
+      },
+    };
+
+    renderWithRouter(detectorId, initialState);
+    const element = screen.queryByTestId('missingResultIndexCallOut');
+
+    // Assert that the element is not in the document
+    expect(element).toBeNull();
+  });
+
+  test('the result index is not found in the visible indices', () => {
+    const detectorInfo = {
+      detector: getRandomDetector(true, resultIndex),
+      hasError: false,
+      isLoadingDetector: false,
+      errorMessage: undefined,
+    };
+
+    (useFetchDetectorInfo as jest.Mock).mockImplementation(() => detectorInfo);
+
+    const initialState = {
+      opensearch: {
+        indices: [{ health: 'green', index: '.kibana_-962704462_v992471_1' }],
+        requesting: false,
+      },
+      ad: {
+        detectors: {},
+      },
+      alerting: {
+        monitors: {},
+      },
+    };
+
+    renderWithRouter(detectorId, initialState);
+    const element = screen.queryByTestId('missingResultIndexCallOut');
+
+    // Assert that the element is in the document
+    expect(element).not.toBeNull();
+  });
+
+  test('the result index is found in the visible indices', () => {
+    const detector = getRandomDetector(true, resultIndex);
+
+    // Set up the mock implementation for useFetchDetectorInfo
+    (useFetchDetectorInfo as jest.Mock).mockImplementation(() => ({
+      detector: detector,
+      hasError: false,
+      isLoadingDetector: false,
+      errorMessage: undefined,
+    }));
+
+    const initialState = {
+      opensearch: {
+        indices: [
+          { health: 'green', index: '.kibana_-962704462_v992471_1' },
+          { health: 'green', index: resultIndex },
+        ],
+        requesting: false,
+      },
+      ad: {
+        detectors: {},
+      },
+      alerting: {
+        monitors: {},
+      },
+    };
+
+    renderWithRouter(detectorId, initialState);
+    const element = screen.queryByTestId('missingResultIndexCallOut');
+
+    // Assert that the element is not in the document
+    expect(element).toBeNull();
+  });
+});

--- a/public/redux/reducers/__tests__/utils.ts
+++ b/public/redux/reducers/__tests__/utils.ts
@@ -10,7 +10,7 @@
  */
 
 import chance from 'chance';
-import { snakeCase } from 'lodash';
+import { isEmpty, snakeCase } from 'lodash';
 import {
   Detector,
   FeatureAttributes,
@@ -82,7 +82,10 @@ const getUIMetadata = (features: FeatureAttributes[]) => {
   } as UiMetaData;
 };
 
-export const getRandomDetector = (isCreate: boolean = true): Detector => {
+export const getRandomDetector = (
+  isCreate: boolean = true,
+  customResultIndex: string = ''
+): Detector => {
   const features = new Array(detectorFaker.natural({ min: 1, max: 5 }))
     .fill(null)
     .map(() => getRandomFeature(isCreate ? false : true));
@@ -116,6 +119,7 @@ export const getRandomDetector = (isCreate: boolean = true): Detector => {
     curState: DETECTOR_STATE.INIT,
     stateError: '',
     shingleSize: DEFAULT_SHINGLE_SIZE,
+    resultIndex: isEmpty(customResultIndex) ? undefined : customResultIndex
   };
 };
 

--- a/test/jest.config.js
+++ b/test/jest.config.js
@@ -54,4 +54,7 @@ module.exports = {
     '^.+\\.svg$': '<rootDir>/test/mocks/transformMock.ts',
     '^.+\\.html$': '<rootDir>/test/mocks/transformMock.ts',
   },
+  setupFiles: [
+    "jest-canvas-mock"
+  ]
 };

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -10,3 +10,4 @@
  */
 
 require('babel-polyfill');
+import 'jest-canvas-mock';


### PR DESCRIPTION
### Description

Customers were receiving a warning message about the detectors we have created on a production cluster. The message incorrectly warned that the result index for the detector is custom and is not present on the cluster, and would be recreated when real-time or historical detection starts for the detector. However, real-time detection had already been started for these detectors, and the result index did exist. Customers could consistently reproduce the bug, although I only succeeded once when creating a detector immediately after a cluster started.

The issue may arise from a potential race condition in the code when the statement finishes before the cat indices call completes (see this code segment https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/blob/main/public/pages/DetectorDetail/containers/DetectorDetail.tsx#L136-L140). This PR adds a check to ensure the cat indices call has finished before concluding that the index does not exist. Additionally, we check if the visible indices are empty. If they are, it likely indicates an issue retrieving existing indices. To be cautious, we choose not to show the error message and consider the result index as not missing.

This PR also resolves a warning message encountered during test runs due to the failure to mock HTMLCanvasElement. This was addressed by following the solution provided here: https://stackoverflow.com/questions/48828759/unit-test-raises-error-because-of-getcontext-is-not-implemented

```
console.error
    Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)
        at module.exports (/Users/kaituo/code/github/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/browser/not-implemented.js:9:17)
        at HTMLCanvasElementImpl.getContext (/Users/kaituo/code/github/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/nodes/HTMLCanvasElement-impl.js:42:5)
        at HTMLCanvasElement.getContext (/Users/kaituo/code/github/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/generated/HTMLCanvasElement.js:131:58)
        at Object.23352 (/Users/kaituo/code/github/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/plotly.js-dist/plotly.js:201984:42)
```

This PR also resolves TypeError that will fail the newly added tests.

```
/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/DetectorDetail.tsx:4560
              "catch"](function (error) {
                      ^

TypeError: dispatch(...).catch is not a function
    at _callee$ (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/DetectorDetail.tsx:4560:23)
    at tryCatch (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:44:17)
    at Generator.<anonymous> (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:125:22)
    at Generator.next (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/regeneratorRuntime.js:69:21)
    at asyncGeneratorStep (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/asyncToGenerator.js:22:9)
    at /Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/asyncToGenerator.js:27:7
    at new Promise (<anonymous>)
    at /Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/node_modules/@babel/runtime/helpers/asyncToGenerator.js:19:12
    at getInitialIndices (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/DetectorDetail.tsx:4576:22)
    at /Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/DetectorDetail.tsx:4586:7
    at commitHookEffectListMount (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:17092:30)
    at commitPassiveHookEffects (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:17124:15)
    at HTMLUnknownElement.callCallback (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:171:18)
    at HTMLUnknownElement.callTheUserObjectsOperation (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
    at innerInvokeEventListeners (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:338:25)
    at invokeEventListeners (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:274:3)
    at HTMLUnknownElementImpl._dispatch (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:221:9)
    at HTMLUnknownElementImpl.dispatchEvent (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:94:17)
    at HTMLUnknownElement.dispatchEvent (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:231:34)
    at Object.invokeGuardedCallbackDev (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:215:20)
    at invokeGuardedCallback (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:263:35)
    at flushPassiveEffectsImpl (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:19754:13)
    at unstable_runWithPriority (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/scheduler/cjs/scheduler.development.js:574:16)
    at runWithPriority$1 (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:9740:14)
    at flushPassiveEffects (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom.development.js:19727:16)
    at Object.<anonymous>.flushWork (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom-test-utils.development.js:766:14)
    at act (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/react-dom/cjs/react-dom-test-utils.development.js:869:13)
    at render (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/@testing-library/react/dist/pure.js:157:29)
    at renderWithRouter (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/__tests__/CustomIndexErrorMsg.test.tsx:62:47)
    at Object.<anonymous> (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/__tests__/CustomIndexErrorMsg.test.tsx:175:5)
    at Promise.then.completed (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jest-circus/build/utils.js:391:28)
    at new Promise (<anonymous>)
    at callAsyncCircusFn (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jest-circus/build/utils.js:316:10)
    at _callCircusTest (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jest-circus/build/run.js:218:40)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at _runTest (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jest-circus/build/run.js:155:3)
    at _runTestsForDescribeBlock (/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/node_modules/jest-circus/build/run.js:66:9)
    at _runTestsForDescribeBlock (/Users/runner/work/anoma/Users/runner/work/anomaly-detection-dashboards-plugin/anomaly-detection-dashboards-plugin/OpenSearch-Dashboards/plugins/anomaly-detection-dashboards-plugin/public/pages/DetectorDetail/containers/DetectorDetail.tsx:4560
              "catch"](function (error) {
                      ^
```

The TypeError is caused by the following code in DetectorDetail. The dispatch function from Redux does not return a promise by default. To handle asynchronous actions and their potential errors correctly, the PR uses try-catch around the dispatch call.

```
await dispatch(getIndices('', dataSourceId)).catch((error: any) => {
        console.error(error);
        core.notifications.toasts.addDanger('Error getting all indices');
      });
```

Testing Done:
* Conducted end-to-end testing to confirm there is no regression due to these changes.
* Added unit tests.

### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/758

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
