### PR TITLE
Revert "Add Enable Flattened custom result index checkbox (#830) (#833)"

### DIFF
--- a/public/models/interfaces.ts
+++ b/public/models/interfaces.ts
@@ -194,7 +194,6 @@ export type Detector = {
   resultIndexMinAge?: number;
   resultIndexMinSize?: number;
   resultIndexTtl?: number;
-  flattenCustomResultIndex?: boolean;
   filterQuery: { [key: string]: any };
   featureAttributes: FeatureAttributes[];
   windowDelay: { period: Schedule };

--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -66,16 +66,6 @@ function CustomResultIndex(props: CustomResultIndexProps) {
     }
   },[customResultIndexConditionsEnabled])
 
-  const hintTextStyle = {
-    color: '#69707d',
-    fontSize: '12px',
-    lineHeight: '16px',
-    fontWeight: 'normal',
-    fontFamily: 'Helvetica, sans-serif',
-    textAlign: 'left',
-    width: '400px',
-};
-
   return (
     <ContentPanel
       title={
@@ -146,48 +136,25 @@ function CustomResultIndex(props: CustomResultIndexProps) {
                 </EuiCompressedFormRow>
               </EuiFlexItem>
             ) : null}
+
+            {enabled ? (
+              <EuiFlexItem>
+                <EuiCheckbox
+                  id={'resultIndexConditionCheckbox'}
+                  label="Enable custom result index lifecycle management"
+                  checked={customResultIndexConditionsEnabled}
+                  onChange={() => {
+                    setCustomResultIndexConditionsEnabled(!customResultIndexConditionsEnabled);
+                  }}
+                />
+              </EuiFlexItem>
+            ) : null}
           </EuiFlexGroup>
         )}
       </Field>
 
