### PR TITLE
Restrict `Suggest anomaly detector` to only show for OpenSearch datasets

### DIFF
--- a/public/utils/contextMenu/getActions.tsx
+++ b/public/utils/contextMenu/getActions.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { i18n } from '@osd/i18n';
 import { EuiIconType } from '@elastic/eui';
 import { toMountPoint } from '../../../../../src/plugins/opensearch_dashboards_react/public';
+import { DEFAULT_DATA } from '../../../../../src/plugins/data/common';
 import {
   Action,
   createAction,
@@ -121,7 +122,11 @@ export const getSuggestAnomalyDetectorAction = () => {
     getIconType: () => ANOMALY_DETECTION_ICON,
     // suggestAD is only compatible with data sources that have certain agents configured
     isCompatible: async (context) => {
-      if (context.datasetId) {
+      if (
+        context.datasetId &&
+        (context.datasetType === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN ||
+          context.datasetType === DEFAULT_DATA.SET_TYPES.INDEX)
+      ) {
         const assistantClient = getAssistantClient();
         const res = await assistantClient.agentConfigExists(
           SUGGEST_ANOMALY_DETECTOR_CONFIG_ID,


### PR DESCRIPTION
### Description

@lezzago mentioned that the suggest feature only works with opensearch index pattern or indices. This PR prevents it to show up if the selected dataset is not opensearch index

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
