### PR TITLE
fix the bug that index field is not getting populated when editing a …

### DIFF
--- a/public/pages/DefineDetector/components/Datasource/DataSource.tsx
+++ b/public/pages/DefineDetector/components/Datasource/DataSource.tsx
@@ -61,12 +61,11 @@ export function DataSource(props: DataSourceProps) {
   const { setFieldValue } = useFormikContext();
 
   useEffect(() => {
-    setFieldValue('index', []);
-    setFieldValue('timeField', undefined);
-    setFieldValue('filters', []);
-
     const getInitialIndices = async () => {
       await dispatch(getIndices(queryText, dataSourceId));
+      setFieldValue('index', props.formikProps.values.index);
+      setFieldValue('timeField', props.formikProps.values.timeField);
+      setFieldValue('filters', props.formikProps.values.filters);
     };
     getInitialIndices();
   }, [dataSourceId]);

--- a/release-notes/opensearch-anomaly-detection-dashboards.release-notes-2.15.0.0.md
+++ b/release-notes/opensearch-anomaly-detection-dashboards.release-notes-2.15.0.0.md
@@ -13,6 +13,7 @@ Compatible with OpenSearch Dashboards 2.15.0
 
 * Fix handling of special characters in categorical values ([#757](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/757))
 * Fix Warning Message About Custom Result Index Despite Existing Indices ([#759](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/759))
+* Fix index field not getting populated when editing a detector ([#783](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/783))
 
 ### Maintenance
 


### PR DESCRIPTION
### Description
When try to edit a detector from detector define page, index field is not get populated with value.

Addressed by changing the timing and sequence of setting index field values. Instead of setting initial field values first and data fetching next, the code now do data fetching first, then setting field values. 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
