### PR TITLE
Change remote IT to use dualCluster is true

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run OpenSearch with plugin
         run: |
           cd anomaly-detection
-          ./gradlew run &
+          ./gradlew run -PdualCluster=true &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
         shell: bash
     


### PR DESCRIPTION
### Description

Changing remote IT to run with dual clusters now so we can test creating a detector with a remote index.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
