### PR TITLE
Switching fieldcaps api to utilize js client

### DIFF
--- a/server/routes/opensearch.ts
+++ b/server/routes/opensearch.ts
@@ -422,10 +422,10 @@ export default class OpenSearchService {
 
       // make call to fields_caps
       if (remoteIndices.length) {
-        const fieldCapsResponse = await callWithRequest('transport.request', {
-          method: 'GET',
-          path:
-            remoteIndices.toString() + '/_field_caps?fields=*&include_unmapped',
+        const fieldCapsResponse = await callWithRequest('fieldCaps', {
+          index: remoteIndices.toString(),
+          fields: '*',
+          include_unmapped: true
         });
         remoteMappings = convertFieldCapsToMappingStructure(fieldCapsResponse);
       }


### PR DESCRIPTION
### Description

changing from using transport client for field caps call to the opensearch-js client directly.

### Issues Resolved

resolves #969 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
