### PR TITLE
Improve Create Forecaster UI and cleanup logs

### DIFF
--- a/public/pages/ConfigureForecastModel/components/AdvancedSettings/AdvancedSettings.tsx
+++ b/public/pages/ConfigureForecastModel/components/AdvancedSettings/AdvancedSettings.tsx
@@ -51,13 +51,6 @@ interface AdvancedSettingsProps {
 export function AdvancedSettings({ isEditable = true }: AdvancedSettingsProps) {
   const [showAdvancedSettings, setShowAdvancedSettings] = useState<boolean>(false);
 
-  const sparseDataOptions = [
-    { value: SparseDataOptionValue.IGNORE, text: 'Ignore missing value' },
-    { value: SparseDataOptionValue.PREVIOUS_VALUE, text: 'Previous value' },
-    { value: SparseDataOptionValue.SET_TO_ZERO, text: 'Set to zero' },
-    { value: SparseDataOptionValue.CUSTOM_VALUE, text: 'Custom value' },
-  ];
-
   return (
     <ContentPanel
       title={
@@ -250,94 +243,6 @@ export function AdvancedSettings({ isEditable = true }: AdvancedSettingsProps) {
             )}
           </Field>
 
-          {/* ---------------- Sparse data handling ---------------- */}
-          <Field
-            name="imputationOption.imputationMethod"
-            id="imputationOption.imputationMethod"
-          >
-            {({ field, form }: FieldProps) => {
-              // If "Custom value" is selected, ensure at least one row is present
-              useEffect(() => {
-                if (
-                  field.value === SparseDataOptionValue.CUSTOM_VALUE &&
-                  (!form.values.imputationOption?.custom_value ||
-                    form.values.imputationOption.custom_value.length === 0)
-                ) {
-                  form.setFieldValue('imputationOption.custom_value', [
-                    { featureName: '', value: undefined },
-                  ]);
-                }
-              }, [field.value, form]);
-
-              return (
-                <>
-                  <FormattedFormRow
-                    fullWidth
-                    title="Sparse data handling"
-                    hint={[`Choose how to handle missing data points.`]}
-                    hintLink={FORECASTER_DOCS_LINK}
-                    isInvalid={isInvalid(field.name, form)}
-                    error={getError(field.name, form)}
-                  >
-                    <div style={{ maxWidth: FIELD_MAX_WIDTH }}>
-                      <EuiCompressedSelect 
-                        {...field} 
-                        options={sparseDataOptions}
-                        disabled={!isEditable}
-                      />
-                    </div>
-                  </FormattedFormRow>
-
-                  {field.value === SparseDataOptionValue.CUSTOM_VALUE && (
-                    <div style={{ maxWidth: FIELD_MAX_WIDTH }}>
-                      <EuiSpacer size="m" />
-                      <EuiText size="xs">
-                        <h5>Custom value</h5>
-                      </EuiText>
-                      <EuiSpacer size="s" />
-                      <FieldArray name="imputationOption.custom_value">
-                        {(arrayHelpers) => (
-                          <>
-                            {form.values.imputationOption.custom_value?.map(
-                              (_, index) => (
-                                <EuiFlexGroup
-                                  key={index}
-                                  gutterSize="s"
-                                  alignItems="center"
-                                >
-                                  <EuiFlexItem grow={false}>
-                                    <Field
-                                      name={`imputationOption.custom_value.${index}.data`}
-                                      id={`imputationOption.custom_value.${index}.data`}
-                                    >
-                                      {({ field }: FieldProps) => (
-                                        <div style={{ width: INPUT_SLIDER_WIDTH }}>
-                                          <EuiCompressedFieldNumber
-                                            style={{ width: '100%' }}
-                                            placeholder="Custom value"
-                                            name={field.name}
-                                            disabled={!isEditable}
-                                            onChange={(e) => {
-                                              form.setFieldValue(field.name, toNumberOrEmpty(e.target.value));
-                                            }}
-                                            value={field.value || ''}
-                                          />
-                                        </div>
-                                      )}
-                                    </Field>
-                                  </EuiFlexItem>
-                                </EuiFlexGroup>
-                              )
-                            )}
-                          </>
-                        )}
-                      </FieldArray>
-                    </div>
-                  )}
-                </>
-              );
-            }}
-          </Field>
         </>
       ) : null}
     </ContentPanel>

--- a/public/pages/ConfigureForecastModel/components/AdvancedSettings/__tests__/AdvancedSettings.test.tsx
+++ b/public/pages/ConfigureForecastModel/components/AdvancedSettings/__tests__/AdvancedSettings.test.tsx
@@ -186,109 +186,6 @@ describe('AdvancedSettings Component', () => {
     });
   });
 
