### PR TITLE
Remove dataSourceFilter that breaks DataSourceView

### DIFF
--- a/public/pages/ConfigureModel/containers/ConfigureModel.tsx
+++ b/public/pages/ConfigureModel/containers/ConfigureModel.tsx
@@ -61,7 +61,6 @@ import { getErrorMessage } from '../../../utils/utils';
 import {
   constructHrefWithDataSourceId,
   getDataSourceFromURL,
-  isDataSourceCompatible,
 } from '../../../pages/utils/helpers';
 import {
   getDataSourceManagementPlugin,
@@ -271,7 +270,6 @@ export function ConfigureModel(props: ConfigureModelProps) {
           fullWidth: false,
           savedObjects: getSavedObjectsClient(),
           notifications: getNotifications(),
-          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     );

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -310,7 +310,6 @@ export const DefineDetector = (props: DefineDetectorProps) => {
           fullWidth: false,
           savedObjects: getSavedObjectsClient(),
           notifications: getNotifications(),
-          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     );

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -71,7 +71,7 @@ import {
   getNotifications,
   getSavedObjectsClient,
 } from '../../../services';
-import { constructHrefWithDataSourceId, getDataSourceFromURL, isDataSourceCompatible } from '../../../pages/utils/helpers';
+import { constructHrefWithDataSourceId, getDataSourceFromURL } from '../../../pages/utils/helpers';
 
 export interface DetectorRouterProps {
   detectorId?: string;
@@ -430,7 +430,6 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
           fullWidth: false,
           savedObjects: getSavedObjectsClient(),
           notifications: getNotifications(),
-          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     );

--- a/public/pages/DetectorJobs/containers/DetectorJobs.tsx
+++ b/public/pages/DetectorJobs/containers/DetectorJobs.tsx
@@ -36,7 +36,6 @@ import { RouteComponentProps, useLocation } from 'react-router-dom';
 import {
   constructHrefWithDataSourceId,
   getDataSourceFromURL,
-  isDataSourceCompatible,
 } from '../../../pages/utils/helpers';
 import {
   getDataSourceManagementPlugin,
@@ -141,7 +140,6 @@ export function DetectorJobs(props: DetectorJobsProps) {
           fullWidth: false,
           savedObjects: getSavedObjectsClient(),
           notifications: getNotifications(),
-          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     );

--- a/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
+++ b/public/pages/ReviewAndCreate/containers/ReviewAndCreate.tsx
@@ -56,7 +56,6 @@ import {
 import {
   constructHrefWithDataSourceId,
   getDataSourceFromURL,
-  isDataSourceCompatible,
 } from '../../../pages/utils/helpers';
 import {
   getDataSourceManagementPlugin,
@@ -311,7 +310,6 @@ export function ReviewAndCreate(props: ReviewAndCreateProps) {
           fullWidth: false,
           savedObjects: getSavedObjectsClient(),
           notifications: getNotifications(),
-          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     );


### PR DESCRIPTION
### Description
DataSourceView is broken on future playground and TrineoApp, however, no console/network errors shown and can't reproduce it locally. 

Pull 2.16 and 2.15 docker image and tested with them. Found that it only breaks under 2.16 docker. The only change between 2.15 and 2.16 is adding this dataSourceFilter for version decoupling work. Suspecting it is because the dataSourceFilter filtered out the version so DataSourceView is giving error says "cannot find data source". Since the scenario where AD uses DataSourceView doesn't require data source filtering, I'm removing the dataSourceFilter check for all DataSourceView usage in AD. 

As it cannot be reproduced locally, confirmed the fix with deploying the docker image. 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
