### PR TITLE
make custom result index lifecycle management in AD optional

### DIFF
--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -392,6 +392,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
                 <CustomResultIndex
                   isEdit={props.isEdit}
                   resultIndex={get(formikProps, 'values.resultIndex')}
+                  formikProps={formikProps}
                 />
               </Fragment>
             </EuiPageBody>

--- a/public/pages/DefineDetector/models/interfaces.ts
+++ b/public/pages/DefineDetector/models/interfaces.ts
@@ -22,7 +22,7 @@ export interface DetectorDefinitionFormikValues {
   timeField: string;
   interval: number;
   windowDelay: number;
-  resultIndexMinAge?: number;
-  resultIndexMinSize?: number;
-  resultIndexTtl?:number;
+  resultIndexMinAge?: number | string;
+  resultIndexMinSize?: number | string;
+  resultIndexTtl?:number | string;
 }

--- a/public/pages/DefineDetector/utils/helpers.ts
+++ b/public/pages/DefineDetector/utils/helpers.ts
@@ -45,9 +45,9 @@ export function detectorDefinitionToFormik(
     timeField: ad.timeField,
     interval: get(ad, 'detectionInterval.period.interval', 10),
     windowDelay: get(ad, 'windowDelay.period.interval', 0),
-    resultIndexMinAge: get(ad, 'resultIndexMinAge', 7),
-    resultIndexMinSize:get(ad, 'resultIndexMinSize', 51200),
-    resultIndexTtl: get(ad, 'resultIndexTtl', 60),
+    resultIndexMinAge: get(ad, 'resultIndexMinAge', undefined),
+    resultIndexMinSize:get(ad, 'resultIndexMinSize', undefined),
+    resultIndexTtl: get(ad, 'resultIndexTtl', undefined),
   };
 }
 

--- a/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
+++ b/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
@@ -131,9 +131,13 @@ export const DetectorDefinitionFields = (
     }
   };
 
-  const minAge = get(props, 'detector.resultIndexMinAge', '-');
-  const minSize = get(props, 'detector.resultIndexMinSize', '-');
-  const ttl = get(props, 'detector.resultIndexTtl', '-');
+  const minAgeValue = get(props, 'detector.resultIndexMinAge', undefined);
+  const minAge = (minAgeValue === undefined) ? '- Days' : minAgeValue + " Days";
+  const minSizeValue = get(props, 'detector.resultIndexMinSize', undefined);
+  const minSize = (minSizeValue === undefined) ? '- MB' : minSizeValue + " MB";
+  const ttlValue = get(props, 'detector.resultIndexTtl', undefined);
+  const ttl = (ttlValue === undefined) ? '- Days' : ttlValue + " Days";
+
 
   return (
     <ContentPanel
@@ -224,19 +228,19 @@ export const DetectorDefinitionFields = (
         <EuiFlexItem>
           <ConfigCell
             title="Custom result index min age"
-            description={minAge === '-' ? minAge : `${minAge} Days`}
+            description={minAge}
           />
         </EuiFlexItem>
         <EuiFlexItem>
           <ConfigCell
             title="Custom result index min size"
-            description={minSize == '-' ? minSize : `${minSize} MB`}
+            description={minSize}
           />
         </EuiFlexItem>
         <EuiFlexItem>
           <ConfigCell
             title="Custom result index TTL"
-            description={ttl == '-' ? ttl : `${ttl} Days`}
+            description={ttl}
           />
         </EuiFlexItem>
       </EuiFlexGrid>

--- a/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
@@ -424,7 +424,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
                     <p
                       class="enabled"
                     >
-                      -
+                      - Days
                     </p>
                   </div>
                 </div>
@@ -458,7 +458,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
                     <p
                       class="enabled"
                     >
-                      -
+                      - MB
                     </p>
                   </div>
                 </div>
@@ -492,7 +492,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
                     <p
                       class="enabled"
                     >
-                      -
+                      - Days
                     </p>
                   </div>
                 </div>
@@ -1518,7 +1518,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                       <p
                         class="enabled"
                       >
-                        -
+                        - Days
                       </p>
                     </div>
                   </div>
@@ -1552,7 +1552,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                       <p
                         class="enabled"
                       >
-                        -
+                        - MB
                       </p>
                     </div>
                   </div>
@@ -1586,7 +1586,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                       <p
                         class="enabled"
                       >
-                        -
+                        - Days
                       </p>
                     </div>
                   </div>

--- a/public/utils/utils.tsx
+++ b/public/utils/utils.tsx
@@ -110,6 +110,11 @@ export const validatePositiveInteger = (value: any) => {
     return 'Must be a positive integer';
 };
 
+export const validateEmptyOrPositiveInteger = (value: any) => {
+  if (Number.isInteger(value) && value < 1)
+    return 'Must be a positive integer';
+};
+
 export const validateNonNegativeInteger = (value: any) => {
   if (!Number.isInteger(value) || value < 0)
     return 'Must be a non-negative integer';


### PR DESCRIPTION
### Description

make custom result index lifecycle management in AD optional, allow customer to choose if they want to manage their custom result index in AD or ISM

### Issues Resolved

https://github.com/opensearch-project/anomaly-detection/issues/1213

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
