### PR TITLE
Wrap data filter in detector creation

### DIFF
--- a/public/pages/DefineDetector/components/DataFilterList/DataFilterList.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/DataFilterList.tsx
@@ -18,7 +18,6 @@ import {
 } from '@elastic/eui';
 import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 import React, { useState, Fragment } from 'react';
-import { get } from 'lodash';
 import { DetectorDefinitionFormikValues } from '../../models/interfaces';
 import { UIFilter, FILTER_TYPES } from '../../../../models/interfaces';
 import { DataFilter } from './components/DataFilter';
@@ -62,7 +61,13 @@ export const DataFilterList = (props: DataFilterListProps) => {
             >
               <Fragment>
                 <EuiSpacer size="m" />
-                <EuiFlexGroup direction="row" gutterSize="xs">
+                <EuiFlexGroup
+                  direction="row"
+                  gutterSize="xs"
+                  style={{
+                    flexWrap: 'wrap',
+                  }}
+                >
                   <EuiFlexItem grow={false}>
                     {values.filters?.length === 0 ||
                     (values.filters?.length === 1 && isCreatingNewFilter) ? (

--- a/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
+++ b/public/pages/DefineDetector/components/DataFilterList/components/DataFilter.tsx
@@ -207,6 +207,13 @@ export const DataFilter = (props: DataFilterProps) => {
         openPopover();
       }}
       onClickAriaLabel="onClick event for the button"
+      style={{
+        maxWidth: 'min(300px, 70vw)',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        display: 'inline-block',
+      }}
     >
       {labelToDisplay}
     </EuiBadge>

--- a/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
+++ b/public/pages/DefineDetector/containers/__tests__/__snapshots__/DefineDetector.test.tsx.snap
@@ -490,6 +490,7 @@ exports[`<DefineDetector /> Full creating detector definition renders the compon
               />
               <div
                 class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style="flex-wrap: wrap;"
               >
                 <div
                   class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -1651,6 +1652,7 @@ exports[`<DefineDetector /> FullEdit editing detector page renders the component
               />
               <div
                 class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style="flex-wrap: wrap;"
               >
                 <div
                   class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -2746,6 +2748,7 @@ exports[`<DefineDetector /> empty creating detector definition renders the compo
               />
               <div
                 class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style="flex-wrap: wrap;"
               >
                 <div
                   class="euiFlexItem euiFlexItem--flexGrowZero"
@@ -3840,6 +3843,7 @@ exports[`<DefineDetector /> empty editing detector definition renders the compon
               />
               <div
                 class="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
+                style="flex-wrap: wrap;"
               >
                 <div
                   class="euiFlexItem euiFlexItem--flexGrowZero"


### PR DESCRIPTION
### Description

When creating anomaly detectors with multiple data filters or long Query DSL filters, the Next button would disappear from the bottom of the page, preventing users from proceeding with detector creation. I added two fixes, one too truncate long filters with ... and also to wrap if we have lots of filters in a row

Screenshots:
![Screenshot 2025-06-30 at 2 05 26 PM](https://github.com/user-attachments/assets/ce468299-5efa-470b-a846-f82280134e69)
![Screenshot 2025-06-30 at 2 04 02 PM](https://github.com/user-attachments/assets/1a62cc8e-3141-4c36-9a23-22b850655a0a)


resolves #715 

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
