### PR TITLE
Fix remote cluster bug when remote and local have same name

### DIFF
--- a/public/pages/DefineDetector/components/Datasource/DataSource.tsx
+++ b/public/pages/DefineDetector/components/Datasource/DataSource.tsx
@@ -146,7 +146,15 @@ export function DataSource(props: DataSourceProps) {
       const localCluster: ClusterInfo[] = getLocalCluster(
         opensearchState.clusters
       );
-      setFieldValue('clusters', getVisibleClusterOptions(localCluster));
+      if (props.formikProps.values.clusters && props.formikProps.values.clusters.length > 0) {
+        const clusterInfoList: ClusterInfo[] = props.formikProps.values.clusters.map(option => ({
+          name: option.cluster,
+          localCluster: option.localcluster === 'true',
+        }));
+        setFieldValue('clusters', getVisibleClusterOptions(clusterInfoList));
+      } else {
+        setFieldValue('clusters', getVisibleClusterOptions(localCluster));
+      }
     }
   }, [opensearchState.clusters]);
 

--- a/public/pages/ReviewAndCreate/components/DataConnectionFlyout/DataConnectionFlyout.tsx
+++ b/public/pages/ReviewAndCreate/components/DataConnectionFlyout/DataConnectionFlyout.tsx
@@ -53,7 +53,7 @@ const getIndexItemsToDisplay = (props: DataConnectionFlyoutProps) => {
     const splitIndex = index.split(':');
     let clusterName = shouldSplit ? splitIndex[0] : props.localClusterName;
     clusterName =
-      clusterName === props.localClusterName
+      clusterName === props.localClusterName && !shouldSplit
         ? `${clusterName} (Local)`
         : `${clusterName} (Remote)`;
     const indexName = shouldSplit ? splitIndex[1] : index;


### PR DESCRIPTION
### Description

This PR fixes 2 different bugs related to remote cluster display during detector creation:
1. When local cluster and remote cluster have the same name we distinguish which cluster is the local/remote one
2. When we click on previous in the model configuration page it will display the correct cluster selection and not reset to just show local cluster

Both these cases are covered in new IT in this PR: https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1755

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
