### PR TITLE
disable flatten result index option for existing detectors

### DIFF
--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -48,6 +48,7 @@ interface CustomResultIndexProps {
 function CustomResultIndex(props: CustomResultIndexProps) {
   const [enabled, setEnabled] = useState<boolean>(!!props.resultIndex);
   const [customResultIndexConditionsEnabled, setCustomResultIndexConditionsEnabled] = useState<boolean>(true);
+  const [isDisabled, setIsDisabled] = useState(false);
   const customResultIndexMinAge = get(props.formikProps, 'values.resultIndexMinAge');
   const customResultIndexMinSize = get(props.formikProps, 'values.resultIndexMinSize');
   const customResultIndexTTL = get(props.formikProps, 'values.resultIndexTtl');
@@ -65,6 +66,14 @@ function CustomResultIndex(props: CustomResultIndexProps) {
       setFieldValue('resultIndexTtl', '');
     }
   },[customResultIndexConditionsEnabled])
+
+  useEffect(() => {
+    if (props.isEdit && !get(props.formikProps, 'values.flattenCustomResultIndex')) {
+      setIsDisabled(true);
+    } else {
+      setIsDisabled(false);
+    }
+  }, [props.isEdit]);
 
   const hintTextStyle = {
     color: '#69707d',
@@ -162,6 +171,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
                     id={'flattenCustomResultIndex'}
                     label="Enable flattened custom result index"
                     checked={field.value ? field.value : get(props.formikProps, 'values.flattenCustomResultIndex')}
+                    disabled={isDisabled}
                     {...field}
                   />
                   <p style={hintTextStyle}>Flattening the custom result index will make it easier to query them on the dashboard. It also allows you to perform term aggregations on categorical fields.</p>


### PR DESCRIPTION
### Description

disable the flatten result index option when:
- is on edit page
- is using custom result index
- flatten result index is not checked for existing detector config

customer can chose to create a detector with flatten result index option, and then later on edit page, they can uncheck it to disable flatten result index.  

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
