### PR TITLE
mds bug fixes

### DIFF
--- a/public/pages/Dashboard/Container/DashboardOverview.tsx
+++ b/public/pages/Dashboard/Container/DashboardOverview.tsx
@@ -207,15 +207,18 @@ export function DashboardOverview(props: OverviewProps) {
   };
 
   const intializeDetectors = async () => {
-    dispatch(
-      getDetectorList(
-        getAllDetectorsQueryParamsWithDataSourceId(
-          MDSOverviewState.selectedDataSourceId
+    // wait until selected data source is ready before doing dispatch calls if mds is enabled
+    if (!dataSourceEnabled || (MDSOverviewState.selectedDataSourceId && MDSOverviewState.selectedDataSourceId !== "")) {
+      dispatch(
+        getDetectorList(
+          getAllDetectorsQueryParamsWithDataSourceId(
+            MDSOverviewState.selectedDataSourceId
+          )
         )
-      )
-    );
-    dispatch(getIndices('', MDSOverviewState.selectedDataSourceId));
-    dispatch(getAliases('', MDSOverviewState.selectedDataSourceId));
+      );
+      dispatch(getIndices('', MDSOverviewState.selectedDataSourceId));
+      dispatch(getAliases('', MDSOverviewState.selectedDataSourceId));
+    }
   };
 
   useEffect(() => {

--- a/public/pages/DetectorsList/containers/List/List.tsx
+++ b/public/pages/DetectorsList/containers/List/List.tsx
@@ -330,11 +330,14 @@ export const DetectorList = (props: ListProps) => {
   }, [confirmModalState.isRequestingToClose, isLoading]);
 
   const getUpdatedDetectors = async () => {
-    dispatch(
-      getDetectorList(
-        getAllDetectorsQueryParamsWithDataSourceId(state.selectedDataSourceId)
-      )
-    );
+    // wait until selected data source is ready before doing dispatch calls if mds is enabled
+    if (!dataSourceEnabled || (state.selectedDataSourceId && state.selectedDataSourceId !== "")) {
+      dispatch(
+        getDetectorList(
+          getAllDetectorsQueryParamsWithDataSourceId(state.selectedDataSourceId)
+        )
+      );
+    }
   };
 
   const handlePageChange = (pageNumber: number) => {

--- a/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
+++ b/public/pages/Overview/containers/AnomalyDetectionOverview.tsx
@@ -155,23 +155,26 @@ export function AnomalyDetectionOverview(props: AnomalyDetectionOverviewProps) {
 
   // fetch smaple detectors and sample indices
   const fetchData = async () => {
-    await dispatch(
-      getDetectorList(
-        getSampleDetectorsQueryParamsWithDataSouceId(
+    // wait until selected data source is ready before doing dispatch calls if mds is enabled
+    if (!dataSourceEnabled || (MDSOverviewState.selectedDataSourceId && MDSOverviewState.selectedDataSourceId !== "")) {
+      await dispatch(
+        getDetectorList(
+          getSampleDetectorsQueryParamsWithDataSouceId(
+            MDSOverviewState.selectedDataSourceId
+          )
+        )
+      ).catch((error: any) => {
+        console.error('Error getting sample detectors: ', error);
+      });
+      await dispatch(
+        getIndices(
+          GET_SAMPLE_INDICES_QUERY,
           MDSOverviewState.selectedDataSourceId
         )
-      )
-    ).catch((error: any) => {
-      console.error('Error getting sample detectors: ', error);
-    });
-    await dispatch(
-      getIndices(
-        GET_SAMPLE_INDICES_QUERY,
-        MDSOverviewState.selectedDataSourceId
-      )
-    ).catch((error: any) => {
-      console.error('Error getting sample indices: ', error);
-    });
+      ).catch((error: any) => {
+        console.error('Error getting sample indices: ', error);
+      });
+    }
   };
 
   // Create and populate sample index, create and start sample detector

--- a/public/redux/reducers/ad.ts
+++ b/public/redux/reducers/ad.ts
@@ -419,7 +419,7 @@ export const getDetector = (
 export const getDetectorList = (
   queryParams: GetDetectorsQueryParams
 ): APIAction => {
-  const dataSourceId = queryParams.dataSourceId || '';
+  const dataSourceId = queryParams.dataSourceId;
 
   const baseUrl = `${AD_NODE_API.DETECTOR}/_list`;
   const url = dataSourceId

--- a/public/redux/reducers/previewAnomalies.ts
+++ b/public/redux/reducers/previewAnomalies.ts
@@ -59,7 +59,9 @@ const reducer = handleActions<PreviewAnomalies>(
   initialDetectorsState
 );
 
-export const previewDetector = (requestBody: any, dataSourceId: string = ''): APIAction => {
+export const previewDetector = (requestBody: any): APIAction => {
+  const dataSourceId = requestBody.dataSourceId;
+
   const baseUrl = `..${AD_NODE_API.DETECTOR}/preview`;
   const url =  dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
 


### PR DESCRIPTION
### Description

This pr includes two mds bug fixes:
- surround dispatch calls with `if (!dataSourceEnabled || (MDSOverviewState.selectedDataSourceId && MDSOverviewState.selectedDataSourceId !== ""))` check to make sure when mds is enabled, we wait until the selected data source and selected data source id is ready before doing any dispatch calls. This saves us from seeing a transient error message says cannot get all detectors even though the page is actually functioning.
- fix a bug in the way how we get dataSourceId in preview anomalies api, getting it from request body instead of as a parameter. 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
