### PR TITLE
Report metrics for suggest anomaly detector

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -155,14 +155,14 @@ jobs:
         working-directory: opensearch-dashboards-functional-test
 
       - name: Capture failure screenshots
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots-${{ matrix.os }}
           path: opensearch-dashboards-functional-test/cypress/screenshots
 
       - name: Capture failure test video
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-videos-${{ matrix.os }}

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -8,7 +8,9 @@
   "optionalPlugins": [
     "dataSource",
     "dataSourceManagement",
-    "assistantDashboards"
+    "assistantDashboards",
+    "usageCollection",
+    "telemetry"
   ],
   "requiredPlugins": [
     "opensearchDashboardsUtils",

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -9,8 +9,7 @@
     "dataSource",
     "dataSourceManagement",
     "assistantDashboards",
-    "usageCollection",
-    "telemetry"
+    "usageCollection"
   ],
   "requiredPlugins": [
     "opensearchDashboardsUtils",

--- a/public/components/DiscoverAction/SuggestAnomalyDetector.tsx
+++ b/public/components/DiscoverAction/SuggestAnomalyDetector.tsx
@@ -144,8 +144,12 @@ function SuggestAnomalyDetector({
     // let LLM to generate parameters for creating anomaly detector
     async function getParameters() {
         try {
+            const checkAgentExistsResponse = await assistantClient.agentConfigExists(SUGGEST_ANOMALY_DETECTOR_CONFIG_ID, { dataSourceId });
+            if (!checkAgentExistsResponse?.exists) {
+                throw new Error('Agent for suggest anomaly detector not found, please configure an agent firstly!');
+            }
             const executeAgentResponse = await
-                assistantClient.executeAgentByName(SUGGEST_ANOMALY_DETECTOR_CONFIG_ID, { index: indexName }, { dataSourceId }
+                assistantClient.executeAgentByConfigName(SUGGEST_ANOMALY_DETECTOR_CONFIG_ID, { index: indexName }, { dataSourceId }
                 );
             reportMetric(SUGGEST_ANOMALY_DETECTOR_METRIC_TYPE.GENERATED);
             const rawGeneratedParameters = executeAgentResponse?.body?.inference_results?.[0]?.output?.[0]?.result;
@@ -317,7 +321,7 @@ function SuggestAnomalyDetector({
                             <EuiText>
                                 Detector created: <a href="#" onClick={(e) => {
                                     e.preventDefault();
-                                    const url = `../${PLUGIN_NAME}#/detectors/${detectorId}`;
+                                    const url = `../${PLUGIN_NAME}#/detectors/${detectorId}/results?dataSourceId=${dataSourceId}`;
                                     window.open(url, '_blank');
                                 }} style={{ textDecoration: 'underline' }}>{formikProps.values.name}</a>
                             </EuiText >

--- a/public/components/DiscoverAction/SuggestAnomalyDetector.tsx
+++ b/public/components/DiscoverAction/SuggestAnomalyDetector.tsx
@@ -321,7 +321,7 @@ function SuggestAnomalyDetector({
                             <EuiText>
                                 Detector created: <a href="#" onClick={(e) => {
                                     e.preventDefault();
-                                    const url = `../${PLUGIN_NAME}#/detectors/${detectorId}/results?dataSourceId=${dataSourceId}`;
+                                    const url = `../${PLUGIN_NAME}#/detectors/${detectorId}/results?dataSourceId=${dataSourceId || ''}`;
                                     window.open(url, '_blank');
                                 }} style={{ textDecoration: 'underline' }}>{formikProps.values.name}</a>
                             </EuiText >

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -43,6 +43,7 @@ import {
   setDataSourceEnabled,
   setNavigationUI,
   setApplication,
+  setUsageCollection,
   setAssistantClient,
 } from './services';
 import { AnomalyDetectionOpenSearchDashboardsPluginStart } from 'public';
@@ -194,10 +195,11 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
       plugins.uiActions.addTriggerAction(CONTEXT_MENU_TRIGGER, action);
     });
 
+    setUsageCollection(plugins.usageCollection);
     // Add suggest anomaly detector action to the uiActions in Discover
-    if (plugins.assistantDashboards?.assistantTriggers?.AI_ASSISTANT_TRIGGER) {
+    if (plugins.assistantDashboards?.assistantTriggers?.AI_ASSISTANT_QUERY_EDITOR_TRIGGER) {
       const suggestAnomalyDetectorAction = getSuggestAnomalyDetectorAction();
-      plugins.uiActions.addTriggerAction(plugins.assistantDashboards.assistantTriggers.AI_ASSISTANT_TRIGGER, suggestAnomalyDetectorAction);
+      plugins.uiActions.addTriggerAction(plugins.assistantDashboards.assistantTriggers.AI_ASSISTANT_QUERY_EDITOR_TRIGGER, suggestAnomalyDetectorAction);
     }
     // registers the expression function used to render anomalies on an Augmented Visualization
     plugins.expressions.registerFunction(overlayAnomaliesFunction);

--- a/public/services.ts
+++ b/public/services.ts
@@ -16,6 +16,7 @@ import { createGetterSetter } from '../../../src/plugins/opensearch_dashboards_u
 import { UiActionsStart } from '../../../src/plugins/ui_actions/public';
 import { SavedAugmentVisLoader } from '../../../src/plugins/vis_augmenter/public';
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import { UsageCollectionSetup } from '../../../src/plugins/usage_collection/public/plugin';
 import { AssistantPublicPluginStart } from '../../../plugins/dashboards-assistant/public/';
 
 export interface DataSourceEnabled {
@@ -45,6 +46,9 @@ export const [getUISettings, setUISettings] =
 
 export const [getQueryService, setQueryService] =
   createGetterSetter<DataPublicPluginStart['query']>('Query');
+
+export const [getUsageCollection, setUsageCollection] =
+  createGetterSetter<UsageCollectionSetup>('UsageCollection');
 
 export const [getAssistantEnabled, setAssistantEnabled] =
   createGetterSetter<AssistantPublicPluginStart>('AssistantClient');

--- a/public/utils/constants.ts
+++ b/public/utils/constants.ts
@@ -118,3 +118,10 @@ export const DASHBOARD_PAGE_NAV_ID = `anomaly_detection_dashboard-dashboard`;
 export const DETECTORS_PAGE_NAV_ID = `anomaly_detection_dashboard-detectors`;
 
 export const USE_NEW_HOME_PAGE = 'home:useNewHomePage';
+
+export enum SUGGEST_ANOMALY_DETECTOR_METRIC_TYPE {
+  THUMBUP = 'thumbup',
+  THUMBDOWN = 'thumbdown',
+  GENERATED = 'generated',
+  CREATED = 'created',
+}


### PR DESCRIPTION
### Description

This PR implements a small enhancement for the suggest anomaly detector feature, we add feedback button to the flyout of suggest anomaly detector, when users click the button, it will call the metric report API in the core plugin usageCollection. And when LLM gives suggested parameters successfully, a `generated` metric is reported, when the suggested detector is created, a `created` metric is reported.

Another change is that we check the feature flag before register the SuggestAnomalyDetector action to Discover, if the feature flag is disabled or the whole assistant capability is disabled, no action will be registered.

Some UI change:
<img width="651" alt="Features" src="https://github.com/user-attachments/assets/4a2c8f12-324e-4d99-8bc4-8adb568bbeed">

<img width="635" alt="Add another feature" src="https://github.com/user-attachments/assets/8340ba53-0539-4c67-b1dc-25b1b4f2b5a7">



### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/816

### Check List

- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
