### PR TITLE
fix an issue that causes dataSourceId to not show in the URL on Overview landing page

### DIFF
--- a/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
+++ b/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
@@ -121,7 +121,7 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
   // Getting all initial sample detectors & indices
   useEffect(() => {
     const { history, location } = props;
-    if (dataSourceEnabled && props.landingDataSourceId !== undefined) {
+    if (dataSourceEnabled) {
       const updatedParams = {
         dataSourceId: MDSOverviewState.selectedDataSourceId,
       };


### PR DESCRIPTION
### Description

fix an issue that causes dataSourceId to not show in the URL on Overview landing page

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
