### PR TITLE
Allow stopping forecaster from FORECAST_FAILURE state and minor cleanups

### DIFF
--- a/public/pages/DefineForecaster/components/FeaturePanel/FeaturePanel.tsx
+++ b/public/pages/DefineForecaster/components/FeaturePanel/FeaturePanel.tsx
@@ -77,7 +77,7 @@ export const FeaturePanel = (props: FeatureProps) => {
           >
             <EuiCompressedFieldText
               data-test-subj={`featureNameTextInput-${index}`}
-              placeholder="Enter feature name"
+              placeholder="Enter indicator name"
               {...field}
               disabled={!isEditable}
               // Ensure value is always a defined string to prevent React warning about

--- a/public/pages/DefineForecaster/utils/helpers.ts
+++ b/public/pages/DefineForecaster/utils/helpers.ts
@@ -401,7 +401,7 @@ export const validateFeatures = (values: any) => {
       // @ts-ignore
       if (featureNameCount.get(attribute.featureName.toLowerCase()) > 1) {
         hasError = true;
-        return { featureName: 'Duplicate feature name' };
+        return { featureName: 'Duplicate indicator name' };
       } else {
         return undefined;
       }
@@ -409,7 +409,7 @@ export const validateFeatures = (values: any) => {
       hasError = true;
       // @ts-ignore
       return {
-        featureName: 'You must enter a feature name',
+        featureName: 'You must enter an indicator name',
       };
     }
   });

--- a/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
+++ b/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
@@ -42,6 +42,7 @@ import {
   EuiSwitch,
   EuiIconTip,
   EuiSmallButtonEmpty,
+  EuiSmallButtonIcon,
 } from '@elastic/eui';
 import {
   Chart,

--- a/public/pages/ForecastDetail/utils/helpers.ts
+++ b/public/pages/ForecastDetail/utils/helpers.ts
@@ -38,7 +38,6 @@ export function configureToFormik(
   forecaster: Forecaster,
   allClusters: ClusterInfo[]
 ): ConfigureFormikValues {
-  console.log('forecaster', forecaster);
   const imputationFormikValues = createImputationFormikValues(forecaster);
 
   // Extract indices and handle undefined case
@@ -72,8 +71,6 @@ export function configureToFormik(
     extractedClusters = undefined;
   }
 
-  console.log('extractedClusters', extractedClusters);
-
   return {
     // index: [...indices.map(indexObj => indexObj.label)],
     index: [...indices.map(index => ({ label: index }))],
@@ -104,10 +101,6 @@ export function formikToForecaster(
   detailsValues: DetailsFormikValues,
   forecaster: Forecaster
 ): Forecaster {
-  console.log('configureValues', configureValues);
-  console.log('detailsValues', detailsValues);
-  console.log('categoryFieldEnabled:', configureValues.categoryFieldEnabled);
-  console.log('categoryField:', configureValues.categoryField);
   
   let forecasterBody = {
     ...forecaster,
@@ -156,7 +149,6 @@ export function formikToForecaster(
     horizon: configureValues.horizon,
     history: configureValues.history,
   } as Forecaster;
-  console.log('forecasterBody', forecasterBody);
 
   return forecasterBody;
 }

--- a/public/pages/ForecastersList/containers/ConfirmActionModals/ForecasterActionsCell.tsx
+++ b/public/pages/ForecastersList/containers/ConfirmActionModals/ForecasterActionsCell.tsx
@@ -149,7 +149,6 @@ export function ForecasterActionsCell(props: ForecasterActionsCellProps) {
                 FORECASTER_STATE.INACTIVE_STOPPED,
                 FORECASTER_STATE.INACTIVE_NOT_STARTED,
                 FORECASTER_STATE.INIT_ERROR,
-                FORECASTER_STATE.FORECAST_FAILURE,
                 FORECASTER_STATE.INIT_TEST_FAILED,
                 FORECASTER_STATE.TEST_COMPLETE,
             ].includes(forecasterState)
@@ -171,6 +170,7 @@ export function ForecasterActionsCell(props: ForecasterActionsCellProps) {
                 FORECASTER_STATE.AWAITING_DATA_TO_RESTART,
                 FORECASTER_STATE.INIT_TEST,
                 FORECASTER_STATE.INITIALIZING_FORECAST,
+                FORECASTER_STATE.FORECAST_FAILURE,
             ].includes(forecasterState)
         ) {
             return [

--- a/release-notes/opensearch-anomaly-detection-dashboards.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-anomaly-detection-dashboards.release-notes-3.1.0.0.md
@@ -7,6 +7,7 @@ Compatible with OpenSearch Dashboards 3.1.0.0
 - Improve validation, error display, and run-once state handling ([#1047](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1047))
 - surface “missing data” error in test mode ([#1050](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1050))
 - Improve Create Forecaster UI and cleanup logs ([#1052](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1052))
+- Allow stopping forecaster from FORECAST_FAILURE state and minor cleanups ([#1054](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1054))
 
 ### Enhancements
 - Enable contextual launch in MDS OpenSearch UI ([#1041](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1041))

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -227,7 +227,7 @@ export const isForecasterErrorState = (state: FORECASTER_STATE): boolean => {
 
 export function isActiveState(state: FORECASTER_STATE | undefined): boolean {
   if (!state) return false;
-  return state.startsWith('AWAITING_') || state === FORECASTER_STATE.RUNNING || state === FORECASTER_STATE.INITIALIZING_FORECAST;
+  return state.startsWith('AWAITING_') || state === FORECASTER_STATE.RUNNING || state === FORECASTER_STATE.INITIALIZING_FORECAST || state === FORECASTER_STATE.FORECAST_FAILURE;
 }
 
 export function isTestState(state: FORECASTER_STATE | undefined): boolean {


### PR DESCRIPTION
### Description

- Mark FORECAST_FAILURE as a non-ending state to enable stopping tasks from this state.
- Remove unnecessary console.log statements.
- Rename "feature" to "indicator" in UI for consistency.
- Add missing dependency EuiSmallButtonIcon.

Testing:
- Manually verified stopping forecaster works correctly from FORECAST_FAILURE state.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
