### PR TITLE
[Look&Feel] Use smaller and compressed varients of buttons and form components

### DIFF
--- a/public/components/ConfigCell/ConfigCell.tsx
+++ b/public/components/ConfigCell/ConfigCell.tsx
@@ -9,11 +9,11 @@
  * GitHub history for details.
  */
 
-import { EuiText, EuiFormRow, EuiFormRowProps } from '@elastic/eui';
+import { EuiText, EuiCompressedFormRow, EuiFormRowProps } from '@elastic/eui';
 import React from 'react';
 
 export const FixedWidthRow = (props: EuiFormRowProps) => (
-  <EuiFormRow {...props} style={{ width: '250px' }} />
+  <EuiCompressedFormRow {...props} style={{ width: '250px' }} />
 );
 
 interface ConfigCellProps {

--- a/public/components/CreateDetectorButtons/CreateDetectorButtons.tsx
+++ b/public/components/CreateDetectorButtons/CreateDetectorButtons.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiButton } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSmallButton } from '@elastic/eui';
 import React from 'react';
 import { APP_PATH, PLUGIN_NAME } from '../../utils/constants';
 import { useLocation } from 'react-router-dom';
@@ -23,27 +23,27 @@ export const CreateDetectorButtons = () => {
   const createDetectorUrl = `${PLUGIN_NAME}#` + constructHrefWithDataSourceId(`${APP_PATH.CREATE_DETECTOR}`, dataSourceId, false);
 
   const sampleDetectorUrl = `${PLUGIN_NAME}#` + constructHrefWithDataSourceId(`${APP_PATH.OVERVIEW}`, dataSourceId, false);
-  
+
   return (
     <EuiFlexGroup direction="row" gutterSize="m" justifyContent="center">
       <EuiFlexItem grow={false}>
-        <EuiButton
+        <EuiSmallButton
           style={{ width: '200px' }}
           href={sampleDetectorUrl}
           data-test-subj="sampleDetectorButton"
         >
           Try a sample detector
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButton
+        <EuiSmallButton
           style={{ width: '200px' }}
           fill
           href={createDetectorUrl}
           data-test-subj="createDetectorButton"
         >
           Create detector
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/components/ConfirmUnlinkDetectorModal/ConfirmUnlinkDetectorModal.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/components/ConfirmUnlinkDetectorModal/ConfirmUnlinkDetectorModal.tsx
@@ -7,7 +7,7 @@ import React, { useState } from 'react';
 import {
   EuiText,
   EuiOverlayMask,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalHeader,
@@ -58,7 +58,7 @@ export const ConfirmUnlinkDetectorModal = (
               Cancel
             </EuiButtonEmpty>
           )}
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="confirmUnlinkButton"
             color="primary"
             fill
@@ -70,7 +70,7 @@ export const ConfirmUnlinkDetectorModal = (
             }}
           >
             {'Remove association'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/components/ConfirmUnlinkDetectorModal/ConfirmUnlinkDetectorModal.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/components/ConfirmUnlinkDetectorModal/ConfirmUnlinkDetectorModal.tsx
@@ -8,7 +8,7 @@ import {
   EuiText,
   EuiOverlayMask,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalHeader,
   EuiModalFooter,
@@ -51,12 +51,12 @@ export const ConfirmUnlinkDetectorModal = (
         </EuiModalBody>
         <EuiModalFooter>
           {isLoading ? null : (
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               data-test-subj="cancelUnlinkButton"
               onClick={props.onHide}
             >
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           )}
           <EuiSmallButton
             data-test-subj="confirmUnlinkButton"

--- a/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/containers/AssociatedDetectors.tsx
+++ b/public/components/FeatureAnywhereContextMenu/AssociatedDetectors/containers/AssociatedDetectors.tsx
@@ -10,7 +10,7 @@ import {
   EuiSpacer,
   EuiInMemoryTable,
   EuiFlyoutBody,
-  EuiButton,
+  EuiSmallButton,
   EuiFlyout,
   EuiFlexItem,
   EuiFlexGroup,
@@ -85,7 +85,7 @@ function AssociatedDetectors({ embeddable, closeFlyout, setMode }) {
       const indexPattern = await getSavedObjectsClient().get('index-pattern', indexPatternId);
       const refs = indexPattern.references as References[];
       const foundDataSourceId = refs.find(ref => ref.type === 'data-source')?.id;
-      setDataSourceId(foundDataSourceId); 
+      setDataSourceId(foundDataSourceId);
     } catch (error) {
       console.error("Error fetching index pattern:", error);
     }
@@ -270,7 +270,7 @@ function AssociatedDetectors({ embeddable, closeFlyout, setMode }) {
       getDetectorList(
         getAllDetectorsQueryParamsWithDataSourceId(dataSourceId)
       )
-    );  
+    );
   };
 
   const handleUnlinkDetectorAction = (detector: DetectorListItem) => {
@@ -371,7 +371,7 @@ function AssociatedDetectors({ embeddable, closeFlyout, setMode }) {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <div>
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="associateDetectorButton"
                   fill
                   disabled={associationLimitReached}
@@ -381,7 +381,7 @@ function AssociatedDetectors({ embeddable, closeFlyout, setMode }) {
                   }}
                 >
                   Associate a detector
-                </EuiButton>
+                </EuiSmallButton>
               </div>
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -9,7 +9,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutFooter,
   EuiTitle,
-  EuiButton,
+  EuiSmallButton,
   EuiFormFieldset,
   EuiCheckableCard,
   EuiSpacer,
@@ -141,7 +141,7 @@ function AddAnomalyDetector({
       const indexPattern = await getSavedObjectsClient().get('index-pattern', indexPatternId);
       const refs = indexPattern.references as References[];
       const foundDataSourceId = refs.find(ref => ref.type === 'data-source')?.id;
-      setDataSourceId(foundDataSourceId); 
+      setDataSourceId(foundDataSourceId);
     } catch (error) {
       console.error("Error fetching index pattern:", error);
     }
@@ -167,7 +167,7 @@ function AddAnomalyDetector({
     }
     fetchData();
     createEmbeddable();
-  }, [dataSourceId]); 
+  }, [dataSourceId]);
 
   const [isShowVis, setIsShowVis] = useState(false);
   const [accordionsOpen, setAccordionsOpen] = useState({ modelFeatures: true });
@@ -478,9 +478,9 @@ function AddAnomalyDetector({
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <div>
-                <EuiButton onClick={() => openAlerting(detectorId)}>
+                <EuiSmallButton onClick={() => openAlerting(detectorId)}>
                   Set up alerts
-                </EuiButton>
+                </EuiSmallButton>
               </div>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -960,7 +960,7 @@ function AddAnomalyDetector({
 
                                 <EuiSpacer size="m" />
                                 <EuiPanel paddingSize="none">
-                                  <EuiButton
+                                  <EuiSmallButton
                                     className="featureButton"
                                     data-test-subj="addFeature"
                                     isDisabled={
@@ -972,7 +972,7 @@ function AddAnomalyDetector({
                                     }}
                                   >
                                     Add another feature
-                                  </EuiButton>
+                                  </EuiSmallButton>
                                 </EuiPanel>
                                 <EuiSpacer size="s" />
                                 <EuiText className="content-panel-subTitle">
@@ -1004,16 +1004,16 @@ function AddAnomalyDetector({
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   {mode === FLYOUT_MODES.existing ? (
-                    <EuiButton
+                    <EuiSmallButton
                       fill={true}
                       data-test-subj="adAnywhereAssociateDetectorButton"
                       isLoading={formikProps.isSubmitting}
                       onClick={() => handleAssociate(selectedDetector)}
                     >
                       Associate detector
-                    </EuiButton>
+                    </EuiSmallButton>
                   ) : (
-                    <EuiButton
+                    <EuiSmallButton
                       fill={true}
                       disabled={associationLimitReached}
                       data-test-subj="adAnywhereCreateDetectorButton"
@@ -1023,7 +1023,7 @@ function AddAnomalyDetector({
                       }}
                     >
                       Create detector
-                    </EuiButton>
+                    </EuiSmallButton>
                   )}
                 </EuiFlexItem>
               </EuiFlexGroup>

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -23,7 +23,7 @@ import {
   EuiFlexGroup,
   EuiFieldNumber,
   EuiCallOut,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiPanel,
 } from '@elastic/eui';
 import './styles.scss';
@@ -1000,7 +1000,7 @@ function AddAnomalyDetector({
             <EuiFlyoutFooter>
               <EuiFlexGroup justifyContent="spaceBetween">
                 <EuiFlexItem grow={false}>
-                  <EuiButtonEmpty onClick={closeFlyout}>Cancel</EuiButtonEmpty>
+                  <EuiSmallButtonEmpty onClick={closeFlyout}>Cancel</EuiSmallButtonEmpty>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
                   {mode === FLYOUT_MODES.existing ? (

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -17,11 +17,11 @@ import {
   EuiText,
   EuiSwitch,
   EuiCompressedFormRow,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCheckbox,
   EuiFlexItem,
   EuiFlexGroup,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiCallOut,
   EuiSmallButtonEmpty,
   EuiPanel,
@@ -684,7 +684,7 @@ function AddAnomalyDetector({
                               isInvalid={isInvalid(field.name, form)}
                               error={getError(field.name, form)}
                             >
-                              <EuiFieldText
+                              <EuiCompressedFieldText
                                 data-test-subj="detectorNameTextInputFlyout"
                                 isInvalid={isInvalid(field.name, form)}
                                 {...field}
@@ -713,7 +713,7 @@ function AddAnomalyDetector({
                                     alignItems="center"
                                   >
                                     <EuiFlexItem grow={false}>
-                                      <EuiFieldNumber
+                                      <EuiCompressedFieldNumber
                                         id="detectionInterval"
                                         placeholder="Detector interval"
                                         data-test-subj="detectionInterval"
@@ -750,7 +750,7 @@ function AddAnomalyDetector({
                             >
                               <EuiFlexGroup gutterSize="s" alignItems="center">
                                 <EuiFlexItem grow={false}>
-                                  <EuiFieldNumber
+                                  <EuiCompressedFieldNumber
                                     id="windowDelay"
                                     placeholder="Window delay"
                                     data-test-subj="windowDelay"
@@ -829,7 +829,7 @@ function AddAnomalyDetector({
                                   alignItems="center"
                                 >
                                   <EuiFlexItem grow={false}>
-                                    <EuiFieldNumber
+                                    <EuiCompressedFieldNumber
                                       id="shingleSize"
                                       placeholder="Shingle size"
                                       data-test-subj="shingleSize"
@@ -889,7 +889,7 @@ function AddAnomalyDetector({
                                       isInvalid={isInvalid(field.name, form)}
                                       helpText={`Custom result index name must contain less than 255 characters including the prefix "opensearch-ad-plugin-result-". Valid characters are a-z, 0-9, -(hyphen) and _(underscore).`}
                                     >
-                                      <EuiFieldText
+                                      <EuiCompressedFieldText
                                         id="resultIndex"
                                         placeholder="Enter result index name"
                                         prepend={CUSTOM_AD_RESULT_INDEX_PREFIX}

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -16,7 +16,7 @@ import {
   EuiIcon,
   EuiText,
   EuiSwitch,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiFieldText,
   EuiCheckbox,
   EuiFlexItem,
@@ -884,7 +884,7 @@ function AddAnomalyDetector({
 
                                 {enabled ? (
                                   <EuiFlexItem>
-                                    <EuiFormRow
+                                    <EuiCompressedFormRow
                                       label="Field"
                                       isInvalid={isInvalid(field.name, form)}
                                       helpText={`Custom result index name must contain less than 255 characters including the prefix "opensearch-ad-plugin-result-". Valid characters are a-z, 0-9, -(hyphen) and _(underscore).`}
@@ -895,7 +895,7 @@ function AddAnomalyDetector({
                                         prepend={CUSTOM_AD_RESULT_INDEX_PREFIX}
                                         {...field}
                                       />
-                                    </EuiFormRow>
+                                    </EuiCompressedFormRow>
                                   </EuiFlexItem>
                                 ) : null}
                               </EuiFlexGroup>

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -18,7 +18,7 @@ import {
   EuiSwitch,
   EuiCompressedFormRow,
   EuiCompressedFieldText,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiFlexItem,
   EuiFlexGroup,
   EuiCompressedFieldNumber,
@@ -857,7 +857,7 @@ function AddAnomalyDetector({
                             {({ field, form }: FieldProps) => (
                               <EuiFlexGroup direction="column">
                                 <EuiFlexItem>
-                                  <EuiCheckbox
+                                  <EuiCompressedCheckbox
                                     id={'resultIndexCheckbox'}
                                     label="Enable custom result index"
                                     checked={enabled}

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AddAnomalyDetector.tsx
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiIcon,
   EuiText,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiCompressedFormRow,
   EuiCompressedFieldText,
   EuiCompressedCheckbox,
@@ -311,7 +311,7 @@ function AddAnomalyDetector({
               {title}
             </h4>
           </EuiTitle>
-          <EuiSwitch
+          <EuiCompressedSwitch
             label="Show visualization"
             checked={isShowVis}
             onChange={() => setIsShowVis(!isShowVis)}

--- a/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AssociateExisting/containers/AssociateExisting.tsx
+++ b/public/components/FeatureAnywhereContextMenu/CreateAnomalyDetector/AssociateExisting/containers/AssociateExisting.tsx
@@ -9,7 +9,7 @@ import {
   EuiSpacer,
   EuiIcon,
   EuiText,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiLoadingSpinner,
   EuiLink,
   EuiFlexGroup,
@@ -78,7 +78,7 @@ export function AssociateExisting(
       const indexPattern = await getSavedObjectsClient().get('index-pattern', associateExistingProps.indexPatternId);
       const refs = indexPattern.references as References[];
       const foundDataSourceId = refs.find(ref => ref.type === 'data-source')?.id;
-      setDataSourceId(foundDataSourceId); 
+      setDataSourceId(foundDataSourceId);
     } catch (error) {
       console.error("Error fetching index pattern:", error);
     }
@@ -228,7 +228,7 @@ export function AssociateExisting(
         Eligible detectors don't include high-cardinality detectors.
       </EuiText>
       {existingDetectorsAvailableToAssociate ? (
-        <EuiComboBox
+        <EuiCompressedComboBox
           isLoading={isLoading}
           id="associate-existing__select"
           options={options}

--- a/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/EnhancedAccordion.tsx
+++ b/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/EnhancedAccordion.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import {
   EuiTitle,
   EuiSpacer,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiButtonEmpty,
   EuiAccordion,
   EuiPanel,
@@ -27,7 +27,7 @@ const EnhancedAccordion = ({
 }) => (
   <div className="euiPanel euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow euiPanel--hasBorder euiPanel--flexGrowZero euiSplitPanel euiSplitPanel--row euiCheckableCard">
     <div className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--subdued euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero euiSplitPanel__inner">
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         color="text"
         iconType="arrowRight"
         aria-label="Expand"

--- a/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/EnhancedAccordion.tsx
+++ b/public/components/FeatureAnywhereContextMenu/EnhancedAccordion/EnhancedAccordion.tsx
@@ -7,7 +7,7 @@ import {
   EuiTitle,
   EuiSpacer,
   EuiSmallButtonIcon,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiAccordion,
   EuiPanel,
 } from '@elastic/eui';
@@ -76,10 +76,10 @@ const EnhancedAccordion = ({
         </EuiAccordion>
       )}
       {isButton && (
-        <EuiButtonEmpty
+        <EuiSmallButtonEmpty
           iconType={iconType}
           className="enhanced-accordion__button"
-        ></EuiButtonEmpty>
+        ></EuiSmallButtonEmpty>
       )}
     </div>
   </div>

--- a/public/components/FormattedFormRow/FormattedFormRow.tsx
+++ b/public/components/FormattedFormRow/FormattedFormRow.tsx
@@ -10,7 +10,7 @@
  */
 
 import React, { ReactElement, ReactNode } from 'react';
-import { EuiFormRow, EuiText, EuiLink, EuiIcon } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiText, EuiLink, EuiIcon } from '@elastic/eui';
 
 type FormattedFormRowProps = {
   title?: string;
@@ -46,7 +46,7 @@ export const FormattedFormRow = (props: FormattedFormRowProps) => {
   const { formattedTitle, ...euiFormRowProps } = props;
 
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       label={
         <div style={{ lineHeight: '8px' }}>
           {formattedTitle ? formattedTitle : <p>{props.title}</p>}
@@ -57,6 +57,6 @@ export const FormattedFormRow = (props: FormattedFormRowProps) => {
       {...euiFormRowProps}
     >
       {props.children}
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 };

--- a/public/pages/AnomalyCharts/components/AlertsButton/AlertsButton.tsx
+++ b/public/pages/AnomalyCharts/components/AlertsButton/AlertsButton.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiButton, EuiButtonProps } from '@elastic/eui';
+import { EuiSmallButton, EuiButtonProps } from '@elastic/eui';
 import React, { Fragment } from 'react';
 import {
   getAlertingCreateMonitorLink,
@@ -30,14 +30,14 @@ export const AlertsButton = (props: AlertsButtonProps) => {
   return (
     <Fragment>
       {props.monitor ? (
-        <EuiButton
+        <EuiSmallButton
           href={`${getAlertingMonitorListLink()}/${props.monitor.id}`}
           {...props}
         >
           Edit alert settings
-        </EuiButton>
+        </EuiSmallButton>
       ) : (
-        <EuiButton
+        <EuiSmallButton
           href={`${getAlertingCreateMonitorLink(
             props.detectorId,
             props.detectorName,
@@ -48,7 +48,7 @@ export const AlertsButton = (props: AlertsButtonProps) => {
           {...props}
         >
           Set up alerts
-        </EuiButton>
+        </EuiSmallButton>
       )}
     </Fragment>
   );

--- a/public/pages/AnomalyCharts/components/AlertsButton/__tests__/__snapshots__/AlertsButton.test.tsx.snap
+++ b/public/pages/AnomalyCharts/components/AlertsButton/__tests__/__snapshots__/AlertsButton.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<AlertsButton /> spec Alerts Button renders component with monitor 1`] = `
 <div>
   <a
-    class="euiButton euiButton--primary"
+    class="euiButton euiButton--primary euiButton--small"
     detectorid="test-detector-id"
     detectorinterval="1"
     detectorname="test-detector-name"
@@ -28,7 +28,7 @@ exports[`<AlertsButton /> spec Alerts Button renders component with monitor 1`] 
 exports[`<AlertsButton /> spec Alerts Button renders component without monitor 1`] = `
 <div>
   <button
-    class="euiButton euiButton--primary"
+    class="euiButton euiButton--primary euiButton--small"
     detectorid="test-detector-id"
     detectorinterval="1"
     detectorname="test-detector-name"

--- a/public/pages/AnomalyCharts/components/AlertsFlyout/AlertsFlyout.tsx
+++ b/public/pages/AnomalyCharts/components/AlertsFlyout/AlertsFlyout.tsx
@@ -10,7 +10,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiFlyout,
@@ -102,13 +102,13 @@ export const AlertsFlyout = (props: AlertsFlyoutProps) => {
       <EuiFlyoutFooter>
         <EuiFlexGroup alignItems="center" justifyContent="flexEnd">
           <EuiFlexItem grow={true}>
-            <EuiButton
+            <EuiSmallButton
               href={`${BASE_DOCS_LINK}/alerting`}
               target="_blank"
               data-test-subj="setUpAlerts"
             >
               Explore Alerting <EuiIcon size="s" type="popout" />
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={true}>
             <AlertsButton

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -21,7 +21,7 @@ import {
   LineAnnotation,
   AnnotationDomainType,
 } from '@elastic/charts';
-import { EuiText, EuiLink, EuiButton, EuiIcon } from '@elastic/eui';
+import { EuiText, EuiLink, EuiSmallButton, EuiIcon } from '@elastic/eui';
 import React, { useState, Fragment } from 'react';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import { useDelayedLoader } from '../../../../hooks/useDelayedLoader';
@@ -166,7 +166,7 @@ export const FeatureChart = (props: FeatureChartProps) => {
       subTitle={featureDescription()}
       actions={
         props.edit ? (
-          <EuiButton onClick={props.onEdit}>Edit feature</EuiButton>
+          <EuiSmallButton onClick={props.onEdit}>Edit feature</EuiSmallButton>
         ) : null
       }
     >

--- a/public/pages/AnomalyCharts/components/FeatureChart/NoFeaturePrompt.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/NoFeaturePrompt.tsx
@@ -16,7 +16,7 @@ import {
   EuiText,
   EuiFlexItem,
   EuiFlexGroup,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
@@ -42,12 +42,12 @@ export const NoFeaturePrompt = (props: NoFeaturePromptProps) => {
                 </EuiText>
               }
               actions={[
-                <EuiButton
+                <EuiSmallButton
                   data-test-subj="createButton"
                   href={`#/detectors/${props.detectorId}/features`}
                 >
                   Add feature
-                </EuiButton>,
+                </EuiSmallButton>,
               ]}
             />
           </EuiFlexItem>

--- a/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomaliesChart.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexItem,
   EuiLoadingChart,
   EuiSpacer,
-  EuiSuperDatePicker,
+  EuiCompressedSuperDatePicker,
   EuiTitle,
 } from '@elastic/eui';
 import { get, orderBy } from 'lodash';
@@ -157,7 +157,7 @@ export const AnomaliesChart = React.memo((props: AnomaliesChartProps) => {
   };
 
   const datePicker = () => (
-    <EuiSuperDatePicker
+    <EuiCompressedSuperDatePicker
       isLoading={props.isLoading}
       start={datePickerRange.start}
       end={datePickerRange.end}

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -20,7 +20,7 @@ import {
   EuiLoadingChart,
   EuiText,
   EuiComboBox,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiIconTip,
   EuiCallOut,
 } from '@elastic/eui';
@@ -521,7 +521,7 @@ export const AnomalyHeatmapChart = React.memo(
                       />
                     </EuiFlexItem>
                     <EuiFlexItem style={{ minWidth: 150 }}>
-                      <EuiSuperSelect
+                      <EuiCompressedSuperSelect
                         options={SORT_BY_FIELD_OPTIONS}
                         valueOfSelected={sortByFieldValue}
                         onChange={(value) => handleSortByFieldChange(value)}

--- a/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
+++ b/public/pages/AnomalyCharts/containers/AnomalyHeatmapChart.tsx
@@ -19,7 +19,7 @@ import {
   EuiFlexGroup,
   EuiLoadingChart,
   EuiText,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedSuperSelect,
   EuiIconTip,
   EuiCallOut,
@@ -487,7 +487,7 @@ export const AnomalyHeatmapChart = React.memo(
                      */}
                     {props.isNotSample ? (
                       <EuiFlexItem style={{ minWidth: 300 }}>
-                        <EuiComboBox
+                        <EuiCompressedComboBox
                           placeholder="Select categorical fields"
                           options={getCategoryFieldOptions(
                             get(props, 'categoryField', [])
@@ -511,7 +511,7 @@ export const AnomalyHeatmapChart = React.memo(
                       </EuiFlexItem>
                     )}
                     <EuiFlexItem style={{ minWidth: 300 }}>
-                      <EuiComboBox
+                      <EuiCompressedComboBox
                         placeholder="Select options"
                         options={entityViewOptions}
                         selectedOptions={currentViewOptions}

--- a/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/AnomalyHeatmapChart.test.tsx.snap
+++ b/public/pages/AnomalyCharts/containers/__tests__/__snapshots__/AnomalyHeatmapChart.test.tsx.snap
@@ -89,17 +89,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -161,7 +161,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                       >
                         <button
                           aria-label="Clear input"
-                          class="euiFormControlLayoutClearButton"
+                          class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                           data-test-subj="comboBoxClearButton"
                           type="button"
                         >
@@ -188,7 +188,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -222,7 +222,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                         value="severity"
                       />
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
@@ -236,7 +236,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                           <button
                             aria-haspopup="true"
                             aria-labelledby="undefined random_html_id"
-                            class="euiSuperSelectControl"
+                            class="euiSuperSelectControl euiSuperSelectControl--compressed"
                             type="button"
                           >
                             By severity
@@ -249,7 +249,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with Sample anomaly da
                             >
                               <svg
                                 aria-hidden="true"
-                                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                 focusable="false"
                                 height="16"
                                 role="img"
@@ -512,17 +512,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -558,7 +558,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -584,17 +584,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -656,7 +656,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                       >
                         <button
                           aria-label="Clear input"
-                          class="euiFormControlLayoutClearButton"
+                          class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                           data-test-subj="comboBoxClearButton"
                           type="button"
                         >
@@ -683,7 +683,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -718,7 +718,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                         value="severity"
                       />
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
@@ -732,7 +732,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                           <button
                             aria-haspopup="true"
                             aria-labelledby="undefined random_html_id"
-                            class="euiSuperSelectControl"
+                            class="euiSuperSelectControl euiSuperSelectControl--compressed"
                             type="button"
                           >
                             By severity
@@ -745,7 +745,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with anomaly summaries
                             >
                               <svg
                                 aria-hidden="true"
-                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                 focusable="false"
                                 height="16"
                                 role="img"
@@ -1009,17 +1009,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -1116,7 +1116,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                       >
                         <button
                           aria-label="Clear input"
-                          class="euiFormControlLayoutClearButton"
+                          class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                           data-test-subj="comboBoxClearButton"
                           type="button"
                         >
@@ -1143,7 +1143,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -1169,17 +1169,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -1241,7 +1241,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                       >
                         <button
                           aria-label="Clear input"
-                          class="euiFormControlLayoutClearButton"
+                          class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                           data-test-subj="comboBoxClearButton"
                           type="button"
                         >
@@ -1268,7 +1268,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -1303,7 +1303,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                         value="severity"
                       />
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
@@ -1317,7 +1317,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                           <button
                             aria-haspopup="true"
                             aria-labelledby="undefined random_html_id"
-                            class="euiSuperSelectControl"
+                            class="euiSuperSelectControl euiSuperSelectControl--compressed"
                             type="button"
                           >
                             By severity
@@ -1330,7 +1330,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with multiple category
                             >
                               <svg
                                 aria-hidden="true"
-                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                 focusable="false"
                                 height="16"
                                 role="img"
@@ -1594,17 +1594,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -1665,7 +1665,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                       >
                         <button
                           aria-label="Clear input"
-                          class="euiFormControlLayoutClearButton"
+                          class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                           data-test-subj="comboBoxClearButton"
                           type="button"
                         >
@@ -1692,7 +1692,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -1718,17 +1718,17 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  class="euiComboBox"
+                  class="euiComboBox euiComboBox--compressed"
                   role="combobox"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <div
-                        class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                        class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                         data-test-subj="comboBoxInput"
                         tabindex="-1"
                       >
@@ -1790,7 +1790,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                       >
                         <button
                           aria-label="Clear input"
-                          class="euiFormControlLayoutClearButton"
+                          class="euiFormControlLayoutClearButton euiFormControlLayoutClearButton--small"
                           data-test-subj="comboBoxClearButton"
                           type="button"
                         >
@@ -1817,7 +1817,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                         >
                           <svg
                             aria-hidden="true"
-                            class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                            class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                             focusable="false"
                             height="16"
                             role="img"
@@ -1852,7 +1852,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                         value="severity"
                       />
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
@@ -1866,7 +1866,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                           <button
                             aria-haspopup="true"
                             aria-labelledby="undefined random_html_id"
-                            class="euiSuperSelectControl"
+                            class="euiSuperSelectControl euiSuperSelectControl--compressed"
                             type="button"
                           >
                             By severity
@@ -1879,7 +1879,7 @@ exports[`<AnomalyHeatmapChart /> spec AnomalyHeatmapChart with one category fiel
                             >
                               <svg
                                 aria-hidden="true"
-                                class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                                 focusable="false"
                                 height="16"
                                 role="img"

--- a/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
+++ b/public/pages/AnomalyCharts/utils/anomalyChartUtils.tsx
@@ -17,7 +17,7 @@ import {
   EuiText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiComboBox,
+  EuiCompressedComboBox,
 } from '@elastic/eui';
 import {
   DateRange,
@@ -798,7 +798,7 @@ export const getMultiCategoryFilters = (
               </EuiFlexItem>
               <EuiFlexItem style={{ minWidth: 300 }} grow={false}>
                 <div>
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     placeholder="Select categorical fields"
                     options={childEntityOptions[childCategoryField]}
                     selectedOptions={selectedChildEntities[childCategoryField]}

--- a/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
+++ b/public/pages/ConfigureModel/components/AdvancedSettings/AdvancedSettings.tsx
@@ -15,7 +15,7 @@ import {
   EuiText,
   EuiLink,
   EuiTitle,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiSpacer,
 } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
@@ -77,7 +77,7 @@ export function AdvancedSettings(props: AdvancedSettingsProps) {
             >
               <EuiFlexGroup gutterSize="s" alignItems="center">
                 <EuiFlexItem grow={false}>
-                  <EuiFieldNumber
+                  <EuiCompressedFieldNumber
                     id="shingleSize"
                     placeholder="Shingle size"
                     data-test-subj="shingleSize"

--- a/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
+++ b/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
@@ -12,7 +12,7 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
-import { EuiFormRow, EuiSelect, EuiComboBox } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiSelect, EuiComboBox } from '@elastic/eui';
 import { getAllFields } from '../../../../redux/selectors/opensearch';
 import {
   getNumberFieldOptions,
@@ -41,7 +41,7 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
         validate={requiredSelectField}
       >
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Aggregation method"
             helpText="The aggregation method determines what constitutes an anomaly. For example, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature."
             isInvalid={isInvalid(field.name, form)}
@@ -71,7 +71,7 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
               }}
               data-test-subj="aggregationType"
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </Field>
 
@@ -81,7 +81,7 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
         validate={requiredNonEmptyFieldSelected}
       >
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Field"
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
@@ -121,7 +121,7 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
                 );
               }}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </Field>
     </Fragment>

--- a/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
+++ b/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
@@ -12,7 +12,7 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
-import { EuiCompressedFormRow, EuiSelect, EuiComboBox } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCompressedSelect, EuiComboBox } from '@elastic/eui';
 import { getAllFields } from '../../../../redux/selectors/opensearch';
 import {
   getNumberFieldOptions,
@@ -47,7 +47,7 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiSelect
+            <EuiCompressedSelect
               id={`featureList.${props.index}.aggregationBy`}
               {...field}
               name={`featureList.${props.index}.aggregationBy`}

--- a/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
+++ b/public/pages/ConfigureModel/components/AggregationSelector/AggregationSelector.tsx
@@ -12,7 +12,7 @@
 import React, { Fragment } from 'react';
 import { useSelector } from 'react-redux';
 import { get } from 'lodash';
-import { EuiCompressedFormRow, EuiCompressedSelect, EuiComboBox } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCompressedSelect, EuiCompressedComboBox } from '@elastic/eui';
 import { getAllFields } from '../../../../redux/selectors/opensearch';
 import {
   getNumberFieldOptions,
@@ -86,7 +86,7 @@ export const AggregationSelector = (props: AggregationSelectorProps) => {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               data-test-subj={`featureFieldTextInput-${props.index}`}
               placeholder="Select field"
               singleSelection={{ asPlainText: true }}

--- a/public/pages/ConfigureModel/components/AggregationSelector/__tests__/__snapshots__/AggregationSelector.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/AggregationSelector/__tests__/__snapshots__/AggregationSelector.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<AggregationSelector /> spec Empty results renders component with aggregation types and defaults to empty 1`] = `
 <div>
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="random_html_id-row"
   >
     <div
@@ -21,14 +21,14 @@ exports[`<AggregationSelector /> spec Empty results renders component with aggre
       class="euiFormRow__fieldWrapper"
     >
       <div
-        class="euiFormControlLayout"
+        class="euiFormControlLayout euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <select
             aria-describedby="random_html_id-help-0"
-            class="euiSelect"
+            class="euiSelect euiSelect--compressed"
             data-test-subj="aggregationType"
             id="random_html_id"
             name="featureList.undefined.aggregationBy"
@@ -67,7 +67,7 @@ exports[`<AggregationSelector /> spec Empty results renders component with aggre
             >
               <svg
                 aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                 focusable="false"
                 height="16"
                 role="img"
@@ -92,7 +92,7 @@ exports[`<AggregationSelector /> spec Empty results renders component with aggre
     </div>
   </div>
   <div
-    class="euiFormRow"
+    class="euiFormRow euiFormRow--compressed"
     id="random_html_id-row"
   >
     <div
@@ -112,19 +112,19 @@ exports[`<AggregationSelector /> spec Empty results renders component with aggre
       <div
         aria-expanded="false"
         aria-haspopup="listbox"
-        class="euiComboBox"
+        class="euiComboBox euiComboBox--compressed"
         data-test-subj="featureFieldTextInput-undefined"
         name="featureList.undefined.aggregationOf"
         role="combobox"
       >
         <div
-          class="euiFormControlLayout"
+          class="euiFormControlLayout euiFormControlLayout--compressed"
         >
           <div
             class="euiFormControlLayout__childrenWrapper"
           >
             <div
-              class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+              class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
               data-test-subj="comboBoxInput"
               tabindex="-1"
             >
@@ -161,7 +161,7 @@ exports[`<AggregationSelector /> spec Empty results renders component with aggre
               >
                 <svg
                   aria-hidden="true"
-                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                  class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                   focusable="false"
                   height="16"
                   role="img"

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -17,7 +17,7 @@ import {
   EuiIcon,
   EuiCompressedFormRow,
   EuiComboBox,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiTitle,
   EuiCallOut,
   EuiSpacer,
@@ -108,7 +108,7 @@ export function CategoryField(props: CategoryFieldProps) {
         {({ field, form }: FieldProps) => (
           <EuiFlexGroup direction="column">
             <EuiFlexItem>
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id={'categoryFieldCheckbox'}
                 label="Enable categorical fields"
                 checked={enabled}

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -16,7 +16,7 @@ import {
   EuiLink,
   EuiIcon,
   EuiCompressedFormRow,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiCompressedCheckbox,
   EuiTitle,
   EuiCallOut,
@@ -144,7 +144,7 @@ export function CategoryField(props: CategoryFieldProps) {
                   error={getError(field.name, form)}
                   helpText={`You can only apply the categorical fields to the 'ip' and 'keyword' OpenSearch data types.`}
                 >
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     data-test-subj="categoryFieldComboBox"
                     id="categoryField"
                     placeholder="Select your categorical fields"

--- a/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
+++ b/public/pages/ConfigureModel/components/CategoryField/CategoryField.tsx
@@ -15,7 +15,7 @@ import {
   EuiText,
   EuiLink,
   EuiIcon,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiComboBox,
   EuiCheckbox,
   EuiTitle,
@@ -138,7 +138,7 @@ export function CategoryField(props: CategoryFieldProps) {
             ) : null}
             {enabled && !noCategoryFields ? (
               <EuiFlexItem>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="Field"
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
@@ -175,7 +175,7 @@ export function CategoryField(props: CategoryFieldProps) {
                     isClearable={true}
                     isDisabled={props.isEdit}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
             ) : null}
           </EuiFlexGroup>

--- a/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CategoryField/__tests__/__snapshots__/CategoryField.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`<CategoryField /> spec renders the component when disabled 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"
@@ -229,7 +229,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   checked=""
@@ -284,7 +284,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
               >
                 <div
@@ -305,18 +305,18 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                     aria-describedby="random_html_id-help-0"
                     aria-expanded="false"
                     aria-haspopup="listbox"
-                    class="euiComboBox"
+                    class="euiComboBox euiComboBox--compressed"
                     data-test-subj="categoryFieldComboBox"
                     role="combobox"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <div
-                          class="euiComboBox__inputWrap euiComboBox__inputWrap-isClearable"
+                          class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isClearable"
                           data-test-subj="comboBoxInput"
                           tabindex="-1"
                         >
@@ -353,7 +353,7 @@ exports[`<CategoryField /> spec renders the component when enabled 1`] = `
                           >
                             <svg
                               aria-hidden="true"
-                              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                              class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                               focusable="false"
                               height="16"
                               role="img"

--- a/public/pages/ConfigureModel/components/CustomAggregation/CustomAggregation.tsx
+++ b/public/pages/ConfigureModel/components/CustomAggregation/CustomAggregation.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { EuiFormRow, EuiCodeEditor } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiCodeEditor } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import { isInvalid, getError } from '../../../../utils/utils';
 
@@ -35,7 +35,7 @@ export const CustomAggregation = (props: CustomAggregationProps) => {
       validate={validateQuery}
     >
       {({ field, form }: FieldProps) => (
-        <EuiFormRow
+        <EuiCompressedFormRow
           fullWidth
           label="Expression"
           helpText="Custom expression uses the OpenSearch query DSL."
@@ -68,7 +68,7 @@ export const CustomAggregation = (props: CustomAggregationProps) => {
             onBlur={field.onBlur}
             value={field.value}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       )}
     </Field>
   );

--- a/public/pages/ConfigureModel/components/CustomAggregation/__tests__/__snapshots__/CustomAggregation.test.tsx.snap
+++ b/public/pages/ConfigureModel/components/CustomAggregation/__tests__/__snapshots__/CustomAggregation.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<CustomAggregation /> spec renders the component 1`] = `
 <div>
   <div
-    class="euiFormRow euiFormRow--fullWidth"
+    class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
     id="random_html_id-row"
   >
     <div

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -17,7 +17,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
-  EuiSmallButton,
+  EuiButton,
   EuiFieldText,
   EuiCheckbox,
   EuiButtonIcon,

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -17,7 +17,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiCheckbox,
   EuiButtonIcon,

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -18,7 +18,7 @@ import {
   EuiFlexItem,
   EuiTitle,
   EuiButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCheckbox,
   EuiButtonIcon,
 } from '@elastic/eui';
@@ -160,7 +160,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               data-test-subj={`featureNameTextInput-${props.index}`}
               name={`featureList.${props.index}.featureName`}
               placeholder="Enter feature name"

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -19,7 +19,7 @@ import {
   EuiTitle,
   EuiButton,
   EuiCompressedFieldText,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiButtonIcon,
 } from '@elastic/eui';
 import './styles.scss';
@@ -181,7 +181,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id={`featureList.${props.index}.featureEnabled`}
               label="Enable feature"
               checked={field.value ? field.value : props.feature.featureEnabled}

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -11,7 +11,7 @@
 
 import React, { Fragment, useState } from 'react';
 import {
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
   EuiAccordion,
   EuiFlexGroup,
@@ -154,7 +154,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
         validate={validateFeatureName}
       >
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Feature name"
             helpText="Enter a descriptive name. The name must be unique within this detector. Feature name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore)."
             isInvalid={isInvalid(field.name, form)}
@@ -167,7 +167,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
               value={field.value ? field.value : props.feature.featureName}
               {...field}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </Field>
 
@@ -176,7 +176,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
         name={`featureList.${props.index}.featureEnabled`}
       >
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Feature state"
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
@@ -187,7 +187,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
               checked={field.value ? field.value : props.feature.featureEnabled}
               {...field}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </Field>
 
@@ -198,7 +198,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
       >
         {({ field, form }: FieldProps) => (
           <Fragment>
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Find anomalies based on"
               isInvalid={isInvalid(field.name, form)}
               error={getError(field.name, form)}
@@ -227,7 +227,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
                   }
                 }}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
             {field.value === FEATURE_TYPE.SIMPLE ? (
               <AggregationSelector index={props.index} />
             ) : (

--- a/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/FeatureAccordion.tsx
@@ -12,7 +12,7 @@
 import React, { Fragment, useState } from 'react';
 import {
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
   EuiAccordion,
   EuiFlexGroup,
   EuiFlexItem,
@@ -203,7 +203,7 @@ export const FeatureAccordion = (props: FeatureAccordionProps) => {
               isInvalid={isInvalid(field.name, form)}
               error={getError(field.name, form)}
             >
-              <EuiSelect
+              <EuiCompressedSelect
                 {...field}
                 options={FEATURE_TYPE_OPTIONS}
                 value={

--- a/public/pages/ConfigureModel/components/Features/Features.tsx
+++ b/public/pages/ConfigureModel/components/Features/Features.tsx
@@ -15,7 +15,7 @@ import {
   EuiText,
   EuiFlexItem,
   EuiFlexGroup,
-  EuiButton,
+  EuiSmallButton,
   EuiLink,
   EuiIcon,
 } from '@elastic/eui';
@@ -90,7 +90,7 @@ export function Features(props: FeaturesProps) {
                   style={{ padding: '12px 0px' }}
                 >
                   <EuiFlexItem grow={false}>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="addFeature"
                       isDisabled={values.featureList.length >= MAX_FEATURE_NUM}
                       onClick={() => {
@@ -98,7 +98,7 @@ export function Features(props: FeaturesProps) {
                       }}
                     >
                       Add another feature
-                    </EuiButton>
+                    </EuiSmallButton>
                     <EuiText className="content-panel-subTitle">
                       <p>
                         You can add up to{' '}

--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -18,7 +18,7 @@ import {
   EuiPage,
   EuiSmallButton,
   EuiTitle,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSpacer,
   EuiText,
   EuiLink,
@@ -358,7 +358,7 @@ export function ConfigureModel(props: ConfigureModelProps) {
             style={{ marginRight: '12px' }}
           >
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
+              <EuiSmallButtonEmpty
                 onClick={() => {
                   if (props.isEdit) {
                     props.history.push(
@@ -380,7 +380,7 @@ export function ConfigureModel(props: ConfigureModelProps) {
                 }}
               >
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             {props.isEdit ? null : (
               <EuiFlexItem grow={false}>

--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPage,
-  EuiButton,
+  EuiSmallButton,
   EuiTitle,
   EuiButtonEmpty,
   EuiSpacer,
@@ -384,7 +384,7 @@ export function ConfigureModel(props: ConfigureModelProps) {
             </EuiFlexItem>
             {props.isEdit ? null : (
               <EuiFlexItem grow={false}>
-                <EuiButton
+                <EuiSmallButton
                   iconSide="left"
                   iconType="arrowLeft"
                   fill={false}
@@ -400,12 +400,12 @@ export function ConfigureModel(props: ConfigureModelProps) {
                   }}
                 >
                   Previous
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             )}
             <EuiFlexItem grow={false}>
               {props.isEdit ? (
-                <EuiButton
+                <EuiSmallButton
                   type="submit"
                   fill={true}
                   data-test-subj="updateDetectorButton"
@@ -415,9 +415,9 @@ export function ConfigureModel(props: ConfigureModelProps) {
                   }}
                 >
                   Save changes
-                </EuiButton>
+                </EuiSmallButton>
               ) : (
-                <EuiButton
+                <EuiSmallButton
                   type="submit"
                   iconSide="right"
                   iconType="arrowRight"
@@ -430,7 +430,7 @@ export function ConfigureModel(props: ConfigureModelProps) {
                   }}
                 >
                   Next
-                </EuiButton>
+                </EuiSmallButton>
               )}
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
+++ b/public/pages/ConfigureModel/containers/SampleAnomalies.tsx
@@ -10,7 +10,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -217,7 +217,7 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
         </EuiFlexGroup>
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               type="button"
               data-test-subj="previewDetector"
               onClick={() => {
@@ -235,7 +235,7 @@ export function SampleAnomalies(props: SampleAnomaliesProps) {
               isLoading={isLoading}
             >
               {firstPreview ? 'Preview anomalies' : 'Refresh preview'}
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiCallOut>

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                     class="euiAccordion__padding--l"
                   >
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="random_html_id-row"
                     >
                       <div
@@ -250,14 +250,14 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          class="euiFormControlLayout"
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <input
                               aria-describedby="random_html_id-help-0"
-                              class="euiFieldText"
+                              class="euiFieldText euiFieldText--compressed"
                               data-test-subj="featureNameTextInput-0"
                               id="random_html_id"
                               name="featureList.0.featureName"
@@ -276,7 +276,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                       </div>
                     </div>
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="random_html_id-row"
                     >
                       <div
@@ -294,7 +294,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          class="euiCheckbox"
+                          class="euiCheckbox euiCheckbox--compressed"
                         >
                           <input
                             checked=""
@@ -317,7 +317,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                       </div>
                     </div>
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="random_html_id-row"
                     >
                       <div
@@ -335,13 +335,13 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          class="euiFormControlLayout"
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <select
-                              class="euiSelect"
+                              class="euiSelect euiSelect--compressed"
                               id="random_html_id"
                               name="featureList.0.featureType"
                             >
@@ -364,7 +364,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                  class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                   focusable="false"
                                   height="16"
                                   role="img"
@@ -383,7 +383,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                       </div>
                     </div>
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="random_html_id-row"
                     >
                       <div
@@ -401,14 +401,14 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                         class="euiFormRow__fieldWrapper"
                       >
                         <div
-                          class="euiFormControlLayout"
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
                         >
                           <div
                             class="euiFormControlLayout__childrenWrapper"
                           >
                             <select
                               aria-describedby="random_html_id-help-0"
-                              class="euiSelect"
+                              class="euiSelect euiSelect--compressed"
                               data-test-subj="aggregationType"
                               id="random_html_id"
                               name="featureList.0.aggregationBy"
@@ -447,7 +447,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                               >
                                 <svg
                                   aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                  class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                   focusable="false"
                                   height="16"
                                   role="img"
@@ -472,7 +472,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                       </div>
                     </div>
                     <div
-                      class="euiFormRow"
+                      class="euiFormRow euiFormRow--compressed"
                       id="random_html_id-row"
                     >
                       <div
@@ -492,19 +492,19 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                         <div
                           aria-expanded="false"
                           aria-haspopup="listbox"
-                          class="euiComboBox"
+                          class="euiComboBox euiComboBox--compressed"
                           data-test-subj="featureFieldTextInput-0"
                           name="featureList.0.aggregationOf"
                           role="combobox"
                         >
                           <div
-                            class="euiFormControlLayout"
+                            class="euiFormControlLayout euiFormControlLayout--compressed"
                           >
                             <div
                               class="euiFormControlLayout__childrenWrapper"
                             >
                               <div
-                                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
                                 data-test-subj="comboBoxInput"
                                 tabindex="-1"
                               >
@@ -541,7 +541,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                                 >
                                   <svg
                                     aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                    class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                     focusable="false"
                                     height="16"
                                     role="img"
@@ -572,7 +572,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="addFeature"
                   type="button"
                 >
@@ -734,7 +734,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"
@@ -952,7 +952,7 @@ exports[`<ConfigureModel /> spec creating model configuration renders the compon
                     class="euiFlexItem euiFlexItem--flexGrowZero"
                   >
                     <button
-                      class="euiButton euiButton--primary"
+                      class="euiButton euiButton--primary euiButton--small"
                       data-test-subj="previewDetector"
                       type="button"
                     >
@@ -1128,426 +1128,6 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
             style="margin: 0px;"
           >
             <div
-              class="euiAccordion euiAccordion-isOpen euiAccordion__noTopBorder"
-            >
-              <div
-                class="euiAccordion__triggerWrapper"
-              >
-                <button
-                  aria-controls="featureList.0"
-                  aria-expanded="true"
-                  class="euiAccordion__button euiAccordionForm__noTopPaddingButton"
-                  id="random_html_id"
-                  type="button"
-                >
-                  <span
-                    class="euiAccordion__iconWrapper"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiAccordion__icon euiAccordion__icon-isOpen"
-                      focusable="false"
-                      height="16"
-                      role="img"
-                      viewBox="0 0 16 16"
-                      width="16"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
-                        fill-rule="nonzero"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="euiIEFlexWrapFix"
-                  >
-                    <div
-                      id="featureAccordionHeaders.0"
-                    >
-                      <div
-                        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
-                      >
-                        <div
-                          class="euiFlexItem"
-                        >
-                          <h5
-                            class="euiTitle euiTitle--xsmall euiAccordionForm__title"
-                          >
-                            Add feature
-                          </h5>
-                        </div>
-                      </div>
-                    </div>
-                  </span>
-                </button>
-                <div
-                  class="euiAccordion__optionalAction"
-                >
-                  <button
-                    class="euiButton euiButton--danger euiButton--small"
-                    type="button"
-                  >
-                    <span
-                      class="euiButtonContent euiButton__content"
-                    >
-                      <span
-                        class="euiButton__text"
-                      >
-                        Delete
-                      </span>
-                    </span>
-                  </button>
-                </div>
-              </div>
-              <div
-                aria-labelledby="random_html_id"
-                class="euiAccordion__childWrapper"
-                id="featureList.0"
-                role="region"
-                tabindex="-1"
-              >
-                <div>
-                  <div
-                    class="euiAccordion__padding--l"
-                  >
-                    <div
-                      class="euiFormRow"
-                      id="random_html_id-row"
-                    >
-                      <div
-                        class="euiFormRow__labelWrapper"
-                      >
-                        <label
-                          aria-invalid="false"
-                          class="euiFormLabel euiFormRow__label"
-                          for="random_html_id"
-                        >
-                          Feature name
-                        </label>
-                      </div>
-                      <div
-                        class="euiFormRow__fieldWrapper"
-                      >
-                        <div
-                          class="euiFormControlLayout"
-                        >
-                          <div
-                            class="euiFormControlLayout__childrenWrapper"
-                          >
-                            <input
-                              aria-describedby="random_html_id-help-0"
-                              class="euiFieldText"
-                              data-test-subj="featureNameTextInput-0"
-                              id="random_html_id"
-                              name="featureList.0.featureName"
-                              placeholder="Enter feature name"
-                              type="text"
-                              value=""
-                            />
-                          </div>
-                        </div>
-                        <div
-                          class="euiFormHelpText euiFormRow__text"
-                          id="random_html_id-help-0"
-                        >
-                          Enter a descriptive name. The name must be unique within this detector. Feature name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore).
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="euiFormRow"
-                      id="random_html_id-row"
-                    >
-                      <div
-                        class="euiFormRow__labelWrapper"
-                      >
-                        <label
-                          aria-invalid="false"
-                          class="euiFormLabel euiFormRow__label"
-                          for="random_html_id"
-                        >
-                          Feature state
-                        </label>
-                      </div>
-                      <div
-                        class="euiFormRow__fieldWrapper"
-                      >
-                        <div
-                          class="euiCheckbox"
-                        >
-                          <input
-                            checked=""
-                            class="euiCheckbox__input"
-                            id="random_html_id"
-                            name="featureList.0.featureEnabled"
-                            type="checkbox"
-                            value="true"
-                          />
-                          <div
-                            class="euiCheckbox__square"
-                          />
-                          <label
-                            class="euiCheckbox__label"
-                            for="random_html_id"
-                          >
-                            Enable feature
-                          </label>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="euiFormRow"
-                      id="random_html_id-row"
-                    >
-                      <div
-                        class="euiFormRow__labelWrapper"
-                      >
-                        <label
-                          aria-invalid="false"
-                          class="euiFormLabel euiFormRow__label"
-                          for="random_html_id"
-                        >
-                          Find anomalies based on
-                        </label>
-                      </div>
-                      <div
-                        class="euiFormRow__fieldWrapper"
-                      >
-                        <div
-                          class="euiFormControlLayout"
-                        >
-                          <div
-                            class="euiFormControlLayout__childrenWrapper"
-                          >
-                            <select
-                              class="euiSelect"
-                              id="random_html_id"
-                              name="featureList.0.featureType"
-                            >
-                              <option
-                                value="simple_aggs"
-                              >
-                                Field value
-                              </option>
-                              <option
-                                value="custom_aggs"
-                              >
-                                Custom expression
-                              </option>
-                            </select>
-                            <div
-                              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                            >
-                              <span
-                                class="euiFormControlLayoutCustomIcon"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                    fill-rule="non-zero"
-                                  />
-                                </svg>
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="euiFormRow"
-                      id="random_html_id-row"
-                    >
-                      <div
-                        class="euiFormRow__labelWrapper"
-                      >
-                        <label
-                          aria-invalid="false"
-                          class="euiFormLabel euiFormRow__label"
-                          for="random_html_id"
-                        >
-                          Aggregation method
-                        </label>
-                      </div>
-                      <div
-                        class="euiFormRow__fieldWrapper"
-                      >
-                        <div
-                          class="euiFormControlLayout"
-                        >
-                          <div
-                            class="euiFormControlLayout__childrenWrapper"
-                          >
-                            <select
-                              aria-describedby="random_html_id-help-0"
-                              class="euiSelect"
-                              data-test-subj="aggregationType"
-                              id="random_html_id"
-                              name="featureList.0.aggregationBy"
-                            >
-                              <option
-                                value="avg"
-                              >
-                                average()
-                              </option>
-                              <option
-                                value="value_count"
-                              >
-                                count()
-                              </option>
-                              <option
-                                value="sum"
-                              >
-                                sum()
-                              </option>
-                              <option
-                                value="min"
-                              >
-                                min()
-                              </option>
-                              <option
-                                value="max"
-                              >
-                                max()
-                              </option>
-                            </select>
-                            <div
-                              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                            >
-                              <span
-                                class="euiFormControlLayoutCustomIcon"
-                              >
-                                <svg
-                                  aria-hidden="true"
-                                  class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                  focusable="false"
-                                  height="16"
-                                  role="img"
-                                  viewBox="0 0 16 16"
-                                  width="16"
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                    fill-rule="non-zero"
-                                  />
-                                </svg>
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          class="euiFormHelpText euiFormRow__text"
-                          id="random_html_id-help-0"
-                        >
-                          The aggregation method determines what constitutes an anomaly. For example, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature.
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="euiFormRow"
-                      id="random_html_id-row"
-                    >
-                      <div
-                        class="euiFormRow__labelWrapper"
-                      >
-                        <label
-                          aria-invalid="false"
-                          class="euiFormLabel euiFormRow__label"
-                          for="random_html_id"
-                        >
-                          Field
-                        </label>
-                      </div>
-                      <div
-                        class="euiFormRow__fieldWrapper"
-                      >
-                        <div
-                          aria-expanded="false"
-                          aria-haspopup="listbox"
-                          class="euiComboBox"
-                          data-test-subj="featureFieldTextInput-0"
-                          name="featureList.0.aggregationOf"
-                          role="combobox"
-                        >
-                          <div
-                            class="euiFormControlLayout"
-                          >
-                            <div
-                              class="euiFormControlLayout__childrenWrapper"
-                            >
-                              <div
-                                class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
-                                data-test-subj="comboBoxInput"
-                                tabindex="-1"
-                              >
-                                <p
-                                  class="euiComboBoxPlaceholder"
-                                >
-                                  Select field
-                                </p>
-                                <div
-                                  class="euiComboBox__input"
-                                  style="font-size: 14px; display: inline-block;"
-                                >
-                                  <input
-                                    aria-controls=""
-                                    data-test-subj="comboBoxSearchInput"
-                                    id="random_html_id"
-                                    role="textbox"
-                                    style="box-sizing: content-box; width: 2px;"
-                                    value=""
-                                  />
-                                  <div
-                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                              >
-                                <button
-                                  aria-label="Open list of options"
-                                  class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
-                                  data-test-subj="comboBoxToggleListButton"
-                                  type="button"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    height="16"
-                                    role="img"
-                                    viewBox="0 0 16 16"
-                                    width="16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
-                                      fill-rule="non-zero"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
               class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
               style="padding: 12px 0px;"
             >
@@ -1555,7 +1135,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="addFeature"
                   type="button"
                 >
@@ -1575,7 +1155,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
                   <p>
                     You can add up to
                      
-                    4
+                    5
                      
                     more features.
                   </p>
@@ -1748,7 +1328,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"

--- a/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
+++ b/public/pages/ConfigureModel/containers/__tests__/__snapshots__/ConfigureModel.test.tsx.snap
@@ -1128,6 +1128,426 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
             style="margin: 0px;"
           >
             <div
+              class="euiAccordion euiAccordion-isOpen euiAccordion__noTopBorder"
+            >
+              <div
+                class="euiAccordion__triggerWrapper"
+              >
+                <button
+                  aria-controls="featureList.0"
+                  aria-expanded="true"
+                  class="euiAccordion__button euiAccordionForm__noTopPaddingButton"
+                  id="random_html_id"
+                  type="button"
+                >
+                  <span
+                    class="euiAccordion__iconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="euiIcon euiIcon--medium euiAccordion__icon euiAccordion__icon-isOpen"
+                      focusable="false"
+                      height="16"
+                      role="img"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="m5.157 13.069 4.611-4.685a.546.546 0 0 0 0-.768L5.158 2.93a.552.552 0 0 1 0-.771.53.53 0 0 1 .759 0l4.61 4.684c.631.641.63 1.672 0 2.312l-4.61 4.684a.53.53 0 0 1-.76 0 .552.552 0 0 1 0-.771Z"
+                        fill-rule="nonzero"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="euiIEFlexWrapFix"
+                  >
+                    <div
+                      id="featureAccordionHeaders.0"
+                    >
+                      <div
+                        class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+                      >
+                        <div
+                          class="euiFlexItem"
+                        >
+                          <h5
+                            class="euiTitle euiTitle--xsmall euiAccordionForm__title"
+                          >
+                            Add feature
+                          </h5>
+                        </div>
+                      </div>
+                    </div>
+                  </span>
+                </button>
+                <div
+                  class="euiAccordion__optionalAction"
+                >
+                  <button
+                    class="euiButton euiButton--danger euiButton--small"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButton__content"
+                    >
+                      <span
+                        class="euiButton__text"
+                      >
+                        Delete
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+              <div
+                aria-labelledby="random_html_id"
+                class="euiAccordion__childWrapper"
+                id="featureList.0"
+                role="region"
+                tabindex="-1"
+              >
+                <div>
+                  <div
+                    class="euiAccordion__padding--l"
+                  >
+                    <div
+                      class="euiFormRow euiFormRow--compressed"
+                      id="random_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="random_html_id"
+                        >
+                          Feature name
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <input
+                              aria-describedby="random_html_id-help-0"
+                              class="euiFieldText euiFieldText--compressed"
+                              data-test-subj="featureNameTextInput-0"
+                              id="random_html_id"
+                              name="featureList.0.featureName"
+                              placeholder="Enter feature name"
+                              type="text"
+                              value=""
+                            />
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="random_html_id-help-0"
+                        >
+                          Enter a descriptive name. The name must be unique within this detector. Feature name must contain 1-64 characters. Valid characters are a-z, A-Z, 0-9, -(hyphen) and _(underscore).
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow euiFormRow--compressed"
+                      id="random_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="random_html_id"
+                        >
+                          Feature state
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiCheckbox euiCheckbox--compressed"
+                        >
+                          <input
+                            checked=""
+                            class="euiCheckbox__input"
+                            id="random_html_id"
+                            name="featureList.0.featureEnabled"
+                            type="checkbox"
+                            value="true"
+                          />
+                          <div
+                            class="euiCheckbox__square"
+                          />
+                          <label
+                            class="euiCheckbox__label"
+                            for="random_html_id"
+                          >
+                            Enable feature
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow euiFormRow--compressed"
+                      id="random_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="random_html_id"
+                        >
+                          Find anomalies based on
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <select
+                              class="euiSelect euiSelect--compressed"
+                              id="random_html_id"
+                              name="featureList.0.featureType"
+                            >
+                              <option
+                                value="simple_aggs"
+                              >
+                                Field value
+                              </option>
+                              <option
+                                value="custom_aggs"
+                              >
+                                Custom expression
+                              </option>
+                            </select>
+                            <div
+                              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                            >
+                              <span
+                                class="euiFormControlLayoutCustomIcon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fill-rule="non-zero"
+                                  />
+                                </svg>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow euiFormRow--compressed"
+                      id="random_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="random_html_id"
+                        >
+                          Aggregation method
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          class="euiFormControlLayout euiFormControlLayout--compressed"
+                        >
+                          <div
+                            class="euiFormControlLayout__childrenWrapper"
+                          >
+                            <select
+                              aria-describedby="random_html_id-help-0"
+                              class="euiSelect euiSelect--compressed"
+                              data-test-subj="aggregationType"
+                              id="random_html_id"
+                              name="featureList.0.aggregationBy"
+                            >
+                              <option
+                                value="avg"
+                              >
+                                average()
+                              </option>
+                              <option
+                                value="value_count"
+                              >
+                                count()
+                              </option>
+                              <option
+                                value="sum"
+                              >
+                                sum()
+                              </option>
+                              <option
+                                value="min"
+                              >
+                                min()
+                              </option>
+                              <option
+                                value="max"
+                              >
+                                max()
+                              </option>
+                            </select>
+                            <div
+                              class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                            >
+                              <span
+                                class="euiFormControlLayoutCustomIcon"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height="16"
+                                  role="img"
+                                  viewBox="0 0 16 16"
+                                  width="16"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                    fill-rule="non-zero"
+                                  />
+                                </svg>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          class="euiFormHelpText euiFormRow__text"
+                          id="random_html_id-help-0"
+                        >
+                          The aggregation method determines what constitutes an anomaly. For example, if you choose min(), the detector focuses on finding anomalies based on the minimum values of your feature.
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormRow euiFormRow--compressed"
+                      id="random_html_id-row"
+                    >
+                      <div
+                        class="euiFormRow__labelWrapper"
+                      >
+                        <label
+                          aria-invalid="false"
+                          class="euiFormLabel euiFormRow__label"
+                          for="random_html_id"
+                        >
+                          Field
+                        </label>
+                      </div>
+                      <div
+                        class="euiFormRow__fieldWrapper"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          class="euiComboBox euiComboBox--compressed"
+                          data-test-subj="featureFieldTextInput-0"
+                          name="featureList.0.aggregationOf"
+                          role="combobox"
+                        >
+                          <div
+                            class="euiFormControlLayout euiFormControlLayout--compressed"
+                          >
+                            <div
+                              class="euiFormControlLayout__childrenWrapper"
+                            >
+                              <div
+                                class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isClearable"
+                                data-test-subj="comboBoxInput"
+                                tabindex="-1"
+                              >
+                                <p
+                                  class="euiComboBoxPlaceholder"
+                                >
+                                  Select field
+                                </p>
+                                <div
+                                  class="euiComboBox__input"
+                                  style="font-size: 14px; display: inline-block;"
+                                >
+                                  <input
+                                    aria-controls=""
+                                    data-test-subj="comboBoxSearchInput"
+                                    id="random_html_id"
+                                    role="textbox"
+                                    style="box-sizing: content-box; width: 2px;"
+                                    value=""
+                                  />
+                                  <div
+                                    style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                              >
+                                <button
+                                  aria-label="Open list of options"
+                                  class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                                  data-test-subj="comboBoxToggleListButton"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                                    focusable="false"
+                                    height="16"
+                                    role="img"
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                                      fill-rule="non-zero"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
               class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
               style="padding: 12px 0px;"
             >
@@ -1155,7 +1575,7 @@ exports[`<ConfigureModel /> spec editing model configuration renders the compone
                   <p>
                     You can add up to
                      
-                    5
+                    4
                      
                     more features.
                   </p>

--- a/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesDistribution.tsx
@@ -17,7 +17,7 @@ import {
 } from '../utils/utils';
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
 import {
-  EuiSelect,
+  EuiCompressedSelect,
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingChart,
@@ -128,10 +128,10 @@ export const AnomaliesDistributionChart = (
       titleDataTestSubj="dashboardSunburstChartHeader"
       title="Anomalies by index and detector"
       titleSize="s"
-      subTitle={`The inner circle shows anomaly distribution by index. 
+      subTitle={`The inner circle shows anomaly distribution by index.
       The outer circle shows distribution by detector.`}
       actions={
-        <EuiSelect
+        <EuiCompressedSelect
           style={{ width: 150 }}
           id="timeRangeSelect"
           options={TIME_RANGE_OPTIONS}

--- a/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
+++ b/public/pages/Dashboard/Components/AnomaliesLiveChart.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../../server/utils/constants';
 import {
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
@@ -215,14 +215,14 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
   const annotations = [timeNowAnnotation];
 
   const fullScreenButton = () => (
-    <EuiButton
+    <EuiSmallButton
       onClick={() => setIsFullScreen((isFullScreen) => !isFullScreen)}
       iconType={isFullScreen ? 'exit' : 'fullScreen'}
       aria-label="View full screen"
       data-test-subj="dashboardFullScreenButton"
     >
       {isFullScreen ? 'Exit full screen' : 'View full screen'}
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   return (
@@ -237,9 +237,9 @@ export const AnomaliesLiveChart = (props: AnomaliesLiveChartProps) => {
           </h3>
         </EuiTitle>
       }
-      subTitle={`Live anomaly results across detectors for the last 30 minutes.  
-                'The results refresh every 1 minute. 
-                'For each detector, if an anomaly occurrence is detected at the end of the detector interval, 
+      subTitle={`Live anomaly results across detectors for the last 30 minutes.
+                'The results refresh every 1 minute.
+                'For each detector, if an anomaly occurrence is detected at the end of the detector interval,
                 'you will see a bar representing its anomaly grade.`}
       actions={[fullScreenButton()]}
       contentPanelClassName={isFullScreen ? 'full-screen' : undefined}

--- a/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
+++ b/public/pages/Dashboard/Components/EmptyDashboard/__tests__/__snapshots__/EmptyDashboard.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`<EmptyDetector /> spec Empty results renders component with empty messa
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="sampleDetectorButton"
         href="anomaly-detection-dashboards#/overview?"
         rel="noreferrer"
@@ -91,7 +91,7 @@ exports[`<EmptyDetector /> spec Empty results renders component with empty messa
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="createDetectorButton"
         href="anomaly-detection-dashboards#/create-ad/?"
         rel="noreferrer"

--- a/public/pages/Dashboard/Components/__tests__/__snapshots__/AnomaliesLiveCharts.test.tsx.snap
+++ b/public/pages/Dashboard/Components/__tests__/__snapshots__/AnomaliesLiveCharts.test.tsx.snap
@@ -51,9 +51,9 @@ exports[`<AnomaliesLiveChart /> spec AnomaliesLiveChart with Sample anomaly data
             class="euiFlexItem content-panel-subTitle"
             style="line-height: normal; max-width: 75%;"
           >
-            Live anomaly results across detectors for the last 30 minutes.  
-                'The results refresh every 1 minute. 
-                'For each detector, if an anomaly occurrence is detected at the end of the detector interval, 
+            Live anomaly results across detectors for the last 30 minutes.
+                'The results refresh every 1 minute.
+                'For each detector, if an anomaly occurrence is detected at the end of the detector interval,
                 'you will see a bar representing its anomaly grade.
           </div>
         </div>
@@ -69,7 +69,7 @@ exports[`<AnomaliesLiveChart /> spec AnomaliesLiveChart with Sample anomaly data
           >
             <button
               aria-label="View full screen"
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               data-test-subj="dashboardFullScreenButton"
               type="button"
             >

--- a/public/pages/Dashboard/Components/utils/DashboardHeader.tsx
+++ b/public/pages/Dashboard/Components/utils/DashboardHeader.tsx
@@ -11,7 +11,7 @@
 
 import React from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPageHeader,
@@ -43,13 +43,13 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
         </EuiFlexItem>
         {props.hasDetectors ? (
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               href={createDetectorUrl}
               data-test-subj="add_detector"
             >
               Create detector
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         ) : null}
       </EuiFlexGroup>

--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -23,7 +23,7 @@ import { getDetectorList } from '../../../redux/reducers/ad';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionProps,
   EuiLoadingSpinner,
   EuiSpacer,
@@ -93,11 +93,11 @@ export function DashboardOverview(props: OverviewProps) {
   const queryParams = getDataSourceFromURL(props.location);
   const [MDSOverviewState, setMDSOverviewState] = useState<MDSStates>({
     queryParams,
-    selectedDataSourceId: queryParams.dataSourceId === undefined 
-      ? undefined 
+    selectedDataSourceId: queryParams.dataSourceId === undefined
+      ? undefined
       : queryParams.dataSourceId,
   });
-  
+
   const getDetectorOptions = (detectorsIdMap: {
     [key: string]: DetectorListItem;
   }) => {
@@ -278,7 +278,7 @@ export function DashboardOverview(props: OverviewProps) {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: props.landingDataSourceId === undefined 
+            activeOption: props.landingDataSourceId === undefined
               || MDSOverviewState.selectedDataSourceId === undefined
                 ? undefined
                 : [{ id: MDSOverviewState.selectedDataSourceId }],
@@ -308,7 +308,7 @@ export function DashboardOverview(props: OverviewProps) {
           <Fragment>
             <EuiFlexGroup justifyContent="flexStart" gutterSize="s">
               <EuiFlexItem>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   id="detectorFilter"
                   data-test-subj="detectorFilter"
                   placeholder={ALL_DETECTORS_MESSAGE}
@@ -320,7 +320,7 @@ export function DashboardOverview(props: OverviewProps) {
                 />
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   id="detectorStateFilter"
                   data-test-subj="detectorStateFilter"
                   placeholder={ALL_DETECTOR_STATES_MESSAGE}
@@ -332,7 +332,7 @@ export function DashboardOverview(props: OverviewProps) {
                 />
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiComboBox
+                <EuiCompressedComboBox
                   id="indicesFilter"
                   data-test-subj="indicesFilter"
                   placeholder={ALL_INDICES_MESSAGE}

--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -15,13 +15,13 @@ import {
   EuiText,
   EuiLink,
   EuiTitle,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiCallOut,
   EuiSpacer,
   EuiCompressedFormRow,
   EuiCheckbox,
   EuiIcon,
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
 } from '@elastic/eui';
 import { Field, FieldProps, FormikProps, useFormikContext } from 'formik';
 import React, { useEffect, useState } from 'react';
@@ -136,7 +136,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
                   error={getError(field.name, form)}
                   helpText={`Custom result index name must contain less than 255 characters including the prefix "opensearch-ad-plugin-result-". Valid characters are a-z, 0-9, -(hyphen) and _(underscore).`}
                 >
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     id="resultIndex"
                     placeholder="Enter result index name"
                     prepend={props.isEdit ? '' : CUSTOM_AD_RESULT_INDEX_PREFIX}
@@ -208,7 +208,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
               >
                 <EuiFlexGroup gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiFieldNumber
+                    <EuiCompressedFieldNumber
                       name="resultIndexMinAge"
                       id="resultIndexMinAge"
                       data-test-subj="resultIndexMinAge"
@@ -251,7 +251,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
               >
                 <EuiFlexGroup gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiFieldNumber
+                    <EuiCompressedFieldNumber
                       name="resultIndexMinSize"
                       id="resultIndexMinSize"
                       placeholder="Min index size"
@@ -294,7 +294,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
               >
                 <EuiFlexGroup gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiFieldNumber
+                    <EuiCompressedFieldNumber
                       name="resultIndexTtl"
                       id="resultIndexTtl"
                       data-test-subj="resultIndexTtl"

--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -18,7 +18,7 @@ import {
   EuiFieldText,
   EuiCallOut,
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiCheckbox,
   EuiIcon,
   EuiFieldNumber,
@@ -58,7 +58,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
       if (customResultIndexMinAge === undefined && customResultIndexMinSize === undefined && customResultIndexTTL === undefined) {
         setCustomResultIndexConditionsEnabled(false);
       }
-    } 
+    }
     if (!customResultIndexConditionsEnabled) {
       setFieldValue('resultIndexMinAge', '');
       setFieldValue('resultIndexMinSize', '');
@@ -130,7 +130,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
 
             {enabled ? (
               <EuiFlexItem>
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="Field"
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
@@ -143,7 +143,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
                     disabled={props.isEdit}
                     {...field}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               </EuiFlexItem>
             ) : null}
           </EuiFlexGroup>
@@ -185,9 +185,9 @@ function CustomResultIndex(props: CustomResultIndexProps) {
           ) : null}
         </EuiFlexItem>
       </EuiFlexGroup>
-      
-      { (enabled && customResultIndexConditionsEnabled) ? (<Field 
-        name="resultIndexMinAge" 
+
+      { (enabled && customResultIndexConditionsEnabled) ? (<Field
+        name="resultIndexMinAge"
         validate={(enabled && customResultIndexConditionsEnabled) ? validateEmptyOrPositiveInteger : null}
         >
         {({ field, form }: FieldProps) => (
@@ -227,7 +227,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
             </EuiFlexItem>
           </EuiFlexGroup>
         )}
-      </Field>) : null}  
+      </Field>) : null}
 
       {(enabled && customResultIndexConditionsEnabled) ? (<Field
         name="resultIndexMinSize"

--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -19,7 +19,7 @@ import {
   EuiCallOut,
   EuiSpacer,
   EuiCompressedFormRow,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiIcon,
   EuiCompressedFieldNumber,
 } from '@elastic/eui';
@@ -102,7 +102,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
         {({ field, form }: FieldProps) => (
           <EuiFlexGroup direction="column">
             <EuiFlexItem>
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id={'resultIndexCheckbox'}
                 label="Enable custom result index"
                 checked={enabled}
@@ -158,7 +158,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
             {({ field, form }: FieldProps) => (
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiCheckbox
+                  <EuiCompressedCheckbox
                     id={'flattenCustomResultIndex'}
                     label="Enable flattened custom result index"
                     checked={field.value ? field.value : get(props.formikProps, 'values.flattenCustomResultIndex')}
@@ -173,7 +173,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
         <EuiFlexItem>
           {enabled ? (
             <EuiFlexItem>
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id={'resultIndexConditionCheckbox'}
                 label="Enable custom result index lifecycle management"
                 checked={customResultIndexConditionsEnabled}

--- a/public/pages/DefineDetector/components/DataFilterList/components/CustomFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/CustomFilter.tsx
@@ -12,7 +12,7 @@
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiCodeEditor,
 } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
@@ -44,7 +44,7 @@ export const CustomFilter = (props: CustomFilterProps) => {
               validate={validateFilterQuery}
             >
               {({ field, form }: FieldProps) => (
-                <EuiFormRow
+                <EuiCompressedFormRow
                   fullWidth
                   label="OpenSearch query DSL"
                   isInvalid={isInvalid(field.name, form)}
@@ -66,7 +66,7 @@ export const CustomFilter = (props: CustomFilterProps) => {
                     }}
                     value={field.value}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               )}
             </Field>
           </EuiFlexItem>

--- a/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
@@ -12,7 +12,7 @@
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiBadge,
   EuiButtonEmpty,
   EuiPopover,
@@ -331,7 +331,7 @@ export const DataFilter = (props: DataFilterProps) => {
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 id="saveFilterButton"
                 fill={true}
                 data-test-subj={`saveFilter${props.index}Button`}
@@ -349,7 +349,7 @@ export const DataFilter = (props: DataFilterProps) => {
                 }}
               >
                 Save
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexGroup>

--- a/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
@@ -19,7 +19,7 @@ import {
   EuiPopover,
   EuiPopoverTitle,
   EuiText,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiCompressedFieldText,
   EuiSpacer,
 } from '@elastic/eui';
@@ -287,7 +287,7 @@ export const DataFilter = (props: DataFilterProps) => {
         <EuiFlexGroup direction="column" style={{ margin: '0px' }}>
           <EuiFlexGroup direction="column">
             <EuiFlexItem>
-              <EuiSwitch
+              <EuiCompressedSwitch
                 data-test-subj={'switchForCustomLabel'}
                 label={<EuiText>Create custom label?</EuiText>}
                 checked={isCustomLabel}

--- a/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
@@ -14,6 +14,7 @@ import {
   EuiFlexItem,
   EuiSmallButton,
   EuiBadge,
+  EuiSmallButtonEmpty,
   EuiButtonEmpty,
   EuiPopover,
   EuiPopoverTitle,
@@ -252,7 +253,7 @@ export const DataFilter = (props: DataFilterProps) => {
               </EuiText>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
+              <EuiSmallButtonEmpty
                 data-test-subj="filterTypeButton"
                 onClick={() => {
                   filterType === FILTER_TYPES.SIMPLE
@@ -263,7 +264,7 @@ export const DataFilter = (props: DataFilterProps) => {
                 {filterType === FILTER_TYPES.SIMPLE
                   ? 'Use query DSL'
                   : 'Use visual editor'}
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPopoverTitle>
@@ -319,7 +320,7 @@ export const DataFilter = (props: DataFilterProps) => {
             gutterSize="s"
           >
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
+              <EuiSmallButtonEmpty
                 id="cancelSaveFilterButton"
                 data-test-subj={`cancelFilter${props.index}Button`}
                 onClick={() => {
@@ -328,7 +329,7 @@ export const DataFilter = (props: DataFilterProps) => {
                 }}
               >
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
@@ -20,7 +20,7 @@ import {
   EuiPopoverTitle,
   EuiText,
   EuiSwitch,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSpacer,
 } from '@elastic/eui';
 import React, { useState, useEffect } from 'react';
@@ -300,7 +300,7 @@ export const DataFilter = (props: DataFilterProps) => {
             {isCustomLabel ? (
               <EuiFlexItem>
                 <FormattedFormRow title="Custom label">
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     name="customLabel"
                     id="customLabel"
                     placeholder="Enter a value"

--- a/public/pages/DefineDetector/components/DataFilterList/components/FilterValue.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/FilterValue.tsx
@@ -14,7 +14,7 @@ import {
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
 } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
@@ -49,7 +49,7 @@ function FilterValue(props: FilterValueProps) {
               }
             >
               {({ field, form }: FieldProps) => (
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="From"
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
@@ -58,7 +58,7 @@ function FilterValue(props: FilterValueProps) {
                     {...field}
                     isInvalid={isInvalid(field.name, form)}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               )}
             </Field>
           </EuiFlexItem>
@@ -73,7 +73,7 @@ function FilterValue(props: FilterValueProps) {
               }
             >
               {({ field, form }: FieldProps) => (
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="To"
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
@@ -85,7 +85,7 @@ function FilterValue(props: FilterValueProps) {
                       form.setFieldTouched(`filters.${props.index}.fieldValue`);
                     }}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               )}
             </Field>
           </EuiFlexItem>
@@ -95,7 +95,7 @@ function FilterValue(props: FilterValueProps) {
       return (
         <Field name={`filters.${props.index}.fieldValue`} validate={required}>
           {({ field, form }: FieldProps) => (
-            <EuiFormRow
+            <EuiCompressedFormRow
               label="Value"
               isInvalid={isInvalid(field.name, form)}
               error={getError(field.name, form)}
@@ -104,7 +104,7 @@ function FilterValue(props: FilterValueProps) {
                 {...field}
                 isInvalid={isInvalid(field.name, form)}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           )}
         </Field>
       );
@@ -113,7 +113,7 @@ function FilterValue(props: FilterValueProps) {
     return (
       <Field name={`filters.${props.index}.fieldValue`} validate={required}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow
+          <EuiCompressedFormRow
             label="Value"
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
@@ -123,7 +123,7 @@ function FilterValue(props: FilterValueProps) {
               options={WHERE_BOOLEAN_FILTERS}
               isInvalid={isInvalid(field.name, form)}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </Field>
     );
@@ -131,9 +131,9 @@ function FilterValue(props: FilterValueProps) {
     return (
       <Field name={`filters.${props.index}.fieldValue`} validate={required}>
         {({ field, form }: FieldProps) => (
-          <EuiFormRow label="Value">
+          <EuiCompressedFormRow label="Value">
             <EuiFieldText {...field} isInvalid={isInvalid(field.name, form)} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         )}
       </Field>
     );

--- a/public/pages/DefineDetector/components/DataFilterList/components/FilterValue.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/FilterValue.tsx
@@ -10,8 +10,8 @@
  */
 
 import {
-  EuiFieldNumber,
-  EuiFieldText,
+  EuiCompressedFieldNumber,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -54,7 +54,7 @@ function FilterValue(props: FilterValueProps) {
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
                 >
-                  <EuiFieldNumber
+                  <EuiCompressedFieldNumber
                     {...field}
                     isInvalid={isInvalid(field.name, form)}
                   />
@@ -78,7 +78,7 @@ function FilterValue(props: FilterValueProps) {
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
                 >
-                  <EuiFieldNumber
+                  <EuiCompressedFieldNumber
                     {...field}
                     isInvalid={isInvalid(field.name, form)}
                     onBlur={() => {
@@ -100,7 +100,7 @@ function FilterValue(props: FilterValueProps) {
               isInvalid={isInvalid(field.name, form)}
               error={getError(field.name, form)}
             >
-              <EuiFieldNumber
+              <EuiCompressedFieldNumber
                 {...field}
                 isInvalid={isInvalid(field.name, form)}
               />
@@ -132,7 +132,7 @@ function FilterValue(props: FilterValueProps) {
       <Field name={`filters.${props.index}.fieldValue`} validate={required}>
         {({ field, form }: FieldProps) => (
           <EuiCompressedFormRow label="Value">
-            <EuiFieldText {...field} isInvalid={isInvalid(field.name, form)} />
+            <EuiCompressedFieldText {...field} isInvalid={isInvalid(field.name, form)} />
           </EuiCompressedFormRow>
         )}
       </Field>

--- a/public/pages/DefineDetector/components/DataFilterList/components/FilterValue.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/FilterValue.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
 } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import React from 'react';
@@ -118,7 +118,7 @@ function FilterValue(props: FilterValueProps) {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiSelect
+            <EuiCompressedSelect
               {...field}
               options={WHERE_BOOLEAN_FILTERS}
               isInvalid={isInvalid(field.name, form)}

--- a/public/pages/DefineDetector/components/DataFilterList/components/SimpleFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/SimpleFilter.tsx
@@ -14,7 +14,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
-  EuiSelect,
+  EuiCompressedSelect,
 } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import React, { useState } from 'react';
@@ -156,7 +156,7 @@ export const SimpleFilter = (props: SimpleFilterProps) => {
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
                 >
-                  <EuiSelect
+                  <EuiCompressedSelect
                     id={`filters.${props.index}.operator`}
                     placeholder="Choose an operator"
                     {...field}

--- a/public/pages/DefineDetector/components/DataFilterList/components/SimpleFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/SimpleFilter.tsx
@@ -10,7 +10,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -101,7 +101,7 @@ export const SimpleFilter = (props: SimpleFilterProps) => {
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
                 >
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     id={`filters.${props.index}.fieldInfo`}
                     singleSelection={{ asPlainText: true }}
                     placeholder="Choose a field"

--- a/public/pages/DefineDetector/components/DataFilterList/components/SimpleFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/SimpleFilter.tsx
@@ -13,7 +13,7 @@ import {
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSelect,
 } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
@@ -96,7 +96,7 @@ export const SimpleFilter = (props: SimpleFilterProps) => {
               validateOnChange={true}
             >
               {({ field, form }: FieldProps) => (
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="Field"
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
@@ -144,14 +144,14 @@ export const SimpleFilter = (props: SimpleFilterProps) => {
                     onSearchChange={handleSearchFieldChange}
                     isInvalid={isInvalid(field.name, form)}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               )}
             </Field>
           </EuiFlexItem>
           <EuiFlexItem>
             <Field name={`filters.${props.index}.operator`}>
               {({ field, form }: FieldProps) => (
-                <EuiFormRow
+                <EuiCompressedFormRow
                   label="Operator"
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
@@ -192,7 +192,7 @@ export const SimpleFilter = (props: SimpleFilterProps) => {
                       );
                     }}
                   />
-                </EuiFormRow>
+                </EuiCompressedFormRow>
               )}
             </Field>
           </EuiFlexItem>

--- a/public/pages/DefineDetector/components/Datasource/DataSource.tsx
+++ b/public/pages/DefineDetector/components/Datasource/DataSource.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { Field, FieldProps, FormikProps, useFormikContext } from 'formik';
 import { debounce, get } from 'lodash';
 import React, { useEffect, useState } from 'react';
@@ -129,7 +129,7 @@ export function DataSource(props: DataSourceProps) {
               error={getError(field.name, form)}
               helpText="You can use a wildcard (*) in your index pattern."
             >
-              <EuiComboBox
+              <EuiCompressedComboBox
                 data-test-subj="indicesFilter"
                 id="index"
                 placeholder="Find indices"

--- a/public/pages/DefineDetector/components/NameAndDescription/NameAndDescription.tsx
+++ b/public/pages/DefineDetector/components/NameAndDescription/NameAndDescription.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiCompressedFieldText, EuiTextArea } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiCompressedTextArea } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import React from 'react';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
@@ -56,7 +56,7 @@ function NameAndDescription(props: NameAndDescriptionProps) {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiTextArea
+            <EuiCompressedTextArea
               data-test-subj="detectorDescriptionTextInput"
               name="detectorDescription"
               id="detectorDescription"

--- a/public/pages/DefineDetector/components/NameAndDescription/NameAndDescription.tsx
+++ b/public/pages/DefineDetector/components/NameAndDescription/NameAndDescription.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiFieldText, EuiTextArea } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiTextArea } from '@elastic/eui';
 import { Field, FieldProps } from 'formik';
 import React from 'react';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
@@ -33,7 +33,7 @@ function NameAndDescription(props: NameAndDescriptionProps) {
             helpText={`Detector name must contain 1-64 characters. Valid characters are
                 a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period).`}
           >
-            <EuiFieldText
+            <EuiCompressedFieldText
               data-test-subj="detectorNameTextInput"
               name="detectorName"
               id="detectorName"

--- a/public/pages/DefineDetector/components/NameAndDescription/__tests__/__snapshots__/NameAndDescription.test.tsx.snap
+++ b/public/pages/DefineDetector/components/NameAndDescription/__tests__/__snapshots__/NameAndDescription.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`<NameAndDescription /> spec renders the component 1`] = `
         style="padding: 10px 0px;"
       >
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           hint="Specify a unique and descriptive name that is easy to recognize."
           id="random_html_id-row"
           title="Name"
@@ -81,14 +81,14 @@ exports[`<NameAndDescription /> spec renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <input
                   aria-describedby="random_html_id-help-0"
-                  class="euiFieldText"
+                  class="euiFieldText euiFieldText--compressed"
                   data-test-subj="detectorNameTextInput"
                   id="random_html_id"
                   name="name"
@@ -108,7 +108,7 @@ exports[`<NameAndDescription /> spec renders the component 1`] = `
           </div>
         </div>
         <div
-          class="euiFormRow"
+          class="euiFormRow euiFormRow--compressed"
           hint="Describe the purpose of the detector."
           id="random_html_id-row"
         >
@@ -145,7 +145,7 @@ exports[`<NameAndDescription /> spec renders the component 1`] = `
             class="euiFormRow__fieldWrapper"
           >
             <textarea
-              class="euiTextArea euiTextArea--resizeVertical"
+              class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
               data-test-subj="detectorDescriptionTextInput"
               id="random_html_id"
               name="description"

--- a/public/pages/DefineDetector/components/Settings/Settings.tsx
+++ b/public/pages/DefineDetector/components/Settings/Settings.tsx
@@ -11,7 +11,7 @@
 
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import {
-  EuiFieldNumber,
+  EuiCompressedFieldNumber,
   EuiFlexGroup,
   EuiFlexItem,
   EuiText,
@@ -46,7 +46,7 @@ export const Settings = () => {
               >
                 <EuiFlexGroup gutterSize="s" alignItems="center">
                   <EuiFlexItem grow={false}>
-                    <EuiFieldNumber
+                    <EuiCompressedFieldNumber
                       name="detectionInterval"
                       id="detectionInterval"
                       placeholder="Detector interval"
@@ -79,7 +79,7 @@ export const Settings = () => {
           >
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={false}>
-                <EuiFieldNumber
+                <EuiCompressedFieldNumber
                   name="windowDelay"
                   id="windowDelay"
                   placeholder="Window delay"

--- a/public/pages/DefineDetector/components/Settings/__tests__/__snapshots__/Settings.test.tsx.snap
+++ b/public/pages/DefineDetector/components/Settings/__tests__/__snapshots__/Settings.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`<Settings /> spec renders the component 1`] = `
             style="max-width: 70%;"
           >
             <div
-              class="euiFormRow euiFormRow--fullWidth"
+              class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
               hint="Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need."
               hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
               id="random_html_id-row"
@@ -125,13 +125,13 @@ exports[`<Settings /> spec renders the component 1`] = `
                     class="euiFlexItem euiFlexItem--flexGrowZero"
                   >
                     <div
-                      class="euiFormControlLayout"
+                      class="euiFormControlLayout euiFormControlLayout--compressed"
                     >
                       <div
                         class="euiFormControlLayout__childrenWrapper"
                       >
                         <input
-                          class="euiFieldNumber"
+                          class="euiFieldNumber euiFieldNumber--compressed"
                           data-test-subj="detectionInterval"
                           id="detectionInterval"
                           min="1"
@@ -162,7 +162,7 @@ exports[`<Settings /> spec renders the component 1`] = `
           </div>
         </div>
         <div
-          class="euiFormRow euiFormRow--fullWidth"
+          class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
           hint="Specify a window of delay for a detector to fetch data, if you need to account for extra processing time."
           hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
           id="random_html_id-row"
@@ -233,13 +233,13 @@ exports[`<Settings /> spec renders the component 1`] = `
                 class="euiFlexItem euiFlexItem--flexGrowZero"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <input
-                      class="euiFieldNumber"
+                      class="euiFieldNumber euiFieldNumber--compressed"
                       data-test-subj="windowDelay"
                       id="windowDelay"
                       name="windowDelay"

--- a/public/pages/DefineDetector/components/Timestamp/Timestamp.tsx
+++ b/public/pages/DefineDetector/components/Timestamp/Timestamp.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { Field, FieldProps, FormikProps } from 'formik';
 import { debounce, get, isEmpty } from 'lodash';
 import React, { useState } from 'react';
@@ -87,7 +87,7 @@ export function Timestamp(props: TimestampProps) {
             isInvalid={isInvalid(field.name, form)}
             error={getError(field.name, form)}
           >
-            <EuiComboBox
+            <EuiCompressedComboBox
               data-test-subj="timestampFilter"
               id="timeField"
               placeholder="Find timestamp"

--- a/public/pages/DefineDetector/components/Timestamp/__tests__/__snapshots__/Timestamp.test.tsx.snap
+++ b/public/pages/DefineDetector/components/Timestamp/__tests__/__snapshots__/Timestamp.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`<Timestamp /> spec renders the component 1`] = `
       style="padding: 10px 0px;"
     >
       <div
-        class="euiFormRow"
+        class="euiFormRow euiFormRow--compressed"
         hint="Choose the time field you want to use for time filter."
         id="random_html_id-row"
         title="Timestamp field"
@@ -84,18 +84,18 @@ exports[`<Timestamp /> spec renders the component 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            class="euiComboBox"
+            class="euiComboBox euiComboBox--compressed"
             data-test-subj="timestampFilter"
             role="combobox"
           >
             <div
-              class="euiFormControlLayout"
+              class="euiFormControlLayout euiFormControlLayout--compressed"
             >
               <div
                 class="euiFormControlLayout__childrenWrapper"
               >
                 <div
-                  class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                  class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                   data-test-subj="comboBoxInput"
                   tabindex="-1"
                 >
@@ -132,7 +132,7 @@ exports[`<Timestamp /> spec renders the component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                      class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                       focusable="false"
                       height="16"
                       role="img"

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -25,7 +25,7 @@ import {
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiPage,
   EuiPageBody,
@@ -323,7 +323,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
             componentType={'DataSourceSelectable'}
             componentConfig={{
               fullWidth: false,
-              activeOption: MDSCreateState.selectedDataSourceId !== undefined 
+              activeOption: MDSCreateState.selectedDataSourceId !== undefined
                 ? [{ id: MDSCreateState.selectedDataSourceId }]
                 : undefined,
               savedObjects: getSavedObjectsClient(),
@@ -435,7 +435,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               {props.isEdit ? (
-                <EuiButton
+                <EuiSmallButton
                   type="submit"
                   fill={true}
                   data-test-subj="updateDetectorButton"
@@ -445,9 +445,9 @@ export const DefineDetector = (props: DefineDetectorProps) => {
                   }}
                 >
                   Save changes
-                </EuiButton>
+                </EuiSmallButton>
               ) : (
-                <EuiButton
+                <EuiSmallButton
                   type="submit"
                   iconSide="right"
                   iconType="arrowRight"
@@ -460,7 +460,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
                   }}
                 >
                   Next
-                </EuiButton>
+                </EuiSmallButton>
               )}
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -26,7 +26,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiPage,
   EuiPageBody,
   EuiPageHeader,
@@ -409,7 +409,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
             style={{ marginRight: '12px' }}
           >
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
+              <EuiSmallButtonEmpty
                 onClick={() => {
                   if (props.isEdit) {
                     props.history.push(
@@ -431,7 +431,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
                 }}
               >
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               {props.isEdit ? (

--- a/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
+++ b/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Specify a unique and descriptive name that is easy to recognize."
             id="random_html_id-row"
             title="Name"
@@ -102,14 +102,14 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
                     aria-describedby="random_html_id-help-0"
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     data-test-subj="detectorNameTextInput"
                     id="random_html_id"
                     name="name"
@@ -129,7 +129,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
             </div>
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Describe the purpose of the detector."
             id="random_html_id-row"
           >
@@ -166,7 +166,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               class="euiFormRow__fieldWrapper"
             >
               <textarea
-                class="euiTextArea euiTextArea--resizeVertical"
+                class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
                 data-test-subj="detectorDescriptionTextInput"
                 id="random_html_id"
                 name="description"
@@ -229,7 +229,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Choose an index or index pattern as the data source."
             id="random_html_id-row"
             title="Index"
@@ -265,18 +265,18 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                 aria-describedby="random_html_id-help-0"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 data-test-subj="indicesFilter"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -316,7 +316,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                       >
                         <svg
                           aria-hidden="true"
-                          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                           focusable="false"
                           height="16"
                           role="img"
@@ -342,7 +342,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
             </div>
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             hint="Choose a subset of your data source to focus your data stream and reduce noisy data."
             id="random_html_id-row"
           >
@@ -478,7 +478,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Choose the time field you want to use for time filter."
             id="random_html_id-row"
             title="Timestamp field"
@@ -513,18 +513,18 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 data-test-subj="timestampFilter"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -561,7 +561,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                       >
                         <svg
                           aria-hidden="true"
-                          class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                          class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                           focusable="false"
                           height="16"
                           role="img"
@@ -639,7 +639,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               style="max-width: 70%;"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 hint="Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need."
                 hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
                 id="random_html_id-row"
@@ -709,13 +709,13 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <input
-                            class="euiFieldNumber"
+                            class="euiFieldNumber euiFieldNumber--compressed"
                             data-test-subj="detectionInterval"
                             id="detectionInterval"
                             min="1"
@@ -746,7 +746,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
             </div>
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             hint="Specify a window of delay for a detector to fetch data, if you need to account for extra processing time."
             hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
             id="random_html_id-row"
@@ -817,13 +817,13 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
                   class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <input
-                        class="euiFieldNumber"
+                        class="euiFieldNumber euiFieldNumber--compressed"
                         data-test-subj="windowDelay"
                         id="windowDelay"
                         name="windowDelay"
@@ -953,7 +953,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"
@@ -1058,7 +1058,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Specify a unique and descriptive name that is easy to recognize."
             id="random_html_id-row"
             title="Name"
@@ -1091,14 +1091,14 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
                     aria-describedby="random_html_id-help-0"
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     data-test-subj="detectorNameTextInput"
                     id="random_html_id"
                     name="name"
@@ -1118,7 +1118,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
             </div>
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Describe the purpose of the detector."
             id="random_html_id-row"
           >
@@ -1155,7 +1155,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
               class="euiFormRow__fieldWrapper"
             >
               <textarea
-                class="euiTextArea euiTextArea--resizeVertical"
+                class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
                 data-test-subj="detectorDescriptionTextInput"
                 id="random_html_id"
                 name="description"
@@ -1216,7 +1216,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Choose an index or index pattern as the data source."
             id="random_html_id-row"
             title="Index"
@@ -1252,18 +1252,18 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                 aria-describedby="random_html_id-help-0"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 data-test-subj="indicesFilter"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -1303,7 +1303,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                       >
                         <svg
                           aria-hidden="true"
-                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                           focusable="false"
                           height="16"
                           role="img"
@@ -1330,7 +1330,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
             </div>
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             hint="Choose a subset of your data source to focus your data stream and reduce noisy data."
             id="random_html_id-row"
           >
@@ -1467,7 +1467,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Choose the time field you want to use for time filter."
             id="random_html_id-row"
             title="Timestamp field"
@@ -1502,18 +1502,18 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 data-test-subj="timestampFilter"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -1550,7 +1550,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                       >
                         <svg
                           aria-hidden="true"
-                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                           focusable="false"
                           height="16"
                           role="img"
@@ -1629,7 +1629,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
               style="max-width: 70%;"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 hint="Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need."
                 hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
                 id="random_html_id-row"
@@ -1698,13 +1698,13 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <input
-                            class="euiFieldNumber"
+                            class="euiFieldNumber euiFieldNumber--compressed"
                             data-test-subj="detectionInterval"
                             id="detectionInterval"
                             min="1"
@@ -1735,7 +1735,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
             </div>
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             hint="Specify a window of delay for a detector to fetch data, if you need to account for extra processing time."
             hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
             id="random_html_id-row"
@@ -1805,13 +1805,13 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                   class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <input
-                        class="euiFieldNumber"
+                        class="euiFieldNumber euiFieldNumber--compressed"
                         data-test-subj="windowDelay"
                         id="windowDelay"
                         name="windowDelay"
@@ -1940,7 +1940,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"
@@ -2045,7 +2045,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Specify a unique and descriptive name that is easy to recognize."
             id="random_html_id-row"
             title="Name"
@@ -2078,14 +2078,14 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
               class="euiFormRow__fieldWrapper"
             >
               <div
-                class="euiFormControlLayout"
+                class="euiFormControlLayout euiFormControlLayout--compressed"
               >
                 <div
                   class="euiFormControlLayout__childrenWrapper"
                 >
                   <input
                     aria-describedby="random_html_id-help-0"
-                    class="euiFieldText"
+                    class="euiFieldText euiFieldText--compressed"
                     data-test-subj="detectorNameTextInput"
                     id="random_html_id"
                     name="name"
@@ -2105,7 +2105,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
             </div>
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Describe the purpose of the detector."
             id="random_html_id-row"
           >
@@ -2142,7 +2142,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
               class="euiFormRow__fieldWrapper"
             >
               <textarea
-                class="euiTextArea euiTextArea--resizeVertical"
+                class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
                 data-test-subj="detectorDescriptionTextInput"
                 id="random_html_id"
                 name="description"
@@ -2235,7 +2235,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
             />
           </div>
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Choose an index or index pattern as the data source."
             id="random_html_id-row"
             title="Index"
@@ -2271,18 +2271,18 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                 aria-describedby="random_html_id-help-0"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 data-test-subj="indicesFilter"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap euiComboBox__inputWrap-isLoading"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -2322,7 +2322,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                       >
                         <svg
                           aria-hidden="true"
-                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                           focusable="false"
                           height="16"
                           role="img"
@@ -2349,7 +2349,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
             </div>
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             hint="Choose a subset of your data source to focus your data stream and reduce noisy data."
             id="random_html_id-row"
           >
@@ -2486,7 +2486,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
           style="padding: 10px 0px;"
         >
           <div
-            class="euiFormRow"
+            class="euiFormRow euiFormRow--compressed"
             hint="Choose the time field you want to use for time filter."
             id="random_html_id-row"
             title="Timestamp field"
@@ -2521,18 +2521,18 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                class="euiComboBox"
+                class="euiComboBox euiComboBox--compressed"
                 data-test-subj="timestampFilter"
                 role="combobox"
               >
                 <div
-                  class="euiFormControlLayout"
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
                 >
                   <div
                     class="euiFormControlLayout__childrenWrapper"
                   >
                     <div
-                      class="euiComboBox__inputWrap euiComboBox__inputWrap--noWrap"
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
                       data-test-subj="comboBoxInput"
                       tabindex="-1"
                     >
@@ -2569,7 +2569,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                       >
                         <svg
                           aria-hidden="true"
-                          class="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
                           focusable="false"
                           height="16"
                           role="img"
@@ -2648,7 +2648,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
               style="max-width: 70%;"
             >
               <div
-                class="euiFormRow euiFormRow--fullWidth"
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
                 hint="Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need."
                 hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
                 id="random_html_id-row"
@@ -2717,13 +2717,13 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                       class="euiFlexItem euiFlexItem--flexGrowZero"
                     >
                       <div
-                        class="euiFormControlLayout"
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
                       >
                         <div
                           class="euiFormControlLayout__childrenWrapper"
                         >
                           <input
-                            class="euiFieldNumber"
+                            class="euiFieldNumber euiFieldNumber--compressed"
                             data-test-subj="detectionInterval"
                             id="detectionInterval"
                             min="1"
@@ -2754,7 +2754,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
             </div>
           </div>
           <div
-            class="euiFormRow euiFormRow--fullWidth"
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
             hint="Specify a window of delay for a detector to fetch data, if you need to account for extra processing time."
             hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
             id="random_html_id-row"
@@ -2824,13 +2824,13 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                   class="euiFlexItem euiFlexItem--flexGrowZero"
                 >
                   <div
-                    class="euiFormControlLayout"
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
                   >
                     <div
                       class="euiFormControlLayout__childrenWrapper"
                     >
                       <input
-                        class="euiFieldNumber"
+                        class="euiFieldNumber euiFieldNumber--compressed"
                         data-test-subj="windowDelay"
                         id="windowDelay"
                         name="windowDelay"
@@ -2959,7 +2959,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"

--- a/public/pages/DetectorConfig/containers/DetectorJobs.tsx
+++ b/public/pages/DetectorConfig/containers/DetectorJobs.tsx
@@ -10,7 +10,7 @@
  */
 
 import ContentPanel from '../../../components/ContentPanel/ContentPanel';
-import { EuiFlexGrid, EuiFlexItem, EuiFormRow, EuiText } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexItem, EuiCompressedFormRow, EuiText } from '@elastic/eui';
 import React from 'react';
 import { get, isEmpty } from 'lodash';
 import { ConfigCell } from '../../../components/ConfigCell';
@@ -52,7 +52,7 @@ export const DetectorJobs = (props: DetectorJobsProps) => {
           />
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiFormRow label="Historical analysis detector">
+          <EuiCompressedFormRow label="Historical analysis detector">
             <EuiText>
               <p className="enabledLongerWidth">
                 {historicalEnabled
@@ -60,7 +60,7 @@ export const DetectorJobs = (props: DetectorJobsProps) => {
                   : 'Disabled'}
               </p>
             </EuiText>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGrid>
     </ContentPanel>

--- a/public/pages/DetectorConfig/containers/Features.tsx
+++ b/public/pages/DetectorConfig/containers/Features.tsx
@@ -15,7 +15,7 @@ import {
   EuiText,
   EuiLink,
   EuiIcon,
-  EuiButton,
+  EuiSmallButton,
   EuiEmptyPrompt,
   EuiSpacer,
 } from '@elastic/eui';
@@ -194,12 +194,12 @@ export const Features = (props: FeaturesProps) => {
       titleDataTestSubj="modelConfigurationHeader"
       titleSize="s"
       actions={[
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="editModelConfigurationButton"
           onClick={props.onEditFeatures}
         >
           Edit
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     >
       {featureNum == 0 ? (
@@ -218,13 +218,13 @@ export const Features = (props: FeaturesProps) => {
             </EuiText>
           }
           actions={[
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="createButton"
               href={`${PLUGIN_NAME}#/detectors/${props.detectorId}/features`}
               fill
             >
               Configure model
-            </EuiButton>,
+            </EuiSmallButton>,
           ]}
         />
       ) : (

--- a/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
+++ b/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="editDetectorSettingsButton"
                 type="button"
               >
@@ -83,7 +83,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               data-test-subj="detectorNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -118,7 +118,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               data-test-subj="indexNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -152,7 +152,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -195,7 +195,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -230,7 +230,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               data-test-subj="detectorIdCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -263,7 +263,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               data-test-subj="detectorDescriptionCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -298,7 +298,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               data-test-subj="timestampNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -332,7 +332,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -366,7 +366,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -400,7 +400,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -434,7 +434,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -502,7 +502,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -536,7 +536,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -609,7 +609,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="editModelConfigurationButton"
                 type="button"
               >
@@ -1202,7 +1202,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1271,7 +1271,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
               >
                 <div
@@ -1355,7 +1355,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="editDetectorSettingsButton"
                 type="button"
               >
@@ -1391,7 +1391,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               data-test-subj="detectorNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1426,7 +1426,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               data-test-subj="indexNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1460,7 +1460,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1503,7 +1503,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1538,7 +1538,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               data-test-subj="detectorIdCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1573,7 +1573,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               data-test-subj="detectorDescriptionCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1608,7 +1608,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               data-test-subj="timestampNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1642,7 +1642,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1676,7 +1676,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1710,7 +1710,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1744,7 +1744,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1812,7 +1812,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1846,7 +1846,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1919,7 +1919,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="editModelConfigurationButton"
                 type="button"
               >
@@ -2584,7 +2584,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -2655,7 +2655,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
               >
                 <div

--- a/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
+++ b/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
@@ -468,7 +468,7 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1778,7 +1778,7 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >

--- a/public/pages/DetectorDetail/components/ConfirmModal/ConfirmModal.tsx
+++ b/public/pages/DetectorDetail/components/ConfirmModal/ConfirmModal.tsx
@@ -21,7 +21,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiButtonEmpty,
-  EuiButton,
+  EuiSmallButton,
   ButtonColor,
 } from '@elastic/eui';
 
@@ -67,7 +67,7 @@ export const ConfirmModal = (props: ConfirmModalProps) => {
           Cancel
         </EuiButtonEmpty>
 
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="confirmButton"
           color={props.confirmButtonColor}
           fill
@@ -76,7 +76,7 @@ export const ConfirmModal = (props: ConfirmModalProps) => {
           isLoading={!!props.confirmButtonIsLoading}
         >
           {props.confirmButtonText}
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/DetectorDetail/components/ConfirmModal/ConfirmModal.tsx
+++ b/public/pages/DetectorDetail/components/ConfirmModal/ConfirmModal.tsx
@@ -20,7 +20,7 @@ import {
   EuiModalBody,
   EuiSpacer,
   EuiText,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButton,
   ButtonColor,
 } from '@elastic/eui';
@@ -63,9 +63,9 @@ export const ConfirmModal = (props: ConfirmModalProps) => {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="cancelButton" onClick={props.onCancel}>
+        <EuiSmallButtonEmpty data-test-subj="cancelButton" onClick={props.onCancel}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
 
         <EuiSmallButton
           data-test-subj="confirmButton"

--- a/public/pages/DetectorDetail/components/DetectorControls/DetectorControls.tsx
+++ b/public/pages/DetectorDetail/components/DetectorControls/DetectorControls.tsx
@@ -11,7 +11,7 @@
 
 import React, { useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFlexGroup,
@@ -36,14 +36,14 @@ export const DetectorControls = (props: DetectorControls) => {
         <EuiPopover
           id="actionsPopover"
           button={
-            <EuiButton
+            <EuiSmallButton
               iconType="arrowDown"
               iconSide="right"
               data-test-subj="actionsButton"
               onClick={() => setIsOpen(!isOpen)}
             >
               Actions
-            </EuiButton>
+            </EuiSmallButton>
           }
           panelPaddingSize="none"
           anchorPosition="downLeft"

--- a/public/pages/DetectorDetail/components/DetectorControls/__tests__/__snapshots__/DetectorControls.test.tsx.snap
+++ b/public/pages/DetectorDetail/components/DetectorControls/__tests__/__snapshots__/DetectorControls.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
           class="euiPopover__anchor"
         >
           <button
-            class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
             data-test-subj="actionsButton"
             type="button"
           >
@@ -67,7 +67,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
           class="euiPopover__anchor"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="actionsButton"
             type="button"
           >
@@ -119,7 +119,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
           class="euiPopover__anchor"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="actionsButton"
             type="button"
           >
@@ -171,7 +171,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
           class="euiPopover__anchor"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="actionsButton"
             type="button"
           >

--- a/public/pages/DetectorDetail/components/DetectorControls/__tests__/__snapshots__/DetectorControls.test.tsx.snap
+++ b/public/pages/DetectorDetail/components/DetectorControls/__tests__/__snapshots__/DetectorControls.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<DetectorControls /> spec Detector Controls renders detector controls w
           class="euiPopover__anchor"
         >
           <button
-          class="euiButton euiButton--primary euiButton--small"
+            class="euiButton euiButton--primary euiButton--small"
             data-test-subj="actionsButton"
             type="button"
           >

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -20,7 +20,7 @@ import {
   EuiCallOut,
   EuiSpacer,
   EuiText,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiLoadingSpinner,
   EuiSmallButton,
 } from '@elastic/eui';
@@ -538,7 +538,7 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
                   </EuiText>
                 </EuiFlexItem>
                 <EuiFlexItem grow={true}>
-                  <EuiFieldText
+                  <EuiCompressedFieldText
                     data-test-subj="typeDeleteField"
                     fullWidth={true}
                     placeholder="delete"

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -22,7 +22,7 @@ import {
   EuiText,
   EuiFieldText,
   EuiLoadingSpinner,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { CoreStart, MountPoint } from '../../../../../../src/core/public';
 import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';

--- a/public/pages/DetectorJobs/components/HistoricalJob/HistoricalJob.tsx
+++ b/public/pages/DetectorJobs/components/HistoricalJob/HistoricalJob.tsx
@@ -15,7 +15,7 @@ import {
   EuiIcon,
   EuiFlexItem,
   EuiFlexGroup,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiSuperDatePicker,
 } from '@elastic/eui';
 import { Field, FieldProps, FormikProps } from 'formik';
@@ -63,7 +63,7 @@ export function HistoricalJob(props: HistoricalJobProps) {
         {({ field, form }: FieldProps) => (
           <EuiFlexGroup direction="column">
             <EuiFlexItem>
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id={'historicalCheckbox'}
                 label="Run historical analysis detection"
                 checked={enabled}

--- a/public/pages/DetectorJobs/components/HistoricalJob/HistoricalJob.tsx
+++ b/public/pages/DetectorJobs/components/HistoricalJob/HistoricalJob.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiCompressedCheckbox,
-  EuiSuperDatePicker,
+  EuiCompressedSuperDatePicker,
 } from '@elastic/eui';
 import { Field, FieldProps, FormikProps } from 'formik';
 import { get } from 'lodash';
@@ -86,7 +86,7 @@ export function HistoricalJob(props: HistoricalJobProps) {
                   isInvalid={isInvalid(field.name, form)}
                   error={getError(field.name, form)}
                 >
-                  <EuiSuperDatePicker
+                  <EuiCompressedSuperDatePicker
                     //isLoading={props.isLoading}
                     start={convertTimestampToString(form.values.startTime)}
                     end={convertTimestampToString(form.values.endTime)}

--- a/public/pages/DetectorJobs/components/HistoricalJob/__tests__/__snapshots__/HistoricalJob.test.tsx.snap
+++ b/public/pages/DetectorJobs/components/HistoricalJob/__tests__/__snapshots__/HistoricalJob.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`<HistoricalJob /> spec renders the component 1`] = `
             class="euiFlexItem"
           >
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 class="euiCheckbox__input"

--- a/public/pages/DetectorJobs/components/RealTimeJob/RealTimeJob.tsx
+++ b/public/pages/DetectorJobs/components/RealTimeJob/RealTimeJob.tsx
@@ -14,7 +14,7 @@ import {
   EuiLink,
   EuiIcon,
   EuiFlexItem,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
 } from '@elastic/eui';
 import { Field, FieldProps, FormikProps } from 'formik';
 import { get } from 'lodash';
@@ -55,7 +55,7 @@ export function RealTimeJob(props: RealTimeJobProps) {
       <Field name="realTime" validate={() => {}}>
         {({ field, form }: FieldProps) => (
           <EuiFlexItem>
-            <EuiCheckbox
+            <EuiCompressedCheckbox
               id={'realTimeCheckbox'}
               label="Start real-time detector automatically (recommended)"
               checked={enabled}

--- a/public/pages/DetectorJobs/components/RealTimeJob/__tests__/__snapshots__/RealTimeJob.test.tsx.snap
+++ b/public/pages/DetectorJobs/components/RealTimeJob/__tests__/__snapshots__/RealTimeJob.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`<RealTimeJob /> spec renders the component 1`] = `
           class="euiFlexItem"
         >
           <div
-            class="euiCheckbox"
+            class="euiCheckbox euiCheckbox--compressed"
           >
             <input
               class="euiCheckbox__input"

--- a/public/pages/DetectorJobs/containers/DetectorJobs.tsx
+++ b/public/pages/DetectorJobs/containers/DetectorJobs.tsx
@@ -18,7 +18,7 @@ import {
   EuiPage,
   EuiSmallButton,
   EuiTitle,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSpacer,
 } from '@elastic/eui';
 import { FormikProps, Formik } from 'formik';
@@ -186,7 +186,7 @@ export function DetectorJobs(props: DetectorJobsProps) {
             style={{ marginRight: '12px' }}
           >
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
+              <EuiSmallButtonEmpty
                 onClick={() => {
                   props.history.push(
                     constructHrefWithDataSourceId(
@@ -198,7 +198,7 @@ export function DetectorJobs(props: DetectorJobsProps) {
                 }}
               >
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/DetectorJobs/containers/DetectorJobs.tsx
+++ b/public/pages/DetectorJobs/containers/DetectorJobs.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPage,
-  EuiButton,
+  EuiSmallButton,
   EuiTitle,
   EuiButtonEmpty,
   EuiSpacer,
@@ -201,7 +201,7 @@ export function DetectorJobs(props: DetectorJobsProps) {
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 iconSide="left"
                 iconType="arrowLeft"
                 fill={false}
@@ -219,10 +219,10 @@ export function DetectorJobs(props: DetectorJobsProps) {
                 }}
               >
                 Previous
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 type="submit"
                 iconSide="right"
                 iconType="arrowRight"
@@ -235,7 +235,7 @@ export function DetectorJobs(props: DetectorJobsProps) {
                 }}
               >
                 Next
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </Fragment>

--- a/public/pages/DetectorJobs/containers/__tests__/__snapshots__/DetectorJobs.test.tsx.snap
+++ b/public/pages/DetectorJobs/containers/__tests__/__snapshots__/DetectorJobs.test.tsx.snap
@@ -107,7 +107,7 @@ exports[`<DetectorJobs /> spec configuring detector jobs renders the component 1
             class="euiFlexItem"
           >
             <div
-              class="euiCheckbox"
+              class="euiCheckbox euiCheckbox--compressed"
             >
               <input
                 checked=""
@@ -220,7 +220,7 @@ exports[`<DetectorJobs /> spec configuring detector jobs renders the component 1
               class="euiFlexItem"
             >
               <div
-                class="euiCheckbox"
+                class="euiCheckbox euiCheckbox--compressed"
               >
                 <input
                   class="euiCheckbox__input"

--- a/public/pages/DetectorResults/components/DetectorState/DetectorFeatureRequired.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorFeatureRequired.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt } from '@elastic/eui';
 import { Fragment } from 'react';
 import { Detector } from '../../../../models/interfaces';
 
@@ -36,14 +36,14 @@ export const DetectorFeatureRequired = (
         </Fragment>
       }
       actions={[
-        <EuiButton
+        <EuiSmallButton
           color="primary"
           fill
           onClick={props.onSwitchToConfiguration}
           style={{ width: '250px' }}
         >
           View detector configuration
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     />
   );

--- a/public/pages/DetectorResults/components/DetectorState/DetectorStopped.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorStopped.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiEmptyPrompt } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt } from '@elastic/eui';
 import { Fragment } from 'react';
 
 export interface DetectorStoppedProps {
@@ -28,13 +28,13 @@ export const DetectorStopped = (props: DetectorStoppedProps) => {
         </Fragment>
       }
       actions={[
-        <EuiButton
+        <EuiSmallButton
           fill
           onClick={props.onStartDetector}
           style={{ width: '200px' }}
         >
           Start detector
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     />
   );

--- a/public/pages/DetectorResults/components/DetectorState/DetectorUnknownState.tsx
+++ b/public/pages/DetectorResults/components/DetectorState/DetectorUnknownState.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import { EuiButton, EuiEmptyPrompt, EuiIcon } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt, EuiIcon } from '@elastic/eui';
 import { Fragment } from 'react';
 import { DETECTOR_INIT_FAILURES } from '../../../DetectorDetail/utils/constants';
 
@@ -36,17 +36,17 @@ export const DetectorUnknownState = (props: DetectorUnknownStateProps) => {
         </Fragment>
       }
       actions={[
-        <EuiButton
+        <EuiSmallButton
           color="primary"
           fill
           onClick={props.onSwitchToConfiguration}
           style={{ width: '250px' }}
         >
           View detector configuration
-        </EuiButton>,
-        <EuiButton onClick={props.onStartDetector} style={{ width: '200px' }}>
+        </EuiSmallButton>,
+        <EuiSmallButton onClick={props.onStartDetector} style={{ width: '200px' }}>
           Restart detector
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     />
   );

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -16,7 +16,7 @@ import {
   EuiPageBody,
   EuiSpacer,
   EuiCallOut,
-  EuiButton,
+  EuiSmallButton,
   EuiProgress,
   EuiFlexGroup,
   EuiFlexItem,
@@ -504,7 +504,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                           <EuiSpacer size="l" />
                         </div>
                       ) : null}
-                      <EuiButton
+                      <EuiSmallButton
                         onClick={props.onSwitchToConfiguration}
                         color={
                           featureMissingSeverity ===
@@ -521,15 +521,15 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                         style={{ marginRight: '8px' }}
                       >
                         View detector configuration
-                      </EuiButton>
+                      </EuiSmallButton>
                       {isDetectorUpdated || isDetectorFailed ? (
-                        <EuiButton
+                        <EuiSmallButton
                           color={isDetectorFailed ? 'danger' : 'warning'}
                           onClick={props.onStartDetector}
                           style={{ marginLeft: '8px' }}
                         >
                           Restart detector
-                        </EuiButton>
+                        </EuiSmallButton>
                       ) : null}
                     </EuiCallOut>
                   ) : null}
@@ -558,7 +558,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                       </EuiFlexItem>
 
                       <EuiFlexItem grow={false}>
-                        <EuiButton
+                        <EuiSmallButton
                           data-test-subj="stopAndStartDetectorButton"
                           onClick={
                             detector?.enabled
@@ -570,7 +570,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
                           {detector?.enabled
                             ? 'Stop detector'
                             : 'Start detector'}
-                        </EuiButton>
+                        </EuiSmallButton>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                   ) : null}

--- a/public/pages/DetectorResults/containers/AnomalyResultsLiveChart.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResultsLiveChart.tsx
@@ -15,7 +15,7 @@ import {
   EuiFlexGroup,
   EuiText,
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiTitle,
   EuiCallOut,
   EuiStat,
@@ -213,14 +213,14 @@ export const AnomalyResultsLiveChart = (
   );
 
   const fullScreenButton = () => (
-    <EuiButton
+    <EuiSmallButton
       onClick={() => setIsFullScreen((isFullScreen) => !isFullScreen)}
       iconType={isFullScreen ? 'exit' : 'fullScreen'}
       aria-label="View full screen"
       data-test-subj="anomalyResultsFullScreenButton"
     >
       {isFullScreen ? 'Exit full screen' : 'View full screen'}
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const customAnomalyTooltip = (details?: string) => {

--- a/public/pages/DetectorsList/components/EmptyMessage/EmptyMessage.tsx
+++ b/public/pages/DetectorsList/components/EmptyMessage/EmptyMessage.tsx
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { EuiButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt, EuiText } from '@elastic/eui';
 import React from 'react';
 import { CreateDetectorButtons } from '../../../../components/CreateDetectorButtons/CreateDetectorButtons';
 
@@ -36,13 +36,13 @@ export const EmptyDetectorMessage = (props: EmptyDetectorProps) => (
     }
     actions={
       props.isFilterApplied ? (
-        <EuiButton
+        <EuiSmallButton
           fill
           onClick={props.onResetFilters}
           data-test-subj="resetListFilters"
         >
           Reset filters
-        </EuiButton>
+        </EuiSmallButton>
       ) : (
         <CreateDetectorButtons />
       )

--- a/public/pages/DetectorsList/components/EmptyMessage/__tests__/__snapshots__/EmptyMessage.test.tsx.snap
+++ b/public/pages/DetectorsList/components/EmptyMessage/__tests__/__snapshots__/EmptyMessage.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<EmptyDetectorMessage /> spec Empty results renders component with empt
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="sampleDetectorButton"
         href="anomaly-detection-dashboards#/overview?"
         rel="noreferrer"
@@ -52,7 +52,7 @@ exports[`<EmptyDetectorMessage /> spec Empty results renders component with empt
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <a
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="createDetectorButton"
         href="anomaly-detection-dashboards#/create-ad/?"
         rel="noreferrer"
@@ -98,7 +98,7 @@ exports[`<EmptyDetectorMessage /> spec Filters results message renders component
     class="euiSpacer euiSpacer--l"
   />
   <button
-    class="euiButton euiButton--primary euiButton--fill"
+    class="euiButton euiButton--primary euiButton--small euiButton--fill"
     data-test-subj="resetListFilters"
     type="button"
   >

--- a/public/pages/DetectorsList/components/ListActions/ListActions.tsx
+++ b/public/pages/DetectorsList/components/ListActions/ListActions.tsx
@@ -11,7 +11,7 @@
 
 import React, { useState } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiContextMenuItem,
   EuiContextMenuPanel,
   EuiFlexGroup,
@@ -36,7 +36,7 @@ export const ListActions = (props: ListActionsProps) => {
         <EuiPopover
           id="actionsPopover"
           button={
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="listActionsButton"
               disabled={props.isActionsDisabled}
               iconType="arrowDown"
@@ -44,7 +44,7 @@ export const ListActions = (props: ListActionsProps) => {
               onClick={() => setIsOpen(!isOpen)}
             >
               Actions
-            </EuiButton>
+            </EuiSmallButton>
           }
           panelPaddingSize="none"
           anchorPosition="downLeft"

--- a/public/pages/DetectorsList/components/ListActions/__tests__/__snapshots__/ListActions.test.tsx.snap
+++ b/public/pages/DetectorsList/components/ListActions/__tests__/__snapshots__/ListActions.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<ListActions /> spec List actions renders component when disabled 1`] =
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary euiButton-isDisabled"
+          class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
           data-test-subj="listActionsButton"
           disabled=""
           type="button"
@@ -67,7 +67,7 @@ exports[`<ListActions /> spec List actions renders component when enabled 1`] = 
         class="euiPopover__anchor"
       >
         <button
-          class="euiButton euiButton--primary"
+          class="euiButton euiButton--primary euiButton--small"
           data-test-subj="listActionsButton"
           type="button"
         >

--- a/public/pages/DetectorsList/components/ListFilters/ListFilters.tsx
+++ b/public/pages/DetectorsList/components/ListFilters/ListFilters.tsx
@@ -12,7 +12,7 @@
 import {
   EuiComboBox,
   EuiComboBoxOptionProps,
-  EuiFieldSearch,
+  EuiCompressedFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPagination,
@@ -37,7 +37,7 @@ interface ListFiltersProps {
 export const ListFilters = (props: ListFiltersProps) => (
   <EuiFlexGroup gutterSize="s">
     <EuiFlexItem grow={false} style={{ width: '40%' }}>
-      <EuiFieldSearch
+      <EuiCompressedFieldSearch
         fullWidth={true}
         value={props.search}
         placeholder="Search"

--- a/public/pages/DetectorsList/components/ListFilters/ListFilters.tsx
+++ b/public/pages/DetectorsList/components/ListFilters/ListFilters.tsx
@@ -10,7 +10,7 @@
  */
 
 import {
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionProps,
   EuiCompressedFieldSearch,
   EuiFlexGroup,
@@ -46,7 +46,7 @@ export const ListFilters = (props: ListFiltersProps) => (
       />
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiComboBox
+      <EuiCompressedComboBox
         id="selectedDetectorStates"
         data-test-subj="detectorStateFilter"
         placeholder="All detector states"
@@ -63,7 +63,7 @@ export const ListFilters = (props: ListFiltersProps) => (
       />
     </EuiFlexItem>
     <EuiFlexItem>
-      <EuiComboBox
+      <EuiCompressedComboBox
         id="selectedIndices"
         data-test-subj="indicesFilter"
         placeholder="All indices"

--- a/public/pages/DetectorsList/components/ListFilters/__tests__/__snapshots__/ListFilters.test.tsx.snap
+++ b/public/pages/DetectorsList/components/ListFilters/__tests__/__snapshots__/ListFilters.test.tsx.snap
@@ -9,13 +9,13 @@ exports[`<ListFilters /> spec Empty results renders component with empty message
     style="width: 40%;"
   >
     <div
-      class="euiFormControlLayout euiFormControlLayout--fullWidth"
+      class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
     >
       <div
         class="euiFormControlLayout__childrenWrapper"
       >
         <input
-          class="euiFieldSearch euiFieldSearch--fullWidth"
+          class="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch--compressed"
           data-test-subj="detectorListSearch"
           placeholder="Search"
           type="search"
@@ -29,7 +29,7 @@ exports[`<ListFilters /> spec Empty results renders component with empty message
           >
             <svg
               aria-hidden="true"
-              class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+              class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
               focusable="false"
               height="16"
               role="img"
@@ -52,18 +52,18 @@ exports[`<ListFilters /> spec Empty results renders component with empty message
     <div
       aria-expanded="false"
       aria-haspopup="listbox"
-      class="euiComboBox euiComboBox--fullWidth"
+      class="euiComboBox euiComboBox--compressed euiComboBox--fullWidth"
       data-test-subj="detectorStateFilter"
       role="combobox"
     >
       <div
-        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
+            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
             data-test-subj="comboBoxInput"
             tabindex="-1"
           >
@@ -100,7 +100,7 @@ exports[`<ListFilters /> spec Empty results renders component with empty message
             >
               <svg
                 aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                 focusable="false"
                 height="16"
                 role="img"
@@ -124,18 +124,18 @@ exports[`<ListFilters /> spec Empty results renders component with empty message
     <div
       aria-expanded="false"
       aria-haspopup="listbox"
-      class="euiComboBox euiComboBox--fullWidth"
+      class="euiComboBox euiComboBox--compressed euiComboBox--fullWidth"
       data-test-subj="indicesFilter"
       role="combobox"
     >
       <div
-        class="euiFormControlLayout euiFormControlLayout--fullWidth"
+        class="euiFormControlLayout euiFormControlLayout--fullWidth euiFormControlLayout--compressed"
       >
         <div
           class="euiFormControlLayout__childrenWrapper"
         >
           <div
-            class="euiComboBox__inputWrap euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
+            class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--fullWidth euiComboBox__inputWrap-isClearable"
             data-test-subj="comboBoxInput"
             tabindex="-1"
           >
@@ -172,7 +172,7 @@ exports[`<ListFilters /> spec Empty results renders component with empty message
             >
               <svg
                 aria-hidden="true"
-                class="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                class="euiIcon euiIcon--small euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                 focusable="false"
                 height="16"
                 role="img"

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -14,7 +14,7 @@ import {
   EuiOverlayMask,
   EuiCallOut,
   EuiText,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiFlexGroup,
@@ -126,7 +126,7 @@ export const ConfirmDeleteDetectorsModal = (
             </p>
           </EuiText>
           <EuiSpacer size="s" />
-          <EuiFieldText
+          <EuiCompressedFieldText
             data-test-subj="typeDeleteField"
             fullWidth={true}
             placeholder="delete"

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -16,7 +16,7 @@ import {
   EuiText,
   EuiFieldText,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiModal,
   EuiModalHeader,
@@ -141,12 +141,12 @@ export const ConfirmDeleteDetectorsModal = (
         </EuiFlexGroup>
         <EuiModalFooter>
           {isLoading ? null : (
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               data-test-subj="cancelButton"
               onClick={props.onHide}
             >
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           )}
           <EuiSmallButton
             data-test-subj="confirmButton"

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmDeleteDetectorsModal.tsx
@@ -15,7 +15,7 @@ import {
   EuiCallOut,
   EuiText,
   EuiFieldText,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiModal,
@@ -148,7 +148,7 @@ export const ConfirmDeleteDetectorsModal = (
               Cancel
             </EuiButtonEmpty>
           )}
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="confirmButton"
             color="danger"
             disabled={!deleteTyped}
@@ -172,7 +172,7 @@ export const ConfirmDeleteDetectorsModal = (
             }}
           >
             {'Delete detectors'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
@@ -14,7 +14,7 @@ import {
   EuiText,
   EuiOverlayMask,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalHeader,
   EuiModalFooter,
@@ -60,12 +60,12 @@ export const ConfirmStartDetectorsModal = (
         </EuiModalBody>
         <EuiModalFooter>
           {isLoading ? null : (
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               data-test-subj="cancelButton"
               onClick={props.onHide}
             >
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           )}
           <EuiSmallButton
             data-test-subj="confirmButton"

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStartDetectorsModal.tsx
@@ -13,7 +13,7 @@ import React, { useState } from 'react';
 import {
   EuiText,
   EuiOverlayMask,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalHeader,
@@ -67,7 +67,7 @@ export const ConfirmStartDetectorsModal = (
               Cancel
             </EuiButtonEmpty>
           )}
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="confirmButton"
             color="primary"
             fill
@@ -79,7 +79,7 @@ export const ConfirmStartDetectorsModal = (
             }}
           >
             {'Start detectors'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
@@ -14,7 +14,7 @@ import {
   EuiText,
   EuiOverlayMask,
   EuiCallOut,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalHeader,
@@ -90,7 +90,7 @@ export const ConfirmStopDetectorsModal = (
               Cancel
             </EuiButtonEmpty>
           )}
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="confirmButton"
             color="primary"
             fill
@@ -102,7 +102,7 @@ export const ConfirmStopDetectorsModal = (
             }}
           >
             {'Stop detectors'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
+++ b/public/pages/DetectorsList/containers/ConfirmActionModals/ConfirmStopDetectorsModal.tsx
@@ -15,7 +15,7 @@ import {
   EuiOverlayMask,
   EuiCallOut,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalHeader,
   EuiModalFooter,
@@ -83,12 +83,12 @@ export const ConfirmStopDetectorsModal = (
         </EuiModalBody>
         <EuiModalFooter>
           {isLoading ? null : (
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               data-test-subj="cancelButton"
               onClick={props.onHide}
             >
               Cancel
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           )}
           <EuiSmallButton
             data-test-subj="confirmButton"

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -12,7 +12,7 @@
 import {
   //@ts-ignore
   EuiBasicTable,
-  EuiButton,
+  EuiSmallButton,
   EuiComboBoxOptionProps,
   EuiPage,
   EuiPageBody,
@@ -207,8 +207,8 @@ export const DetectorList = (props: ListProps) => {
     selectedIndices: queryParams.indices
       ? queryParams.indices.split(',')
       : ALL_INDICES,
-    selectedDataSourceId: queryParams.dataSourceId === undefined 
-      ? undefined 
+    selectedDataSourceId: queryParams.dataSourceId === undefined
+      ? undefined
       : queryParams.dataSourceId,
   });
 
@@ -246,7 +246,7 @@ export const DetectorList = (props: ListProps) => {
       indices: state.selectedIndices.join(','),
       sortDirection: state.queryParams.sortDirection,
       sortField: state.queryParams.sortField,
-    } as GetDetectorsQueryParams; 
+    } as GetDetectorsQueryParams;
 
     if (dataSourceEnabled) {
       updatedParams = {
@@ -699,7 +699,7 @@ export const DetectorList = (props: ListProps) => {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: state.selectedDataSourceId !== undefined 
+            activeOption: state.selectedDataSourceId !== undefined
               ? [{ id: state.selectedDataSourceId }]
               : undefined,
             savedObjects: getSavedObjectsClient(),
@@ -737,13 +737,13 @@ export const DetectorList = (props: ListProps) => {
               isStartDisabled={listActionsState.isStartDisabled}
               isStopDisabled={listActionsState.isStopDisabled}
             />,
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="createDetectorButton"
               fill
               href={createDetectorUrl}
             >
               Create detector
-            </EuiButton>,
+            </EuiSmallButton>,
           ]}
         >
           {confirmModal}

--- a/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/EmptyHistoricalDetectorResults.tsx
+++ b/public/pages/HistoricalDetectorResults/components/EmptyHistoricalDetectorResults/EmptyHistoricalDetectorResults.tsx
@@ -13,7 +13,7 @@ import {
   EuiEmptyPrompt,
   EuiLink,
   EuiIcon,
-  EuiButton,
+  EuiSmallButton,
   EuiOverlayMask,
 } from '@elastic/eui';
 import React, { Fragment, useState } from 'react';
@@ -61,7 +61,7 @@ export const EmptyHistoricalDetectorResults = (
         </Fragment>
       }
       actions={
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="runHistoricalAnalysisButton"
           fill={true}
           onClick={() => {
@@ -69,7 +69,7 @@ export const EmptyHistoricalDetectorResults = (
           }}
         >
           Run historical analysis
-        </EuiButton>
+        </EuiSmallButton>
       }
     />
   );

--- a/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalDetectorCallout/HistoricalDetectorCallout.tsx
@@ -16,7 +16,7 @@ import {
   EuiText,
   EuiFlexItem,
   EuiProgress,
-  EuiButton,
+  EuiSmallButton,
   EuiSpacer,
 } from '@elastic/eui';
 import React from 'react';
@@ -121,9 +121,9 @@ export const HistoricalDetectorCallout = (
               ) : null}
               <EuiSpacer size="s" />
               <EuiFlexItem grow={false} style={{ marginLeft: '22px' }}>
-                <EuiButton fill={false} onClick={() => props.onStopDetector()}>
+                <EuiSmallButton fill={false} onClick={() => props.onStopDetector()}>
                   Stop historical analysis
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </div>
           }

--- a/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
@@ -17,7 +17,7 @@ import {
   EuiModalHeaderTitle,
   EuiModalBody,
   EuiButtonEmpty,
-  EuiButton,
+  EuiSmallButton,
   EuiSuperDatePicker,
 } from '@elastic/eui';
 import { get } from 'lodash';
@@ -77,7 +77,7 @@ export const HistoricalRangeModal = (props: HistoricalRangeModalProps) => {
           Cancel
         </EuiButtonEmpty>
 
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="confirmButton"
           fill
           onClick={() => {
@@ -89,7 +89,7 @@ export const HistoricalRangeModal = (props: HistoricalRangeModalProps) => {
           }}
         >
           Run historical analysis
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
@@ -16,7 +16,7 @@ import {
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiModalBody,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSmallButton,
   EuiSuperDatePicker,
 } from '@elastic/eui';
@@ -73,9 +73,9 @@ export const HistoricalRangeModal = (props: HistoricalRangeModalProps) => {
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="cancelButton" onClick={props.onClose}>
+        <EuiSmallButtonEmpty data-test-subj="cancelButton" onClick={props.onClose}>
           Cancel
-        </EuiButtonEmpty>
+        </EuiSmallButtonEmpty>
 
         <EuiSmallButton
           data-test-subj="confirmButton"

--- a/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
+++ b/public/pages/HistoricalDetectorResults/components/HistoricalRangeModal/HistoricalRangeModal.tsx
@@ -18,7 +18,7 @@ import {
   EuiModalBody,
   EuiSmallButtonEmpty,
   EuiSmallButton,
-  EuiSuperDatePicker,
+  EuiCompressedSuperDatePicker,
 } from '@elastic/eui';
 import { get } from 'lodash';
 import { Detector } from '../../../../models/interfaces';
@@ -58,7 +58,7 @@ export const HistoricalRangeModal = (props: HistoricalRangeModalProps) => {
       </EuiModalHeader>
       <EuiModalBody>
         <FormattedFormRow title="Select a date range">
-          <EuiSuperDatePicker
+          <EuiCompressedSuperDatePicker
             isPaused={true}
             showUpdateButton={false}
             commonlyUsedRanges={HISTORICAL_DATE_RANGE_COMMON_OPTIONS}

--- a/public/pages/HistoricalDetectorResults/components/__tests__/__snapshots__/EmptyHistoricalDetectorResults.test.tsx.snap
+++ b/public/pages/HistoricalDetectorResults/components/__tests__/__snapshots__/EmptyHistoricalDetectorResults.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`<EmptyHistoricalDetectorResults /> spec renders component 1`] = `
     class="euiSpacer euiSpacer--l"
   />
   <button
-    class="euiButton euiButton--primary euiButton--fill"
+    class="euiButton euiButton--primary euiButton--small euiButton--fill"
     data-test-subj="runHistoricalAnalysisButton"
     type="button"
   >

--- a/public/pages/Overview/components/SampleDataBox/SampleDataBox.tsx
+++ b/public/pages/Overview/components/SampleDataBox/SampleDataBox.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { get } from 'lodash';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiTitle,
@@ -96,7 +96,7 @@ export const SampleDataBox = (props: SampleDataBoxProps) => {
             alignItems="center"
           >
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 style={{ width: '300px' }}
                 data-test-subj={get(
                   props,
@@ -114,7 +114,7 @@ export const SampleDataBox = (props: SampleDataBoxProps) => {
                   : props.isDataLoaded
                   ? 'Detector created'
                   : props.loadDataButtonDescription}
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               {props.isDataLoaded ? (

--- a/public/pages/Overview/components/SampleDataBox/__tests__/__snapshots__/SampleDataBox.test.tsx.snap
+++ b/public/pages/Overview/components/SampleDataBox/__tests__/__snapshots__/SampleDataBox.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`<SampleDataBox /> spec Data is loaded renders component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton-isDisabled"
+                class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                 data-test-subj="loadDataButton"
                 disabled=""
                 style="width: 300px;"
@@ -198,7 +198,7 @@ exports[`<SampleDataBox /> spec Data is loading renders component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary euiButton-isDisabled"
+                class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                 data-test-subj="loadDataButton"
                 disabled=""
                 style="width: 300px;"
@@ -303,7 +303,7 @@ exports[`<SampleDataBox /> spec Data not loaded renders component 1`] = `
               class="euiFlexItem euiFlexItem--flexGrowZero"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="loadDataButton"
                 style="width: 300px;"
                 type="button"

--- a/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
+++ b/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
@@ -17,7 +17,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiLink,
-  EuiButton,
+  EuiSmallButton,
   EuiLoadingSpinner,
   EuiFlexGrid,
 } from '@elastic/eui';
@@ -104,8 +104,8 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
   const queryParams = getDataSourceFromURL(props.location);
   const [MDSOverviewState, setMDSOverviewState] = useState<MDSStates>({
     queryParams,
-    selectedDataSourceId: queryParams.dataSourceId === undefined 
-      ? undefined 
+    selectedDataSourceId: queryParams.dataSourceId === undefined
+      ? undefined
       : queryParams.dataSourceId,
   });
 
@@ -130,7 +130,7 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
         ...location,
         search: queryString.stringify(updatedParams),
       });
-    } 
+    }
     fetchData();
   }, [MDSOverviewState]);
 
@@ -250,7 +250,7 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
           componentType={'DataSourceSelectable'}
           componentConfig={{
             fullWidth: false,
-            activeOption: props.landingDataSourceId === undefined 
+            activeOption: props.landingDataSourceId === undefined
               || MDSOverviewState.selectedDataSourceId === undefined
                 ? undefined
                 : [{ id: MDSOverviewState.selectedDataSourceId }],
@@ -286,13 +286,13 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
             </EuiTitle>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               fill
               href={createDetectorUrl}
               data-test-subj="add_detector"
             >
               Create detector
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageHeader>

--- a/public/pages/Overview/containers/__tests__/__snapshots__/AnomalyDetectionOverview.test.tsx.snap
+++ b/public/pages/Overview/containers/__tests__/__snapshots__/AnomalyDetectionOverview.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <a
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="add_detector"
           href="anomaly-detection-dashboards#/create-ad/"
           rel="noreferrer"
@@ -520,7 +520,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createHttpSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -622,7 +622,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createECommerceSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -724,7 +724,7 @@ exports[`<AnomalyDetectionOverview /> spec No sample detectors created renders c
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createHostHealthSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -782,7 +782,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <a
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="add_detector"
           href="anomaly-detection-dashboards#/create-ad/"
           rel="noreferrer"
@@ -1275,7 +1275,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createHttpSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -1377,7 +1377,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createECommerceSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -1479,7 +1479,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createHostHealthSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -1537,7 +1537,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
         class="euiFlexItem euiFlexItem--flexGrowZero"
       >
         <a
-          class="euiButton euiButton--primary euiButton--fill"
+          class="euiButton euiButton--primary euiButton--small euiButton--fill"
           data-test-subj="add_detector"
           href="anomaly-detection-dashboards#/create-ad/"
           rel="noreferrer"
@@ -2030,7 +2030,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary euiButton-isDisabled"
+                            class="euiButton euiButton--primary euiButton--small euiButton-isDisabled"
                             data-test-subj="createHttpSampleDetectorButton"
                             disabled=""
                             style="width: 300px;"
@@ -2153,7 +2153,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createECommerceSampleDetectorButton"
                             style="width: 300px;"
                             type="button"
@@ -2255,7 +2255,7 @@ exports[`<AnomalyDetectionOverview /> spec Some detectors created renders compon
                           class="euiFlexItem euiFlexItem--flexGrowZero"
                         >
                           <button
-                            class="euiButton euiButton--primary"
+                            class="euiButton euiButton--primary euiButton--small"
                             data-test-subj="createHostHealthSampleDetectorButton"
                             style="width: 300px;"
                             type="button"

--- a/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
+++ b/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
@@ -13,7 +13,7 @@ import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import {
   EuiFlexGrid,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiCallOut,
   EuiLoadingSpinner,
   EuiFlexGroup,
@@ -147,12 +147,12 @@ export const DetectorDefinitionFields = (
       titleSize="s"
       panelStyles={{ margin: '0px' }}
       actions={[
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="editDetectorSettingsButton"
           onClick={props.onEditDetectorDefinition}
         >
           Edit
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     >
       {props.isCreate ? getValidationCallout() : null}

--- a/public/pages/ReviewAndCreate/components/DetectorScheduleFields/DetectorScheduleFields.tsx
+++ b/public/pages/ReviewAndCreate/components/DetectorScheduleFields/DetectorScheduleFields.tsx
@@ -10,7 +10,7 @@
  */
 
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
-import { EuiFlexGrid, EuiFlexItem, EuiButton, EuiText } from '@elastic/eui';
+import { EuiFlexGrid, EuiFlexItem, EuiSmallButton, EuiText } from '@elastic/eui';
 import React from 'react';
 import moment from 'moment';
 import { get } from 'lodash';
@@ -45,12 +45,12 @@ export const DetectorScheduleFields = (props: DetectorScheduleFieldsProps) => {
       titleSize="s"
       panelStyles={{ margin: '0px' }}
       actions={[
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="editScheduleButton"
           onClick={props.onEditDetectorSchedule}
         >
           Edit
-        </EuiButton>,
+        </EuiSmallButton>,
       ]}
     >
       <EuiFlexGrid columns={4} gutterSize="l" style={{ border: 'none' }}>

--- a/public/pages/ReviewAndCreate/components/ModelConfigurationFields/ModelConfigurationFields.tsx
+++ b/public/pages/ReviewAndCreate/components/ModelConfigurationFields/ModelConfigurationFields.tsx
@@ -13,7 +13,7 @@ import React, { useState } from 'react';
 import {
   EuiBasicTable,
   EuiLink,
-  EuiButton,
+  EuiSmallButton,
   EuiSpacer,
   EuiCallOut,
   EuiLoadingSpinner,
@@ -282,7 +282,7 @@ export const ModelConfigurationFields = (
             size="s"
             style={{ marginBottom: '10px' }}
           >
-            {/* Callout can either display feature subissue which related to a specific 
+            {/* Callout can either display feature subissue which related to a specific
             feature issue or display a feature_attribute issue that is general like
             more then x anomaly feature or dulicate feature names */}
             {props.validationFeatureResponse.hasOwnProperty('sub_issues') ? (
@@ -307,7 +307,7 @@ export const ModelConfigurationFields = (
       title="Model configuration"
       titleSize="s"
       actions={[
-        <EuiButton onClick={props.onEditModelConfiguration}>Edit</EuiButton>,
+        <EuiSmallButton onClick={props.onEditModelConfiguration}>Edit</EuiSmallButton>,
       ]}
     >
       {getValidationCallout()}

--- a/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/DetectorDefinitionFields.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/DetectorDefinitionFields.test.tsx.snap
@@ -380,7 +380,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -934,7 +934,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >

--- a/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/DetectorDefinitionFields.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/DetectorDefinitionFields.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               data-test-subj="editDetectorSettingsButton"
               type="button"
             >
@@ -74,7 +74,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             data-test-subj="detectorNameCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -109,7 +109,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             data-test-subj="indexNameCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -143,7 +143,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -174,7 +174,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -209,7 +209,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             data-test-subj="detectorDescriptionCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -244,7 +244,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             data-test-subj="timestampNameCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -278,7 +278,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -312,7 +312,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -346,7 +346,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -414,7 +414,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -448,7 +448,7 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -523,7 +523,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <button
-              class="euiButton euiButton--primary"
+              class="euiButton euiButton--primary euiButton--small"
               data-test-subj="editDetectorSettingsButton"
               type="button"
             >
@@ -559,7 +559,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             data-test-subj="detectorNameCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -594,7 +594,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             data-test-subj="indexNameCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -628,7 +628,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -659,7 +659,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -694,7 +694,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             data-test-subj="detectorIdCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -729,7 +729,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             data-test-subj="detectorDescriptionCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -764,7 +764,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             data-test-subj="timestampNameCell"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -798,7 +798,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -832,7 +832,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -866,7 +866,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -900,7 +900,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -968,7 +968,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >
@@ -1002,7 +1002,7 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
             class="euiFlexItem"
           >
             <div
-              class="euiFormRow"
+              class="euiFormRow euiFormRow--compressed"
               id="random_html_id-row"
               style="width: 250px;"
             >

--- a/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/ModelConfigurationFields.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/ModelConfigurationFields.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`ModelConfigurationFields renders the component in create mode (no ID) 1
           class="euiFlexItem"
         >
           <button
-            class="euiButton euiButton--primary"
+            class="euiButton euiButton--primary euiButton--small"
             type="button"
           >
             <span

--- a/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -16,7 +16,7 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPage,
-  EuiButton,
+  EuiSmallButton,
   EuiTitle,
   EuiButtonEmpty,
   EuiSpacer,
@@ -387,7 +387,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 iconSide="left"
                 iconType="arrowLeft"
                 fill={false}
@@ -397,10 +397,10 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
                 }}
               >
                 Previous
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 type="submit"
                 fill={true}
                 data-test-subj="createDetectorButton"
@@ -409,7 +409,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
                 onClick={formikProps.handleSubmit}
               >
                 Create detector
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
         </Fragment>

--- a/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -18,7 +18,7 @@ import {
   EuiPage,
   EuiSmallButton,
   EuiTitle,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSpacer,
 } from '@elastic/eui';
 import {
@@ -372,7 +372,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
             style={{ marginRight: '12px' }}
           >
             <EuiFlexItem grow={false}>
-              <EuiButtonEmpty
+              <EuiSmallButtonEmpty
                 onClick={() => {
                   props.history.push(
                     constructHrefWithDataSourceId(
@@ -384,7 +384,7 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
                 }}
               >
                 Cancel
-              </EuiButtonEmpty>
+              </EuiSmallButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiSmallButton

--- a/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="editDetectorSettingsButton"
                 type="button"
               >
@@ -124,7 +124,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               data-test-subj="detectorNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -157,7 +157,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               data-test-subj="indexNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -189,7 +189,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -232,7 +232,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -267,7 +267,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               data-test-subj="detectorDescriptionCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -300,7 +300,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               data-test-subj="timestampNameCell"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -332,7 +332,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -366,7 +366,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -400,7 +400,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -468,7 +468,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -502,7 +502,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -575,7 +575,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 type="button"
               >
                 <span
@@ -1021,7 +1021,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <button
-                class="euiButton euiButton--primary"
+                class="euiButton euiButton--primary euiButton--small"
                 data-test-subj="editScheduleButton"
                 type="button"
               >
@@ -1056,7 +1056,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1090,7 +1090,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1187,7 +1187,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="editDetectorSettingsButton"
                   type="button"
                 >
@@ -1252,7 +1252,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 data-test-subj="detectorNameCell"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1285,7 +1285,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 data-test-subj="indexNameCell"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1317,7 +1317,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1360,7 +1360,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1395,7 +1395,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 data-test-subj="detectorDescriptionCell"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1428,7 +1428,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 data-test-subj="timestampNameCell"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1460,7 +1460,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1494,7 +1494,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1528,7 +1528,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1596,7 +1596,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1630,7 +1630,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -1703,7 +1703,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   type="button"
                 >
                   <span
@@ -2162,7 +2162,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <button
-                  class="euiButton euiButton--primary"
+                  class="euiButton euiButton--primary euiButton--small"
                   data-test-subj="editScheduleButton"
                   type="button"
                 >
@@ -2197,7 +2197,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -2231,7 +2231,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >
@@ -2275,7 +2275,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButtonEmpty euiButtonEmpty--primary"
+        class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--small"
         type="button"
       >
         <span
@@ -2293,7 +2293,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary"
+        class="euiButton euiButton--primary euiButton--small"
         data-test-subj="reviewAndCreatePreviousButton"
         type="button"
       >
@@ -2327,7 +2327,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
       class="euiFlexItem euiFlexItem--flexGrowZero"
     >
       <button
-        class="euiButton euiButton--primary euiButton--fill"
+        class="euiButton euiButton--primary euiButton--small euiButton--fill"
         data-test-subj="createDetectorButton"
         type="submit"
       >

--- a/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
@@ -434,7 +434,7 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
               class="euiFlexItem"
             >
               <div
-                class="euiFormRow"
+                class="euiFormRow euiFormRow--compressed"
                 id="random_html_id-row"
                 style="width: 250px;"
               >
@@ -1562,7 +1562,7 @@ exports[`issue in detector validation issues in feature query 1`] = `
                 class="euiFlexItem"
               >
                 <div
-                  class="euiFormRow"
+                  class="euiFormRow euiFormRow--compressed"
                   id="random_html_id-row"
                   style="width: 250px;"
                 >


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.


### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