-  describe('Sparse data handling', () => {
-    beforeEach(() => {
-      renderWithFormik();
-      expandPanel();
-    });
-
-    test('renders sparse data handling dropdown with all options', () => {
-      const dropdown = screen.getByDisplayValue('Ignore missing value');
-      
-      expect(dropdown).toBeInTheDocument();
-      expect(screen.getByText('Choose how to handle missing data points.')).toBeInTheDocument();
-    });
-
-    test('shows all sparse data options', () => {
-      const dropdown = screen.getByDisplayValue('Ignore missing value');
-      
-      // Check that all options are available in the select
-      expect(dropdown.querySelector('option[value="ignore"]')).toBeInTheDocument();
-      expect(dropdown.querySelector('option[value="previous_value"]')).toBeInTheDocument();
-      expect(dropdown.querySelector('option[value="set_to_zero"]')).toBeInTheDocument();
-      expect(dropdown.querySelector('option[value="custom_value"]')).toBeInTheDocument();
-    });
-
-    test('changes sparse data handling option', () => {
-      const dropdown = screen.getByDisplayValue('Ignore missing value');
-      
-      fireEvent.change(dropdown, { target: { value: SparseDataOptionValue.PREVIOUS_VALUE } });
-      expect(dropdown).toHaveValue(SparseDataOptionValue.PREVIOUS_VALUE);
-    });
-
-    test('shows custom value section when custom value is selected', () => {
-      const dropdown = screen.getByDisplayValue('Ignore missing value');
-      
-      fireEvent.change(dropdown, { target: { value: SparseDataOptionValue.CUSTOM_VALUE } });
-      
-      expect(screen.getByRole('heading', { level: 5, name: 'Custom value' })).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('Custom value')).toBeInTheDocument();
-    });
-
-    test('hides custom value section when other options are selected', () => {
-      // First select custom value
-      const dropdown = screen.getByDisplayValue('Ignore missing value');
-      fireEvent.change(dropdown, { target: { value: SparseDataOptionValue.CUSTOM_VALUE } });
-      expect(screen.getByRole('heading', { level: 5, name: 'Custom value' })).toBeInTheDocument();
-      
-      // Then select a different option
-      fireEvent.change(dropdown, { target: { value: SparseDataOptionValue.SET_TO_ZERO } });
-      expect(screen.queryByRole('heading', { level: 5, name: 'Custom value' })).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Custom value functionality', () => {
-    test('automatically adds custom value field when custom value option is selected', () => {
-      const initialValues = {
-        ...defaultInitialValues,
-        imputationOption: {
-          imputationMethod: SparseDataOptionValue.CUSTOM_VALUE,
-          custom_value: [],
-        },
-      };
-      
-      renderWithFormik(initialValues);
-      expandPanel();
-      
-      expect(screen.getByRole('heading', { level: 5, name: 'Custom value' })).toBeInTheDocument();
-      expect(screen.getByPlaceholderText('Custom value')).toBeInTheDocument();
-    });
-
-    test('custom value input accepts numeric values', async () => {
-      const initialValues = {
-        ...defaultInitialValues,
-        imputationOption: {
-          imputationMethod: SparseDataOptionValue.CUSTOM_VALUE,
-          custom_value: [{ data: '' }],
-        },
-      };
-      
-      renderWithFormik(initialValues);
-      expandPanel();
-      
-      const customValueInput = screen.getByPlaceholderText('Custom value');
-      fireEvent.change(customValueInput, { target: { value: '42.5' } });
-      
-      expect((customValueInput as HTMLInputElement).value).toBe('42.5');
-    });
-
-    test('custom value field is disabled when not editable', () => {
-      const initialValues = {
-        ...defaultInitialValues,
-        imputationOption: {
-          imputationMethod: SparseDataOptionValue.CUSTOM_VALUE,
-          custom_value: [{ data: '' }],
-        },
-      };
-      
-      renderWithFormik(initialValues, { isEditable: false });
-      expandPanel();
-      
-      const customValueInput = screen.getByPlaceholderText('Custom value');
-      expect(customValueInput).toBeDisabled();
-    });
-  });
-
   describe('Form integration', () => {
     test('handles empty string values for numeric fields', () => {
       renderWithFormik();
@@ -315,10 +212,6 @@ describe('AdvancedSettings Component', () => {
         shingleSize: 16,
         suggestedSeasonality: 24,
         recencyEmphasis: 2560,
-        imputationOption: {
-          imputationMethod: SparseDataOptionValue.PREVIOUS_VALUE,
-          custom_value: [],
-        },
       };
       
       renderWithFormik(initialValues);
@@ -327,7 +220,6 @@ describe('AdvancedSettings Component', () => {
       expect((screen.getByTestId('shingleSize') as HTMLInputElement).value).toBe('16');
       expect((screen.getByTestId('suggestedSeasonality') as HTMLInputElement).value).toBe('24');
       expect((screen.getByTestId('recencyEmphasis') as HTMLInputElement).value).toBe('2560');
-      expect(screen.getByDisplayValue('Previous value')).toBeInTheDocument();
     });
   });
 
@@ -340,7 +232,6 @@ describe('AdvancedSettings Component', () => {
       expect(screen.getByText('Shingle size')).toBeInTheDocument();
       expect(screen.getByText('Suggested seasonality')).toBeInTheDocument();
       expect(screen.getAllByText('Recency emphasis')[0]).toBeInTheDocument();
-      expect(screen.getByText('Sparse data handling')).toBeInTheDocument();
     });
 
     test('shows unit badges for numeric fields', () => {
@@ -358,7 +249,6 @@ describe('AdvancedSettings Component', () => {
       expect(screen.getByTestId('shingleSize')).toBeDisabled();
       expect(screen.getByTestId('suggestedSeasonality')).toBeDisabled();
       expect(screen.getByTestId('recencyEmphasis')).toBeDisabled();
-      expect(screen.getByDisplayValue('Ignore missing value')).toBeDisabled();
     });
   });
 });

--- a/public/pages/DefineForecaster/containers/DefineForecaster.tsx
+++ b/public/pages/DefineForecaster/containers/DefineForecaster.tsx
@@ -369,6 +369,7 @@ export const DefineForecaster = (props: DefineForecasterProps) => {
                     isLoading={isLoading}
                     formikProps={formikProps}
                   />
+                  <EuiSpacer />
                 </Fragment>
               </div>
             </EuiPageBody>

--- a/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
+++ b/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
@@ -706,13 +706,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
             timestamp: now
           };
         }
-      } else {
-        console.log('Skipping change', {
-          timeSinceLastUpdate,
-          currentStart: windowStart,
-          newStart: newWindowStart,
-          diff: Math.abs(newWindowStart - lastUpdate.windowStart)
-        });
       }
     }
   }, [maxPoints, uniqueTimestamps]);

