### PR TITLE
fix a MDS related bug on feature anywhere page

### DIFF
--- a/public/expressions/helpers.ts
+++ b/public/expressions/helpers.ts
@@ -52,6 +52,9 @@ export const getAnomalies = async (
       }
     );
   } else {
+    if (!resultIndex.endsWith('*')) {
+      resultIndex += '*';
+    }
     anomalySummaryResponse = await getClient().post(
       `..${AD_NODE_API.DETECTOR}/results/_search/${resultIndex}/true/${dataSourceId}`,
       {

--- a/public/expressions/overlay_anomalies.ts
+++ b/public/expressions/overlay_anomalies.ts
@@ -134,7 +134,8 @@ export const overlayAnomaliesFunction =
           detectorId,
           startTimeInMillis,
           endTimeInMillis,
-          resultIndex
+          resultIndex,
+          dataSourceId
         );
         const anomalyLayer = convertAnomaliesToPointInTimeEventsVisLayer(
           anomalies,


### PR DESCRIPTION
### Description

When reopening the create detector feature anywhere flyout after creating the detector, there's an error complaining about search anomalies API . The reason for that is dataSourceId was forgotten to be passed into the getAnomalies call

![Screenshot 2024-06-07 at 10 27 43 AM](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/assets/41348518/e2cd8e57-e323-4f49-a370-a528f1a343e8)


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
