### PR TITLE
Hide data sources below 3.1 in forecasting pages

### DIFF
--- a/public/pages/DefineForecaster/containers/DefineForecaster.tsx
+++ b/public/pages/DefineForecaster/containers/DefineForecaster.tsx
@@ -61,7 +61,7 @@ import { DataSourceSelectableConfig, } from '../../../../../../src/plugins/data_
 import {
   constructHrefWithDataSourceId,
   getDataSourceFromURL,
-  isDataSourceCompatible,
+  isForecastingDataSourceCompatible,
 } from '../../utils/helpers';
 import queryString from 'querystring';
 import { Features } from '../components/Features/Features';
@@ -307,7 +307,7 @@ export const DefineForecaster = (props: DefineForecasterProps) => {
               notifications: getNotifications(),
               onSelectedDataSources: (dataSources) =>
                 handleDataSourceChange(dataSources),
-              dataSourceFilter: isDataSourceCompatible,
+              dataSourceFilter: isForecastingDataSourceCompatible,
             }}
           />
         );

--- a/public/pages/ForecastersList/components/ListFilters/ListFilters.tsx
+++ b/public/pages/ForecastersList/components/ListFilters/ListFilters.tsx
@@ -54,10 +54,6 @@ const getPlaceholderWithBadge = (label: string, count: number) => {
 
 // The ratio is now approximately 4:1:2 between search:status:index
 export const ListFilters = (props: ListFiltersProps) => {
-  console.log('ListFilters props:', {
-    selectedForecasterStates: props.selectedForecasterStates,
-    stateOptions: getForecasterStateOptions()
-  });
 
   return (
     <EuiFlexGroup gutterSize="s">
@@ -79,11 +75,9 @@ export const ListFilters = (props: ListFiltersProps) => {
           singleSelection={false}
           options={(() => {
             const options = getForecasterStateOptions();
-            console.log('State filter options:', options);
             return options;
           })()}
           onChange={(selectedOptions) => {
-            console.log('State filter onChange called with:', selectedOptions);
             props.onForecasterStateChange(selectedOptions);
             setTimeout(() => {
               console.log('After onForecasterStateChange, props are now:', props.selectedForecasterStates);

--- a/public/pages/ForecastersList/containers/List/List.tsx
+++ b/public/pages/ForecastersList/containers/List/List.tsx
@@ -61,7 +61,7 @@ import {
   getAllForecastersQueryParamsWithDataSourceId,
   getDataSourceFromURL,
   getVisibleOptions,
-  isDataSourceCompatible,
+  isForecastingDataSourceCompatible,
   sanitizeSearchText,
 } from '../../../utils/helpers';
 import { ListFilters } from '../../components/ListFilters/ListFilters';
@@ -573,7 +573,7 @@ export const ForecastersList = (props: ListProps) => {
             notifications: getNotifications(),
             onSelectedDataSources: (dataSources) =>
               handleDataSourceChange(dataSources),
-            dataSourceFilter: isDataSourceCompatible,
+            dataSourceFilter: isForecastingDataSourceCompatible,
           }}
         />
       );


### PR DESCRIPTION
### Description

In environments running OpenSearch versions lower than 3.1, the forecasting backend is not enabled. Without this guard, users would still see the incompatible data source in forecasting pages, click into it, and encounter backend errors. Previously, the compatibility check relied on supportedOSDataSourceVersions in opensearch_dashboards.json, but this was only applied at the plugin level. Since forecasting and Anomaly Detection share the same plugin, the existing minimum compatible version in data source (>=2.9.0) did not prevent <3.1 data sources from appearing on forecasting pages. This PR ensures that forecasting has its own data source compatibility check.

Also, while the isDataSourceCompatible helper was intended to filter unsupported data sources, it failed for supportedOSDataSourceVersions because the pluginManifest import returned an object with default as the root property. This caused checks like

'supportedOSDataSourceVersions' in pluginManifest

to always return false. Accessing pluginManifest.default.supportedOSDataSourceVersions via pluginManifest.hasOwnProperty('supportedOSDataSourceVersions')) fixes the logic so that unsupported versions are properly excluded.

Also, I need to change to default-import JSON 
`import manifest from '../../../opensearch_dashboards.json';` to fix jest unit test error. Use import pluginManifest from ... so we get the plain object in both the app and Jest. Previously import * as yielded an ES module namespace in Jest (no hasOwnProperty), causing TypeError: pluginManifest.hasOwnProperty is not a function in tests.

Testing done:
* Manual verification (see video) and UT.

https://github.com/user-attachments/assets/ac6d84b8-a15c-4101-8162-ee7e8aba2f10

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