--- a/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
+++ b/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
@@ -191,10 +191,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
 
   // useEffect for datePickerRange
   useEffect(() => {
-    console.log('[EFFECT-1] datePickerRange update', {
-      startDate: dateRange.startDate,
-      endDate: dateRange.endDate
-    });
 
     setDatePickerRange({
       start: dateRange.startDate.toString(),
@@ -219,7 +215,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
           const startTimestamp = startTime.valueOf();
           const endTimestamp = endTime.valueOf();
 
-          console.log('startTime', startTimestamp, 'endTime', endTimestamp);
           // handleDateRangeChange(startTimestamp, endTimestamp, start, end);
 
           // Convert the current dateRange to absolute timestamps for comparison
@@ -231,10 +226,8 @@ export const ForecastChart: FC<ForecastChartProps> = ({
             startTimestamp >= currentStartTimestamp &&
             endTimestamp <= currentEndTimestamp
           ) {
-            console.log('handleZoomRangeChange');
             handleZoomRangeChange(startTimestamp, endTimestamp, start, end);
           } else {
-            console.log('handleDateRangeChange');
             handleDateRangeChange(startTimestamp, endTimestamp, start, end);
           }
         }
@@ -390,14 +383,9 @@ export const ForecastChart: FC<ForecastChartProps> = ({
 
   // Replace the existing effect with this optimized version
   useEffect(() => {
-    console.log('[EFFECT-4] selectedForecasts update', {
-      selectedForecasts: selectedForecasts,
-      forecastTo: forecastTo
-    });
     // Skip if there are no selected forecasts
     if (selectedForecasts.length === 0) {
       if (forecastTo !== undefined) {
-        console.log('[EFFECT-4] Clearing forecastTo (no selected forecasts)');
         setForecastTo(undefined);
       }
       prevSelectedForecastsRef.current = selectedForecasts;
@@ -411,11 +399,8 @@ export const ForecastChart: FC<ForecastChartProps> = ({
       JSON.stringify(prevForecasts) !== JSON.stringify(selectedForecasts);
 
     if (!hasChanged) {
-      console.log('[EFFECT-4] Skipping - selectedForecasts unchanged');
       return; // Skip processing if selectedForecasts hasn't changed
     }
-
-    console.log('[EFFECT-4] Processing new selectedForecasts');
 
     // Grab the first forecast run
     const firstRun = selectedForecasts[0];
@@ -435,7 +420,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
 
     // Only update state if the value has actually changed
     if (forecastTo !== newForecastTo) {
-      console.log('[EFFECT-4] Setting forecastTo', { from: forecastTo, to: newForecastTo });
       setForecastTo(newForecastTo);
     }
 
@@ -663,7 +647,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
     // Extract and sort all unique timestamps
     const uniqueXValues = Array.from(new Set(combinedData.map(d => d.x))).sort((a, b) => a - b);
 
-    console.log('Unique timestamps count:', uniqueXValues.length, 'Total data points:', combinedData.length);
     return uniqueXValues;
   }, [combinedData]);
 
@@ -708,17 +691,7 @@ export const ForecastChart: FC<ForecastChartProps> = ({
           !isSmallRapidWindowStartChange
         );
 
-      console.log('shouldUpdate', shouldUpdate, 'noChange:', noChange, 'newWindowSize:', newWindowSize, 'windowSize:', windowSize, 'newWindowStart:', newWindowStart, 'windowStart:', windowStart, timeSinceLastUpdate, now,
-        lastUpdate.timestamp, total, maxPoints);
-
       if (shouldUpdate) {
-        console.log('[EFFECT-3] Setting window values', {
-          fromSize: windowSize,
-          toSize: newWindowSize,
-          fromStart: windowStart,
-          toStart: newWindowStart,
-          timeSinceLastUpdate
-        });
 
         // Update the state
         setWindow({
@@ -734,7 +707,7 @@ export const ForecastChart: FC<ForecastChartProps> = ({
           };
         }
       } else {
-        console.log('[EFFECT-3] Skipping change', {
+        console.log('Skipping change', {
           timeSinceLastUpdate,
           currentStart: windowStart,
           newStart: newWindowStart,
@@ -772,14 +745,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
     // Filter combinedData to only include rows with x values in our window
     const data = combinedData.filter(
       row => row.x >= minTimestamp && row.x <= maxTimestamp
-    );
-
-    console.log(
-      'windowedData',
-      'Unique timestamps in window:', timestampSlice.length,
-      'Total rows in window:', data.length,
-      'Window start:', windowStart,
-      'Window size:', windowSize
     );
 
     return data;
@@ -900,7 +865,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
   // Disable zoom out when the window size already covers all unique timestamps
   // or when it reaches the maximum allowed points (maxPoints).
   const disableZoomOut = windowSize >= Math.min(uniqueTimestamps.length, maxPoints);
-  console.log('disabledZoomOut', windowSize, combinedData.length, maxPoints);
 
   // Check if current state is active AND the selected forecast is the latest
   const isLive = isActiveState(forecaster?.curState) &&
@@ -1322,7 +1286,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
       const intervalInMs = forecaster.forecastInterval.period.interval * 60000;
       setIntervalMilliseconds(intervalInMs);
 
-      console.log(`[ForecastChart] Updated interval milliseconds: ${intervalInMs}ms (${forecaster.forecastInterval.period.interval} minutes)`);
     }
   }, [forecaster]); // Re-run when forecaster changes
 
@@ -1374,10 +1337,6 @@ export const ForecastChart: FC<ForecastChartProps> = ({
         index.timeSlots[slotKey][entityId].push(point);
       });
     });
-
-    console.log('Built spatial index with',
-      Object.keys(index.timeSlots).length, 'time slots,',
-      'time range:', new Date(index.minTime).toISOString(), 'to', new Date(index.maxTime).toISOString());
 
     return index;
   }, [intervalMilliseconds]);

--- a/public/pages/ForecastersList/containers/ConfirmActionModals/ForecasterActionsCell.tsx
+++ b/public/pages/ForecastersList/containers/ConfirmActionModals/ForecasterActionsCell.tsx
@@ -39,7 +39,6 @@ import { ConfirmTestForecasterModal } from "./ConfirmTestForecasterModal";
 interface ForecasterActionsCellProps {
     rowIndex: number;
     forecastersToDisplay: ForecasterListItem[];
-    // allMonitors: { [key: string]: Monitor };
     confirmModalState: ConfirmModalState;
     setConfirmModalState: (state: any) => void;
     setIsLoadingFinalForecasters: (state: boolean) => void;

--- a/release-notes/opensearch-anomaly-detection-dashboards.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-anomaly-detection-dashboards.release-notes-3.1.0.0.md
@@ -6,6 +6,7 @@ Compatible with OpenSearch Dashboards 3.1.0.0
 - Fix a MDS bug ([#1039](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1039))
 - Improve validation, error display, and run-once state handling ([#1047](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1047))
 - surface “missing data” error in test mode ([#1050](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1050))
+- Improve Create Forecaster UI and cleanup logs ([#1052](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1052))
 
 ### Enhancements
 - Enable contextual launch in MDS OpenSearch UI ([#1041](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1041))


### PR DESCRIPTION
### Description

- Add spacing between the Create Forecaster form and footer for easier interaction.
- Remove unsupported Sparse Data Handling option from forecasting UI.
- Clean up unnecessary console.log statements.

Testing done:
- manual test

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
