### PR TITLE
Revert "disable flatten result index option for existing detectors (#…

### DIFF
--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -48,7 +48,6 @@ interface CustomResultIndexProps {
 function CustomResultIndex(props: CustomResultIndexProps) {
   const [enabled, setEnabled] = useState<boolean>(!!props.resultIndex);
   const [customResultIndexConditionsEnabled, setCustomResultIndexConditionsEnabled] = useState<boolean>(true);
-  const [isDisabled, setIsDisabled] = useState(false);
   const customResultIndexMinAge = get(props.formikProps, 'values.resultIndexMinAge');
   const customResultIndexMinSize = get(props.formikProps, 'values.resultIndexMinSize');
   const customResultIndexTTL = get(props.formikProps, 'values.resultIndexTtl');
@@ -66,14 +65,6 @@ function CustomResultIndex(props: CustomResultIndexProps) {
       setFieldValue('resultIndexTtl', '');
     }
   },[customResultIndexConditionsEnabled])
-
-  useEffect(() => {
-    if (props.isEdit && !get(props.formikProps, 'values.flattenCustomResultIndex')) {
-      setIsDisabled(true);
-    } else {
-      setIsDisabled(false);
-    }
-  }, [props.isEdit]);
 
   const hintTextStyle = {
     color: '#69707d',
@@ -171,7 +162,6 @@ function CustomResultIndex(props: CustomResultIndexProps) {
                     id={'flattenCustomResultIndex'}
                     label="Enable flattened custom result index"
                     checked={field.value ? field.value : get(props.formikProps, 'values.flattenCustomResultIndex')}
-                    disabled={isDisabled}
                     {...field}
                   />
                   <p style={hintTextStyle}>Flattening the custom result index will make it easier to query them on the dashboard. It also allows you to perform term aggregations on categorical fields.</p>


### PR DESCRIPTION
This reverts commit c51aca0c653d5636a8c9e44809d1df437034f4a9.

reverting this change for this enhancement at backend side - https://github.com/opensearch-project/anomaly-detection/pull/1409

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
