### PR TITLE
Fallback to cluster health on remote info failure

### DIFF
--- a/server/routes/opensearch.ts
+++ b/server/routes/opensearch.ts
@@ -570,14 +570,19 @@ export default class OpenSearchService {
 
       let clustersResponse: ClusterInfo[] = [];
 
-      const remoteInfo = await callWithRequest('transport.request', {
-        method: 'GET',
-        path: '/_remote/info',
-      });
-      clustersResponse = Object.keys(remoteInfo).map((key) => ({
-        name: key,
-        localCluster: false,
-      }));
+      try {
+        const remoteInfo = await callWithRequest('transport.request', {
+          method: 'GET',
+          path: '/_remote/info',
+        });
+        clustersResponse = Object.keys(remoteInfo).map((key) => ({
+          name: key,
+          localCluster: false,
+        }));
+      } catch (remoteErr) {
+        console.warn('Failed to fetch remote cluster info, proceeding with local datasource info only.', remoteErr);
+      }
+
 
       const clusterHealth = await callWithRequest('cat.health', {
         format: 'json',


### PR DESCRIPTION
### Description
Changed call to get remote info to only display a warning if it fails and to continue on to cluster health call so to ensure a default of only the local cluster showing up in the cluster selection.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