-      <EuiFlexGroup direction="column">
-        <EuiFlexItem>
-          { enabled ? (
-            <Field
-              name="flattenCustomResultIndex">
-            {({ field, form }: FieldProps) => (
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <EuiCompressedCheckbox
-                    id={'flattenCustomResultIndex'}
-                    label="Enable flattened custom result index"
-                    checked={field.value ? field.value : get(props.formikProps, 'values.flattenCustomResultIndex')}
-                    {...field}
-                  />
-                  <p style={hintTextStyle}>Flattening the custom result index will make it easier to query them on the dashboard. It also allows you to perform term aggregations on categorical fields.</p>
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            )}
-          </Field>) : null}
-        </EuiFlexItem>
-        <EuiFlexItem>
-          {enabled ? (
-            <EuiFlexItem>
-              <EuiCompressedCheckbox
-                id={'resultIndexConditionCheckbox'}
-                label="Enable custom result index lifecycle management"
-                checked={customResultIndexConditionsEnabled}
-                onChange={() => {
-                  setCustomResultIndexConditionsEnabled(!customResultIndexConditionsEnabled);
-                }}
-              />
-            </EuiFlexItem>
-          ) : null}
-        </EuiFlexItem>
-      </EuiFlexGroup>
-
-      { (enabled && customResultIndexConditionsEnabled) ? (<Field
-        name="resultIndexMinAge"
+      { (enabled && customResultIndexConditionsEnabled) ? (<Field 
+        name="resultIndexMinAge" 
         validate={(enabled && customResultIndexConditionsEnabled) ? validateEmptyOrPositiveInteger : null}
         >
         {({ field, form }: FieldProps) => (

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -229,7 +229,6 @@ export const DefineDetector = (props: DefineDetectorProps) => {
       formikProps.setFieldTouched('resultIndexMinAge');
       formikProps.setFieldTouched('resultIndexMinSize');
       formikProps.setFieldTouched('resultIndexTtl');
-      formikProps.setFieldTouched('flattenCustomResultIndex');
       formikProps.validateForm().then((errors) => {
         if (isEmpty(errors)) {
           if (props.isEdit) {

--- a/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
+++ b/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
@@ -974,16 +974,6 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               </div>
             </div>
           </div>
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            />
-            <div
-              class="euiFlexItem"
-            />
-          </div>
         </div>
       </div>
     </div>
@@ -1962,16 +1952,6 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
                 </label>
               </div>
             </div>
-          </div>
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            />
-            <div
-              class="euiFlexItem"
-            />
           </div>
         </div>
       </div>
@@ -2984,16 +2964,6 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
                 </label>
               </div>
             </div>
-          </div>
-          <div
-            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
-          >
-            <div
-              class="euiFlexItem"
-            />
-            <div
-              class="euiFlexItem"
-            />
           </div>
         </div>
       </div>

--- a/public/pages/DefineDetector/models/interfaces.ts
+++ b/public/pages/DefineDetector/models/interfaces.ts
@@ -25,5 +25,4 @@ export interface DetectorDefinitionFormikValues {
   resultIndexMinAge?: number | string;
   resultIndexMinSize?: number | string;
   resultIndexTtl?:number | string;
-  flattenCustomResultIndex?: boolean;
 }

--- a/public/pages/DefineDetector/utils/__tests__/helpers.test.tsx
+++ b/public/pages/DefineDetector/utils/__tests__/helpers.test.tsx
@@ -44,7 +44,6 @@ describe('detectorDefinitionToFormik', () => {
       resultIndexMinAge: randomDetector.resultIndexMinAge,
       resultIndexMinSize: randomDetector.resultIndexMinSize,
       resultIndexTtl: randomDetector.resultIndexTtl,
-      flattenCustomResultIndex: randomDetector.flattenCustomResultIndex,
     });
   });
   test('should return if detector does not have metadata', () => {
@@ -65,7 +64,6 @@ describe('detectorDefinitionToFormik', () => {
       resultIndexMinAge: randomDetector.resultIndexMinAge,
       resultIndexMinSize: randomDetector.resultIndexMinSize,
       resultIndexTtl: randomDetector.resultIndexTtl,
-      flattenCustomResultIndex: randomDetector.flattenCustomResultIndex,
     });
   });
   test("upgrade old detector's filters to include filter type", () => {

--- a/public/pages/DefineDetector/utils/constants.tsx
+++ b/public/pages/DefineDetector/utils/constants.tsx
@@ -46,6 +46,5 @@ export const INITIAL_DETECTOR_DEFINITION_VALUES: DetectorDefinitionFormikValues 
     resultIndex: undefined,
     resultIndexMinAge: 7,
     resultIndexMinSize: 51200,
-    resultIndexTtl: 60,
-    flattenCustomResultIndex: false,
+    resultIndexTtl: 60
   };

--- a/public/pages/DefineDetector/utils/helpers.ts
+++ b/public/pages/DefineDetector/utils/helpers.ts
@@ -48,7 +48,6 @@ export function detectorDefinitionToFormik(
     resultIndexMinAge: get(ad, 'resultIndexMinAge', undefined),
     resultIndexMinSize:get(ad, 'resultIndexMinSize', undefined),
     resultIndexTtl: get(ad, 'resultIndexTtl', undefined),
-    flattenCustomResultIndex: get(ad, 'flattenCustomResultIndex', false),
   };
 }
 
@@ -126,7 +125,6 @@ export function formikToDetectorDefinition(
     resultIndexMinAge: values.resultIndexMinAge,
     resultIndexMinSize: values.resultIndexMinSize,
     resultIndexTtl: values.resultIndexTtl,
-    flattenCustomResultIndex: values.flattenCustomResultIndex,
   } as Detector;
 
   return detectorBody;

--- a/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
+++ b/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
@@ -447,40 +447,6 @@ exports[`<DetectorConfig /> spec renders rules 1`] = `
                     class="euiFormLabel euiFormRow__label"
                     for="random_html_id"
                   >
-                    Flatten custom result index
-                  </label>
-                </div>
-                <div
-                  class="euiFormRow__fieldWrapper"
-                >
-                  <div
-                    class="euiText euiText--medium"
-                    id="random_html_id"
-                  >
-                    <p
-                      class="enabled"
-                    >
-                      -
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiFormRow euiFormRow--compressed"
-                id="random_html_id-row"
-                style="width: 250px;"
-              >
-                <div
-                  class="euiFormRow__labelWrapper"
-                >
-                  <label
-                    class="euiFormLabel euiFormRow__label"
-                    for="random_html_id"
-                  >
                     Custom result index min age
                   </label>
                 </div>

--- a/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
+++ b/public/pages/DetectorConfig/containers/__tests__/__snapshots__/DetectorConfig.test.tsx.snap
@@ -1905,40 +1905,6 @@ exports[`<DetectorConfig /> spec renders the component 1`] = `
                     class="euiFormLabel euiFormRow__label"
                     for="random_html_id"
                   >
-                    Flatten custom result index
-                  </label>
-                </div>
-                <div
-                  class="euiFormRow__fieldWrapper"
-                >
-                  <div
-                    class="euiText euiText--medium"
-                    id="random_html_id"
-                  >
-                    <p
-                      class="enabled"
-                    >
-                      Yes
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiFormRow euiFormRow--compressed"
-                id="random_html_id-row"
-                style="width: 250px;"
-              >
-                <div
-                  class="euiFormRow__labelWrapper"
-                >
-                  <label
-                    class="euiFormLabel euiFormRow__label"
-                    for="random_html_id"
-                  >
                     Custom result index min age
                   </label>
                 </div>
@@ -3316,40 +3282,6 @@ exports[`<DetectorConfig /> spec renders the component with 2 custom and 1 simpl
                       class="enabled"
                     >
                       -
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiFormRow euiFormRow--compressed"
-                id="random_html_id-row"
-                style="width: 250px;"
-              >
-                <div
-                  class="euiFormRow__labelWrapper"
-                >
-                  <label
-                    class="euiFormLabel euiFormRow__label"
-                    for="random_html_id"
-                  >
-                    Flatten custom result index
-                  </label>
-                </div>
-                <div
-                  class="euiFormRow__fieldWrapper"
-                >
-                  <div
-                    class="euiText euiText--medium"
-                    id="random_html_id"
-                  >
-                    <p
-                      class="enabled"
-                    >
-                      Yes
                     </p>
                   </div>
                 </div>

--- a/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
+++ b/public/pages/ReviewAndCreate/components/DetectorDefinitionFields/DetectorDefinitionFields.tsx
@@ -137,8 +137,7 @@ export const DetectorDefinitionFields = (
   const minSize = (minSizeValue === undefined) ? '-' : minSizeValue + " MB";
   const ttlValue = get(props, 'detector.resultIndexTtl', undefined);
   const ttl = (ttlValue === undefined) ? '-' : ttlValue + " Days";
-  const flattenCustomResultIndex = get(props, 'detector.flattenCustomResultIndex', undefined);
-  const flatten = (flattenCustomResultIndex === undefined) ? '-' : flattenCustomResultIndex ? 'Yes' : 'No';
+
 
   return (
     <ContentPanel
@@ -224,12 +223,6 @@ export const DetectorDefinitionFields = (
           <ConfigCell
             title="Custom result index"
             description={get(props, 'detector.resultIndex', '-')}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <ConfigCell
-            title="Flatten custom result index"
-            description={flatten}
           />
         </EuiFlexItem>
         <EuiFlexItem>

--- a/public/pages/ReviewAndCreate/components/__tests__/DetectorDefinitionFields.test.tsx
+++ b/public/pages/ReviewAndCreate/components/__tests__/DetectorDefinitionFields.test.tsx
@@ -58,7 +58,6 @@ const testDetector = {
   resultIndexMinAge: 7,
   resultIndexMinSize: 51200,
   resultIndexTtl: 60,
-  flattenCustomResultIndex: true,
 } as Detector;
 
 describe('<AdditionalSettings /> spec', () => {
@@ -86,7 +85,6 @@ describe('<AdditionalSettings /> spec', () => {
     getByText('test-timefield');
     getByText('1 Minutes');
     getByText('opensearch-ad-plugin-result-test');
-    getByText('Yes')
     getByText('7 Days');
     getByText('51200 MB');
     getByText('60 Days');

--- a/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/DetectorDefinitionFields.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/components/__tests__/__snapshots__/DetectorDefinitionFields.test.tsx.snap
@@ -357,40 +357,6 @@ exports[`<AdditionalSettings /> spec renders the component in create mode (no ID
                   class="euiFormLabel euiFormRow__label"
                   for="random_html_id"
                 >
-                  Flatten custom result index
-                </label>
-              </div>
-              <div
-                class="euiFormRow__fieldWrapper"
-              >
-                <div
-                  class="euiText euiText--medium"
-                  id="random_html_id"
-                >
-                  <p
-                    class="enabled"
-                  >
-                    Yes
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiFormRow euiFormRow--compressed"
-              id="random_html_id-row"
-              style="width: 250px;"
-            >
-              <div
-                class="euiFormRow__labelWrapper"
-              >
-                <label
-                  class="euiFormLabel euiFormRow__label"
-                  for="random_html_id"
-                >
                   Custom result index min age
                 </label>
               </div>
@@ -891,40 +857,6 @@ exports[`<AdditionalSettings /> spec renders the component in edit mode (with ID
                     class="enabled"
                   >
                     opensearch-ad-plugin-result-test
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="euiFlexItem"
-          >
-            <div
-              class="euiFormRow euiFormRow--compressed"
-              id="random_html_id-row"
-              style="width: 250px;"
-            >
-              <div
-                class="euiFormRow__labelWrapper"
-              >
-                <label
-                  class="euiFormLabel euiFormRow__label"
-                  for="random_html_id"
-                >
-                  Flatten custom result index
-                </label>
-              </div>
-              <div
-                class="euiFormRow__fieldWrapper"
-              >
-                <div
-                  class="euiText euiText--medium"
-                  id="random_html_id"
-                >
-                  <p
-                    class="enabled"
-                  >
-                    Yes
                   </p>
                 </div>
               </div>

--- a/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
+++ b/public/pages/ReviewAndCreate/containers/__tests__/__snapshots__/ReviewAndCreate.test.tsx.snap
@@ -413,40 +413,6 @@ exports[`<ReviewAndCreate /> spec renders the component, validation loading 1`] 
                     class="euiFormLabel euiFormRow__label"
                     for="random_html_id"
                   >
-                    Flatten custom result index
-                  </label>
-                </div>
-                <div
-                  class="euiFormRow__fieldWrapper"
-                >
-                  <div
-                    class="euiText euiText--medium"
-                    id="random_html_id"
-                  >
-                    <p
-                      class="enabled"
-                    >
-                      -
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              class="euiFlexItem"
-            >
-              <div
-                class="euiFormRow euiFormRow--compressed"
-                id="random_html_id-row"
-                style="width: 250px;"
-              >
-                <div
-                  class="euiFormRow__labelWrapper"
-                >
-                  <label
-                    class="euiFormLabel euiFormRow__label"
-                    for="random_html_id"
-                  >
                     Custom result index min age
                   </label>
                 </div>
@@ -1667,40 +1633,6 @@ exports[`issue in detector validation issues in feature query 1`] = `
                       for="random_html_id"
                     >
                       Custom result index
-                    </label>
-                  </div>
-                  <div
-                    class="euiFormRow__fieldWrapper"
-                  >
-                    <div
-                      class="euiText euiText--medium"
-                      id="random_html_id"
-                    >
-                      <p
-                        class="enabled"
-                      >
-                        -
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="euiFlexItem"
-              >
-                <div
-                  class="euiFormRow euiFormRow--compressed"
-                  id="random_html_id-row"
-                  style="width: 250px;"
-                >
-                  <div
-                    class="euiFormRow__labelWrapper"
-                  >
-                    <label
-                      class="euiFormLabel euiFormRow__label"
-                      for="random_html_id"
-                    >
-                      Flatten custom result index
                     </label>
                   </div>
                   <div

--- a/public/pages/ReviewAndCreate/utils/helpers.ts
+++ b/public/pages/ReviewAndCreate/utils/helpers.ts
@@ -72,10 +72,6 @@ export function formikToDetector(values: CreateDetectorFormikValues): Detector {
       resultIndex && resultIndex.trim().length > 0
         ? values.resultIndexTtl
         : undefined,
-    flattenCustomResultIndex:
-      resultIndex && resultIndex.trim().length > 0
-        ? values.flattenCustomResultIndex
-        : undefined,
     imputationOption: formikToImputationOption(values.imputationOption),
     rules: formikToRules(values.suppressionRules),
   } as Detector;

--- a/public/redux/reducers/__tests__/utils.ts
+++ b/public/redux/reducers/__tests__/utils.ts
@@ -131,7 +131,6 @@ export const getRandomDetector = (
     resultIndexMinAge: 7,
     resultIndexMinSize: 51200,
     resultIndexTtl: 60,
-    flattenCustomResultIndex: true,
     imputationOption: randomImputationOption(features),
     rules: randomRules(features)
   };


### PR DESCRIPTION
This reverts commit f53450c733ca32341cec5f5295086b64ce6a04ae.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
