### PR TITLE
Update Frontend CI to Use JDK 21

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        jdk: [ 11 ]
+        jdk: [ 21 ]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
### Description

This PR updates the frontend CI configuration to set up JDK 21, aligning with the baseline JDK 21 already set on the backend (https://github.com/opensearch-project/anomaly-detection/pull/1228). Without this update, remote tests in CI would fail with the error: "error: release version 21 not supported."

Testing:
* Verified that remote tests in CI pass successfully with JDK 21.

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
