### PR TITLE
fix: Anomaly detection features count locked at 5

### DIFF
--- a/public/pages/ConfigureModel/components/Features/Features.tsx
+++ b/public/pages/ConfigureModel/components/Features/Features.tsx
@@ -23,11 +23,14 @@ import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 
 import { get } from 'lodash';
 import React, { Fragment, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import ContentPanel from '../../../../components/ContentPanel/ContentPanel';
 import { Detector } from '../../../../models/interfaces';
-import { initialFeatureValue } from '../../utils/helpers';
-import { MAX_FEATURE_NUM, BASE_DOCS_LINK } from '../../../../utils/constants';
+import { initialFeatureValue, getMaxFeatureLimit } from '../../utils/helpers';
+import { BASE_DOCS_LINK } from '../../../../utils/constants';
 import { FeatureAccordion } from '../FeatureAccordion';
+import { getClustersSetting } from '../../../../redux/reducers/opensearch';
+import { AppState } from '../../../../redux/reducers';
 
 interface FeaturesProps {
   detector: Detector | undefined;
@@ -35,6 +38,19 @@ interface FeaturesProps {
 }
 
 export function Features(props: FeaturesProps) {
+  const dispatch = useDispatch();
+  const anomalySettings = useSelector(
+      (state: AppState) => state.opensearch.settings
+  );
+
+  useEffect(() => {
+    const getSettingResult = async () => {
+      await dispatch(getClustersSetting());
+    };
+    getSettingResult();
+  }, []);
+
+
   // If the features list is empty: push a default initial one
   useEffect(() => {
     if (get(props, 'formikProps.values.featureList', []).length === 0) {
@@ -88,7 +104,7 @@ export function Features(props: FeaturesProps) {
                   <EuiFlexItem grow={false}>
                     <EuiSmallButton
                       data-test-subj="addFeature"
-                      isDisabled={values.featureList.length >= MAX_FEATURE_NUM}
+                      isDisabled={values.featureList.length >= getMaxFeatureLimit(anomalySettings)}
                       onClick={() => {
                         push(initialFeatureValue());
                       }}
@@ -99,7 +115,7 @@ export function Features(props: FeaturesProps) {
                       <p>
                         You can add up to{' '}
                         {Math.max(
-                          MAX_FEATURE_NUM - values.featureList.length,
+                          getMaxFeatureLimit(anomalySettings) - values.featureList.length,
                           0
                         )}{' '}
                         more features.

--- a/public/pages/ConfigureModel/utils/helpers.ts
+++ b/public/pages/ConfigureModel/utils/helpers.ts
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-import { DATA_TYPES, DEFAULT_SHINGLE_SIZE } from '../../../utils/constants';
+import { DATA_TYPES, DEFAULT_SHINGLE_SIZE, MAX_FEATURE_NUM } from '../../../utils/constants';
 import {
   FEATURE_TYPE,
   FeatureAttributes,
@@ -40,6 +40,7 @@ import {
   Action,
 } from '../../../models/types';
 import { SparseDataOptionValue } from './constants';
+import { ClusterSetting } from 'server/models/types';
 
 export const getFieldOptions = (
   allFields: { [key: string]: string[] },
@@ -711,3 +712,15 @@ export const rulesToFormik = (
   );
   return finalRules;
 };
+
+export function getMaxFeatureLimit(
+  settings: ClusterSetting[]
+) {
+  if (!settings || settings.length === 0) {
+    return MAX_FEATURE_NUM;
+  }
+  const maxFeatureSetting = settings.find(
+    (setting) => setting.name === 'max_anomaly_features'
+  );
+  return maxFeatureSetting ? parseInt(maxFeatureSetting.value, 10) : MAX_FEATURE_NUM;
+}

--- a/public/redux/reducers/opensearch.ts
+++ b/public/redux/reducers/opensearch.ts
@@ -21,6 +21,7 @@ import { getPathsPerDataType } from './mapper';
 import {
   CatIndex,
   ClusterInfo,
+  ClusterSetting,
   IndexAlias,
 } from '../../../server/models/types';
 import { AD_NODE_API } from '../../../utils/constants';
@@ -35,6 +36,7 @@ const BULK = 'opensearch/BULK';
 const DELETE_INDEX = 'opensearch/DELETE_INDEX';
 const GET_CLUSTERS_INFO = 'opensearch/GET_CLUSTERS_INFO';
 const GET_INDICES_AND_ALIASES = 'opensearch/GET_INDICES_AND_ALIASES';
+const GET_CLUSTERS_SETTING = 'opensearch/GET_CLUSTERS_SETTING';
 
 export type Mappings = {
   [key: string]: any;
@@ -69,6 +71,7 @@ interface OpenSearchState {
   searchResult: object;
   errorMessage: string;
   clusters: ClusterInfo[];
+  settings: ClusterSetting[];
 }
 
 export const initialState: OpenSearchState = {
@@ -299,6 +302,31 @@ const reducer = handleActions<OpenSearchState>(
         errorMessage: get(action, 'error.error', action.error),
       }),
     },
+    [GET_CLUSTERS_SETTING]: {
+      REQUEST: (state: OpenSearchState): OpenSearchState => {
+        return { ...state, requesting: true, errorMessage: '' };
+      },
+      SUCCESS: (
+        state: OpenSearchState,
+        action: APIResponseAction
+      ): OpenSearchState => {
+        return {
+          ...state,
+          requesting: false,
+          settings: get(action, 'result.response.settings', []),
+        };
+      },
+      FAILURE: (
+        state: OpenSearchState,
+        action: APIErrorAction
+      ): OpenSearchState => {
+        return {
+          ...state,
+          requesting: false,
+          errorMessage: get(action, 'error.error', action.error),
+      }
+      },
+    },
   },
   initialState
 );
@@ -323,6 +351,14 @@ export const getClustersInfo = (dataSourceId: string = ''): APIAction => {
   return {
     type: GET_CLUSTERS_INFO,
     request: (client: HttpSetup) => client.get(url),
+  };
+};
+
+export const getClustersSetting = (): APIAction => {
+  const baseUrl = `..${AD_NODE_API.GET_CLUSTERS_SETTING}`;
+  return {
+    type: GET_CLUSTERS_SETTING,
+    request: (client: HttpSetup) => client.get(baseUrl),
   };
 };
 

--- a/server/models/types.ts
+++ b/server/models/types.ts
@@ -22,6 +22,11 @@ export type ClusterInfo = {
   localCluster: boolean;
 }
 
+export type ClusterSetting = {
+  name: string;
+  value: string;
+}
+
 export type IndexAlias = {
   index: string[] | string;
   alias: string;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -23,6 +23,7 @@ export const AD_NODE_API = Object.freeze({
   CREATE_SAMPLE_DATA: `${BASE_NODE_API_PATH}/create_sample_data`,
   GET_CLUSTERS_INFO: `${BASE_NODE_API_PATH}/_remote/info`,
   GET_INDICES_AND_ALIASES: `${BASE_NODE_API_PATH}/_indices_and_aliases`,
+  GET_CLUSTERS_SETTING: `${BASE_NODE_API_PATH}/_cluster/settings`,
 });
 export const ALERTING_NODE_API = Object.freeze({
   _SEARCH: `${BASE_NODE_API_PATH}/monitors/_search`,


### PR DESCRIPTION
### Description

Remove hardcoded maximum features, get the limit from anomaly detection setting API instead

### Issues Resolved
Fix #1016

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
