### PR TITLE
Display selected clusters correctly on edit page

### DIFF
--- a/public/pages/DefineDetector/components/Datasource/DataSource.tsx
+++ b/public/pages/DefineDetector/components/Datasource/DataSource.tsx
@@ -46,8 +46,7 @@ import { INITIAL_MODEL_CONFIGURATION_VALUES } from '../../../ConfigureModel/util
 import { FILTER_TYPES } from '../../../../models/interfaces';
 import { useLocation } from 'react-router-dom';
 import _ from 'lodash';
-import { cleanString } from '../../../../../../../src/plugins/vis_type_vega/public/expressions/helpers';
-import { L } from '../../../../../../../src/plugins/maps_legacy/public/lazy_load_bundle/lazy';
+import { getClusterOptionLabel } from '../../utils/helpers';
 
 interface DataSourceProps {
   formikProps: FormikProps<DetectorDefinitionFormikValues>;
@@ -59,7 +58,7 @@ interface DataSourceProps {
   oldFilterQuery: any;
 }
 
-interface ClusterOption {
+export interface ClusterOption {
   label: string;
   cluster: string;
   localcluster: string;
@@ -81,7 +80,7 @@ export function DataSource(props: DataSourceProps) {
   useEffect(() => {
     const getInitialClusters = async () => {
       await dispatch(getClustersInfo(dataSourceId));
-      setFieldValue('clusters', props.formikProps.values.clusters);
+      handleClusterUpdate(opensearchState.clusters);
     };
     getInitialClusters();
   }, [dataSourceId]);
@@ -141,7 +140,7 @@ export function DataSource(props: DataSourceProps) {
     return clustersString;
   };
 
-  useEffect(() => {
+  const handleClusterUpdate = (clusters: ClusterInfo[]) => {
     if (opensearchState.clusters && opensearchState.clusters.length > 0) {
       const localCluster: ClusterInfo[] = getLocalCluster(
         opensearchState.clusters
@@ -156,10 +155,11 @@ export function DataSource(props: DataSourceProps) {
         setFieldValue('clusters', getVisibleClusterOptions(localCluster));
       }
     }
-  }, [opensearchState.clusters]);
+  };
 
-  const getClusterOptionLabel = (clusterInfo: ClusterInfo) =>
-    `${clusterInfo.name} ${clusterInfo.localCluster ? '(Local)' : '(Remote)'}`;
+  useEffect(() => {
+    handleClusterUpdate(opensearchState.clusters);
+  }, [opensearchState.clusters]);
 
   useEffect(() => {
     setIndexNames(props.formikProps.values.index);

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -17,7 +17,7 @@ import React, {
   useState,
 } from 'react';
 import { RouteComponentProps, useLocation } from 'react-router';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Dispatch } from 'redux';
 import { FormikProps, Formik } from 'formik';
 import { get, isEmpty } from 'lodash';
@@ -69,6 +69,7 @@ import {
   isDataSourceCompatible,
 } from '../../../pages/utils/helpers';
 import queryString from 'querystring';
+import { AppState } from '../../../redux/reducers';
 
 interface DefineDetectorRouterProps {
   detectorId?: string;
@@ -89,7 +90,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
   const MDSQueryParams = getDataSourceFromURL(location);
   const dataSourceId = MDSQueryParams.dataSourceId;
   const dataSourceEnabled = getDataSourceEnabled().enabled;
-
+  const opensearchState = useSelector((state: AppState) => state.opensearch);
   const core = React.useContext(CoreServicesContext) as CoreStart;
   const dispatch = useDispatch<Dispatch<APIAction>>();
   useHideSideNavBar(true, false);
@@ -345,7 +346,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
       initialValues={
         props.initialValues
           ? props.initialValues
-          : detectorDefinitionToFormik(detector)
+          : detectorDefinitionToFormik(detector, opensearchState.clusters)
       }
       enableReinitialize={true}
       onSubmit={() => {}}

--- a/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
+++ b/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
@@ -1097,6 +1097,1169 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
 </div>
 `;
 
+exports[`<DefineDetector /> FullEdit editing detector page renders the component 1`] = `
+<div
+  class="euiPage euiPage--paddingMedium euiPage--grow"
+  style="margin-top: -24px;"
+>
+  <div
+    class="euiPageBody euiPageBody--borderRadiusNone"
+  >
+    <header
+      class="euiPageHeader euiPageHeader--responsive euiPageHeader--center"
+    >
+      <div
+        class="euiPageHeaderSection"
+      >
+        <div
+          class="euiText euiText--small"
+          data-test-subj="defineOrEditDetectorTitle"
+        >
+          <h1>
+            Edit detector settings
+             
+          </h1>
+        </div>
+      </div>
+    </header>
+    <div
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      style="padding: 20px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <h3
+            class="euiTitle euiTitle--small"
+            data-test-subj="contentPanelTitle"
+          >
+            Detector details
+          </h3>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem content-panel-subTitle"
+              style="line-height: normal; max-width: 75%;"
+            />
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
+        />
+        <div
+          style="padding: 10px 0px;"
+        >
+          <div
+            class="euiFormRow euiFormRow--compressed"
+            hint="Specify a unique and descriptive name that is easy to recognize."
+            id="random_html_id-row"
+            title="Name"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Name
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Specify a unique and descriptive name that is easy to recognize.
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                class="euiFormControlLayout euiFormControlLayout--compressed"
+              >
+                <div
+                  class="euiFormControlLayout__childrenWrapper"
+                >
+                  <input
+                    aria-describedby="random_html_id-help-0"
+                    class="euiFieldText euiFieldText--compressed"
+                    data-test-subj="detectorNameTextInput"
+                    id="random_html_id"
+                    name="name"
+                    placeholder="Enter detector name"
+                    type="text"
+                    value="cojeragowo"
+                  />
+                </div>
+              </div>
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                Detector name must contain 1-64 characters. Valid characters are
+                a-z, A-Z, 0-9, -(hyphen), _(underscore) and .(period).
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormRow euiFormRow--compressed"
+            hint="Describe the purpose of the detector."
+            id="random_html_id-row"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Description 
+                    <span
+                      class="optional"
+                    >
+                      - optional
+                    </span>
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Describe the purpose of the detector.
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <textarea
+                class="euiTextArea euiTextArea--resizeVertical euiTextArea--compressed"
+                data-test-subj="detectorDescriptionTextInput"
+                id="random_html_id"
+                name="description"
+                placeholder="Describe the detector"
+                rows="3"
+              >
+                Fohniz wonengiz tup emu mo fuefuluj lov dewdavwo fovteh ka mecazaso enehvi.
+              </textarea>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--l"
+    />
+    <div
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      style="padding: 20px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <h3
+            class="euiTitle euiTitle--small"
+            data-test-subj="contentPanelTitle"
+          >
+            Select Data
+          </h3>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem content-panel-subTitle"
+              style="line-height: normal; max-width: 75%;"
+            />
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
+        />
+        <div
+          style="padding: 10px 0px;"
+        >
+          <div
+            class="euiFormRow euiFormRow--compressed"
+            hint="Select a local cluster or remote clusters from cross-cluster connections."
+            id="random_html_id-row"
+            title="Clusters"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Clusters
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Select a local cluster or remote clusters from cross-cluster connections.
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="euiComboBox euiComboBox--compressed"
+                data-test-subj="clustersFilter"
+                role="combobox"
+              >
+                <div
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                >
+                  <div
+                    class="euiFormControlLayout__childrenWrapper"
+                  >
+                    <div
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isLoading"
+                      data-test-subj="comboBoxInput"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                        cluster="opensearch"
+                        localcluster="false"
+                        title="opensearch (Remote)"
+                      >
+                        <span
+                          class="euiBadge__content"
+                        >
+                          <span
+                            class="euiBadge__text"
+                          >
+                            opensearch (Remote)
+                          </span>
+                          <button
+                            aria-label="Remove opensearch (Remote) from selection in this group"
+                            class="euiBadge__iconButton"
+                            title="Remove opensearch (Remote) from selection in this group"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiBadge__icon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              tabindex="-1"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                          </button>
+                        </span>
+                      </span>
+                      <div
+                        class="euiComboBox__input"
+                        style="font-size: 14px; display: inline-block;"
+                      >
+                        <input
+                          aria-controls=""
+                          data-test-subj="comboBoxSearchInput"
+                          id="random_html_id"
+                          role="textbox"
+                          style="box-sizing: content-box; width: 2px;"
+                          value=""
+                        />
+                        <div
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <span
+                        class="euiLoadingSpinner euiLoadingSpinner--medium"
+                      />
+                      <button
+                        aria-label="Open list of options"
+                        class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                        data-test-subj="comboBoxToggleListButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                            fill-rule="non-zero"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormRow euiFormRow--compressed"
+            hint="Choose an index, index pattern or alias as the data source."
+            id="random_html_id-row"
+            title="Index"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Index
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Choose an index, index pattern or alias as the data source.
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                aria-describedby="random_html_id-help-0"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="euiComboBox euiComboBox--compressed"
+                data-test-subj="indicesFilter"
+                role="combobox"
+              >
+                <div
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                >
+                  <div
+                    class="euiFormControlLayout__childrenWrapper"
+                  >
+                    <div
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap-isLoading"
+                      data-test-subj="comboBoxInput"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="euiBadge euiBadge--hollow euiBadge--iconRight euiComboBoxPill"
+                        title="opensearch:index-1"
+                      >
+                        <span
+                          class="euiBadge__content"
+                        >
+                          <span
+                            class="euiBadge__text"
+                          >
+                            opensearch:index-1
+                          </span>
+                          <button
+                            aria-label="Remove opensearch:index-1 from selection in this group"
+                            class="euiBadge__iconButton"
+                            title="Remove opensearch:index-1 from selection in this group"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="euiIcon euiIcon--small euiIcon--inherit euiIcon-isLoading euiBadge__icon"
+                              focusable="false"
+                              height="16"
+                              role="img"
+                              tabindex="-1"
+                              viewBox="0 0 16 16"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                          </button>
+                        </span>
+                      </span>
+                      <div
+                        class="euiComboBox__input"
+                        style="font-size: 14px; display: inline-block;"
+                      >
+                        <input
+                          aria-controls=""
+                          data-test-subj="comboBoxSearchInput"
+                          id="random_html_id"
+                          role="textbox"
+                          style="box-sizing: content-box; width: 2px;"
+                          value=""
+                        />
+                        <div
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <span
+                        class="euiLoadingSpinner euiLoadingSpinner--medium"
+                      />
+                      <button
+                        aria-label="Open list of options"
+                        class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                        data-test-subj="comboBoxToggleListButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                            fill-rule="non-zero"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="euiFormHelpText euiFormRow__text"
+                id="random_html_id-help-0"
+              >
+                You can use a wildcard (*) in your index pattern.
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+            hint="Choose a subset of your data source to focus your data stream and reduce noisy data."
+            id="random_html_id-row"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Data filter
+                    <span
+                      class="optional"
+                    >
+                      - optional
+                    </span>
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Choose a subset of your data source to focus your data stream and reduce noisy data.
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                class="euiSpacer euiSpacer--m"
+              />
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+              >
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="euiIcon euiIcon--medium"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    style="margin-right: -4px; margin-top: 2px;"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m9.759 12.652-1.8 2.25-.78-.625 1.8-2.25A.1.1 0 0 0 9 11.965V8.362a1 1 0 0 1 .232-.64l4.631-5.558A.1.1 0 0 0 13.787 2H2.213a.1.1 0 0 0-.077.164l4.631 5.558a1 1 0 0 1 .232.64v5.853a.1.1 0 0 0 .178.062l.781.625c-.65.812-1.959.353-1.959-.687V8.362L1.368 2.804C.771 2.088 1.281 1 2.214 1h11.573c.932 0 1.442 1.088.845 1.804L10 8.362v3.603a1.1 1.1 0 0 1-.241.687Z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                  style="margin-top: 0px;"
+                >
+                  <button
+                    class="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                    type="button"
+                  >
+                    <span
+                      class="euiButtonContent euiButtonEmpty__content"
+                    >
+                      <span
+                        class="euiButtonEmpty__text"
+                      >
+                        + Add data filter
+                      </span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--l"
+    />
+    <div
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      style="padding: 20px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <h3
+            class="euiTitle euiTitle--small"
+            data-test-subj="contentPanelTitle"
+          >
+            Timestamp
+          </h3>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem content-panel-subTitle"
+              style="line-height: normal; max-width: 75%;"
+            >
+              Select the time field you want to use for the time filter.
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
+        />
+        <div
+          style="padding: 10px 0px;"
+        >
+          <div
+            class="euiFormRow euiFormRow--compressed"
+            hint="Choose the time field you want to use for time filter."
+            id="random_html_id-row"
+            title="Timestamp field"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Timestamp field
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Choose the time field you want to use for time filter.
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                class="euiComboBox euiComboBox--compressed"
+                data-test-subj="timestampFilter"
+                role="combobox"
+              >
+                <div
+                  class="euiFormControlLayout euiFormControlLayout--compressed"
+                >
+                  <div
+                    class="euiFormControlLayout__childrenWrapper"
+                  >
+                    <div
+                      class="euiComboBox__inputWrap euiComboBox__inputWrap--compressed euiComboBox__inputWrap--noWrap"
+                      data-test-subj="comboBoxInput"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="euiComboBoxPill euiComboBoxPill--plainText"
+                      >
+                        @timestamp
+                      </span>
+                      <div
+                        class="euiComboBox__input"
+                        style="font-size: 14px; display: inline-block;"
+                      >
+                        <input
+                          aria-controls=""
+                          data-test-subj="comboBoxSearchInput"
+                          id="random_html_id"
+                          role="textbox"
+                          style="box-sizing: content-box; width: 2px;"
+                          value=""
+                        />
+                        <div
+                          style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
+                    >
+                      <button
+                        aria-label="Open list of options"
+                        class="euiFormControlLayoutCustomIcon euiFormControlLayoutCustomIcon--clickable"
+                        data-test-subj="comboBoxToggleListButton"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="euiIcon euiIcon--small euiFormControlLayoutCustomIcon__icon"
+                          focusable="false"
+                          height="16"
+                          role="img"
+                          viewBox="0 0 16 16"
+                          width="16"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M13.069 5.157 8.384 9.768a.546.546 0 0 1-.768 0L2.93 5.158a.552.552 0 0 0-.771 0 .53.53 0 0 0 0 .759l4.684 4.61c.641.631 1.672.63 2.312 0l4.684-4.61a.53.53 0 0 0 0-.76.552.552 0 0 0-.771 0Z"
+                            fill-rule="non-zero"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--l"
+    />
+    <div
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      style="padding: 20px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <h3
+            class="euiTitle euiTitle--small"
+            data-test-subj="contentPanelTitle"
+          >
+            Operation settings
+          </h3>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem content-panel-subTitle"
+              style="line-height: normal; max-width: 75%;"
+            />
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
+        />
+        <div
+          style="padding: 10px 0px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+              style="max-width: 70%;"
+            >
+              <div
+                class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+                hint="Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need."
+                hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
+                id="random_html_id-row"
+                title="Detector interval"
+              >
+                <div
+                  class="euiFormRow__labelWrapper"
+                >
+                  <label
+                    aria-invalid="false"
+                    class="euiFormLabel euiFormRow__label"
+                    for="random_html_id"
+                  >
+                    <div
+                      style="line-height: 8px;"
+                    >
+                      <p>
+                        Detector interval
+                      </p>
+                      <br />
+                      <div
+                        class="euiText euiText--medium sublabel"
+                        style="max-width: 400px;"
+                      >
+                        Define how often the detector collects data to generate anomalies. The shorter the interval is, the more real time the detector results will be, and the more computing resources the detector will need.
+                         
+                        <a
+                          class="euiLink euiLink--primary"
+                          href="https://opensearch.org/docs/monitoring-plugins/ad"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          Learn more
+                          <svg
+                            aria-label="External link"
+                            class="euiIcon euiIcon--small euiLink__externalIcon"
+                            focusable="false"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                            />
+                          </svg>
+                          <span
+                            class="euiScreenReaderOnly"
+                          >
+                            (opens in a new tab or window)
+                          </span>
+                        </a>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+                <div
+                  class="euiFormRow__fieldWrapper"
+                >
+                  <div
+                    class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                    id="random_html_id"
+                  >
+                    <div
+                      class="euiFlexItem euiFlexItem--flexGrowZero"
+                    >
+                      <div
+                        class="euiFormControlLayout euiFormControlLayout--compressed"
+                      >
+                        <div
+                          class="euiFormControlLayout__childrenWrapper"
+                        >
+                          <input
+                            class="euiFieldNumber euiFieldNumber--compressed"
+                            data-test-subj="detectionInterval"
+                            id="detectionInterval"
+                            min="1"
+                            name="interval"
+                            placeholder="Detector interval"
+                            type="number"
+                            value="2"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="euiFlexItem"
+                    >
+                      <div
+                        class="euiText euiText--medium"
+                      >
+                        <p
+                          class="minutes"
+                        >
+                          minutes
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFormRow euiFormRow--fullWidth euiFormRow--compressed"
+            hint="Specify a window of delay for a detector to fetch data, if you need to account for extra processing time."
+            hintlink="https://opensearch.org/docs/monitoring-plugins/ad"
+            id="random_html_id-row"
+            style="margin-top: 16px;"
+            title="Window delay"
+          >
+            <div
+              class="euiFormRow__labelWrapper"
+            >
+              <label
+                aria-invalid="false"
+                class="euiFormLabel euiFormRow__label"
+                for="random_html_id"
+              >
+                <div
+                  style="line-height: 8px;"
+                >
+                  <p>
+                    Window delay
+                  </p>
+                  <br />
+                  <div
+                    class="euiText euiText--medium sublabel"
+                    style="max-width: 400px;"
+                  >
+                    Specify a window of delay for a detector to fetch data, if you need to account for extra processing time.
+                     
+                    <a
+                      class="euiLink euiLink--primary"
+                      href="https://opensearch.org/docs/monitoring-plugins/ad"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      Learn more
+                      <svg
+                        aria-label="External link"
+                        class="euiIcon euiIcon--small euiLink__externalIcon"
+                        focusable="false"
+                        height="16"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                        />
+                      </svg>
+                      <span
+                        class="euiScreenReaderOnly"
+                      >
+                        (opens in a new tab or window)
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </label>
+            </div>
+            <div
+              class="euiFormRow__fieldWrapper"
+            >
+              <div
+                class="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+                id="random_html_id"
+              >
+                <div
+                  class="euiFlexItem euiFlexItem--flexGrowZero"
+                >
+                  <div
+                    class="euiFormControlLayout euiFormControlLayout--compressed"
+                  >
+                    <div
+                      class="euiFormControlLayout__childrenWrapper"
+                    >
+                      <input
+                        class="euiFieldNumber euiFieldNumber--compressed"
+                        data-test-subj="windowDelay"
+                        id="windowDelay"
+                        name="windowDelay"
+                        placeholder="Window delay"
+                        type="number"
+                        value="1"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="euiFlexItem"
+                >
+                  <div
+                    class="euiText euiText--medium"
+                  >
+                    <p
+                      class="minutes"
+                    >
+                      minutes
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="euiSpacer euiSpacer--l"
+    />
+    <div
+      class="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusMedium euiPanel--plain euiPanel--hasShadow"
+      style="padding: 20px;"
+    >
+      <div
+        class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+        style="padding: 0px;"
+      >
+        <div
+          class="euiFlexItem"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
+            data-test-subj="contentPanelTitle"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <h2
+                class="euiTitle euiTitle--small"
+                id="resultIndexField"
+              >
+                Custom result index
+              </h2>
+            </div>
+          </div>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem content-panel-subTitle"
+              style="line-height: normal; max-width: 75%;"
+            >
+              <div
+                class="euiText euiText--medium content-panel-subTitle"
+                style="line-height: normal;"
+              >
+                Store detector results to your own index.
+                 
+                <a
+                  class="euiLink euiLink--primary"
+                  href="https://opensearch.org/docs/monitoring-plugins/ad"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more
+                  <svg
+                    aria-label="External link"
+                    class="euiIcon euiIcon--small euiLink__externalIcon"
+                    focusable="false"
+                    height="16"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M13 8.5a.5.5 0 1 1 1 0V12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h3.5a.5.5 0 0 1 0 1H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V8.5Zm-5.12.339a.5.5 0 1 1-.706-.707L13.305 2H10.5a.5.5 0 1 1 0-1H14a1 1 0 0 1 1 1v3.5a.5.5 0 1 1-1 0V2.72L7.88 8.838Z"
+                    />
+                  </svg>
+                  <span
+                    class="euiScreenReaderOnly"
+                  >
+                    (opens in a new tab or window)
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="euiFlexItem euiFlexItem--flexGrowZero"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterMedium euiFlexGroup--alignItemsCenter euiFlexGroup--justifyContentSpaceBetween euiFlexGroup--directionRow euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+      <div>
+        <hr
+          class="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
+        />
+        <div
+          style="padding: 10px 0px;"
+        >
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            >
+              <div
+                class="euiCheckbox euiCheckbox--compressed"
+              >
+                <input
+                  class="euiCheckbox__input"
+                  disabled=""
+                  id="resultIndexCheckbox"
+                  type="checkbox"
+                />
+                <div
+                  class="euiCheckbox__square"
+                />
+                <label
+                  class="euiCheckbox__label"
+                  for="resultIndexCheckbox"
+                >
+                  Enable custom result index
+                </label>
+              </div>
+            </div>
+          </div>
+          <div
+            class="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
+          >
+            <div
+              class="euiFlexItem"
+            />
+            <div
+              class="euiFlexItem"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<DefineDetector /> empty creating detector definition renders the component 1`] = `
 <div
   class="euiPage euiPage--paddingMedium euiPage--grow"

--- a/public/redux/reducers/__tests__/utils.ts
+++ b/public/redux/reducers/__tests__/utils.ts
@@ -92,7 +92,8 @@ export const getUIMetadata = (features: FeatureAttributes[]) => {
 
 export const getRandomDetector = (
   isCreate: boolean = true,
-  customResultIndex: string = ''
+  customResultIndex: string = '',
+  indices: string[] = ['logstash-*']
 ): Detector => {
   const features = new Array(detectorFaker.natural({ min: 1, max: 5 }))
     .fill(null)
@@ -104,7 +105,7 @@ export const getRandomDetector = (
     name: detectorFaker.word({ length: 10 }),
     description: detectorFaker.paragraph({ sentences: 1 }),
     timeField: '@timestamp',
-    indices: ['logstash-*'],
+    indices: indices,
     featureAttributes: features,
     filterQuery: randomQuery(),
     uiMetadata: getUIMetadata(features),

--- a/release-notes/opensearch-anomaly-detection-dashboards.release-notes-3.0.0.0-beta1.md
+++ b/release-notes/opensearch-anomaly-detection-dashboards.release-notes-3.0.0.0-beta1.md
@@ -9,6 +9,7 @@ Compatible with OpenSearch Dashboards 3.0.0.0-beta1
 - Switching fieldcaps api to utilize js client ([#984](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/984))
 - Update namespace for alerting plugin to avoid conflict with alerting ([#1003](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1003))
 - Fix remote cluster bug when remote and local have same name ([#1007](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1007))
+- Display selected clusters correctly on edit page ([#1011](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1011))
 
 ### Infrastructure
 - change gradle run to dualcluster is true ([#998](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/998))


### PR DESCRIPTION
### Description
Added clusters definition when converting from detector object to formik props so the clusters will show up correctly when editing a detector

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
