### PR TITLE
Honor detector frequency when flagging missing feature data

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -6,9 +6,9 @@ env:
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
-  OPENSEARCH_DASHBOARDS_VERSION: '3.2'
-  OPENSEARCH_VERSION: '3.2.0'
-  OPENSEARCH_PLUGIN_VERSION: '3.2.0.0'
+  OPENSEARCH_DASHBOARDS_VERSION: '3.3'
+  OPENSEARCH_VERSION: '3.3.0'
+  OPENSEARCH_PLUGIN_VERSION: '3.3.0.0'
 
 jobs:
   tests:

--- a/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/FeatureChart.tsx
@@ -63,6 +63,7 @@ interface FeatureChartProps {
   edit?: boolean;
   onEdit?(): void;
   detectorInterval: Schedule;
+  detectorFrequency: Schedule;
   showFeatureMissingDataPointAnnotation?: boolean;
   detectorEnabledTime?: number;
   rawFeatureData: FeatureAggregationData[][];
@@ -237,7 +238,8 @@ export const FeatureChart = (props: FeatureChartProps) => {
                     ),
                     props.dateRange,
                     // date range is selected by customer in UX so window delay time is not considered
-                    false
+                    false,
+                    props.detectorFrequency.interval
                   )}
                   marker={<EuiIcon type="alert" />}
                   style={{

--- a/public/pages/AnomalyCharts/components/FeatureChart/__tests__/FeatureChart.missingData.test.tsx
+++ b/public/pages/AnomalyCharts/components/FeatureChart/__tests__/FeatureChart.missingData.test.tsx
@@ -1,0 +1,234 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { FeatureChart } from '../FeatureChart';
+import {
+  DateRange,
+  EntityData,
+  FeatureAggregationData,
+  FeatureAttributes,
+  FEATURE_TYPE,
+  Schedule,
+  UNITS,
+} from '../../../../../models/interfaces';
+
+const mockLineAnnotationSpy = jest.fn();
+
+jest.mock('@elastic/charts', () => {
+  const React = require('react');
+  return {
+    Chart: ({ children }: any) => <div data-test-subj="chart">{children}</div>,
+    Axis: () => null,
+    LineSeries: () => null,
+    RectAnnotation: () => null,
+    Settings: () => null,
+    Position: { Right: 'Right' },
+    ScaleType: { Time: 'time', Linear: 'linear' },
+    niceTimeFormatter: () => () => '',
+    timeFormatter: () => () => '',
+    AnnotationDomainType: { XDomain: 'xDomain' },
+    LineAnnotation: (props: any) => {
+      mockLineAnnotationSpy(props);
+      if (!props.dataValues || props.dataValues.length === 0) {
+        return null;
+      }
+      return (
+        <div
+          data-test-subj="line-annotation"
+          data-values-length={props.dataValues?.length ?? 0}
+        />
+      );
+    },
+  };
+});
+
+jest.mock('../../../../../components/ContentPanel/ContentPanel', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="content-panel">{children}</div>
+  ),
+}));
+
+jest.mock('../../../../../hooks/useDelayedLoader', () => ({
+  useDelayedLoader: () => false,
+}));
+
+jest.mock('../../../../../utils/opensearchDashboardsUtils', () => ({
+  darkModeEnabled: () => false,
+}));
+
+jest.mock('../../../../DetectorConfig/components/CodeModal/CodeModal', () => ({
+  CodeModal: () => null,
+}));
+
+const MINUTE_IN_MILLIS = 60 * 1000;
+const baseTime = 1587431440000;
+
+const defaultFeature: FeatureAttributes = {
+  featureId: 'feature-1',
+  featureName: 'feature',
+  featureEnabled: true,
+  importance: 1,
+  aggregationQuery: {},
+};
+
+const defaultDateRange: DateRange = {
+  startDate: baseTime,
+  endDate: baseTime + 10 * MINUTE_IN_MILLIS,
+};
+
+const defaultEntityData: EntityData[][] = [[]];
+
+const defaultWindowDelay: Schedule = {
+  interval: 0,
+  unit: UNITS.MINUTES,
+};
+
+const createFeatureData = (points: number): FeatureAggregationData[] => {
+  return Array.from({ length: points })
+    .map((_, index) => {
+      const startTime = baseTime + index * MINUTE_IN_MILLIS;
+      const endTime = startTime + MINUTE_IN_MILLIS;
+      return {
+        data: 1,
+        startTime,
+        endTime,
+        plotTime: endTime,
+      };
+    })
+    .reverse();
+};
+
+const renderFeatureChart = ({
+  featureData,
+  detectorInterval,
+  detectorFrequency,
+}: {
+  featureData: FeatureAggregationData[];
+  detectorInterval: Schedule;
+  detectorFrequency: Schedule;
+}) => {
+  return render(
+    <FeatureChart
+      feature={defaultFeature}
+      featureData={[featureData]}
+      rawFeatureData={[featureData]}
+      annotations={[]}
+      isLoading={false}
+      dateRange={defaultDateRange}
+      featureType={FEATURE_TYPE.SIMPLE}
+      field="field"
+      aggregationMethod="avg"
+      featureDataSeriesName="feature data"
+      detectorInterval={detectorInterval}
+      detectorFrequency={detectorFrequency}
+      showFeatureMissingDataPointAnnotation={true}
+      detectorEnabledTime={defaultDateRange.startDate}
+      entityData={defaultEntityData}
+      windowDelay={defaultWindowDelay}
+    />
+  );
+};
+
+describe('FeatureChart missing data annotations', () => {
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockLineAnnotationSpy.mockClear();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('LineAnnotation not rendered with full data when detector frequency is greater than interval', () => {
+    const featureData = createFeatureData(10);
+
+    const detectorInterval: Schedule = {
+      interval: 1,
+      unit: UNITS.MINUTES,
+    };
+    const detectorFrequency: Schedule = {
+      interval: 5,
+      unit: UNITS.MINUTES,
+    };
+
+    const { queryByTestId } = renderFeatureChart({
+      featureData,
+      detectorInterval,
+      detectorFrequency,
+    });
+
+    expect(mockLineAnnotationSpy).toHaveBeenCalledTimes(1);
+    const callArgs = mockLineAnnotationSpy.mock.calls[0][0];
+    expect(callArgs.dataValues).toHaveLength(0);
+    expect(queryByTestId('line-annotation')).toBeNull();
+  });
+
+  test('LineAnnotation not rendered when latest five minutes are missing but detector frequency is five minutes', () => {
+    const featureData = createFeatureData(5);
+
+    const detectorInterval: Schedule = {
+      interval: 1,
+      unit: UNITS.MINUTES,
+    };
+    const detectorFrequency: Schedule = {
+      interval: 5,
+      unit: UNITS.MINUTES,
+    };
+
+    const { queryByTestId } = renderFeatureChart({
+      featureData,
+      detectorInterval,
+      detectorFrequency,
+    });
+
+    expect(mockLineAnnotationSpy).toHaveBeenCalledTimes(1);
+    const callArgs = mockLineAnnotationSpy.mock.calls[0][0];
+    expect(callArgs.dataValues).toHaveLength(0);
+    expect(queryByTestId('line-annotation')).toBeNull();
+  });
+
+  test('LineAnnotation rendered when latest data points are missing', () => {
+    const featureData = createFeatureData(5);
+
+    const detectorInterval: Schedule = {
+      interval: 1,
+      unit: UNITS.MINUTES,
+    };
+
+    const detectorFrequency: Schedule = {
+      interval: 1,
+      unit: UNITS.MINUTES,
+    };
+
+    const { getByTestId } = renderFeatureChart({
+      featureData,
+      detectorInterval,
+      detectorFrequency,
+    });
+
+    expect(mockLineAnnotationSpy).toHaveBeenCalledTimes(1);
+    const callArgs = mockLineAnnotationSpy.mock.calls[0][0];
+    expect(callArgs.dataValues.length).toBeGreaterThan(0);
+
+    const annotationNode = getByTestId('line-annotation');
+    expect(annotationNode.getAttribute('data-values-length')).toEqual(
+      callArgs.dataValues.length.toString()
+    );
+  });
+});

--- a/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
+++ b/public/pages/AnomalyCharts/containers/FeatureBreakDown.tsx
@@ -170,15 +170,17 @@ export const FeatureBreakDown = React.memo((props: FeatureBreakDownProps) => {
                 focusOnFeatureAccordion(index);
               }}
               detectorInterval={props.detector.detectionInterval.period}
+              // if frequency is not set, use the detection interval
+              detectorFrequency={get(props, 'detector.frequency.period', props.detector.detectionInterval.period)}
               showFeatureMissingDataPointAnnotation={
                 props.showFeatureMissingDataPointAnnotation
               }
               detectorEnabledTime={props.detector.enabledTime}
               entityData={getEntityDataForChart(props.anomalyAndFeatureResults)}
               isHCDetector={props.isHCDetector}
-              windowDelay={get(props, `detector.windowDelay.period`, {
-                period: { interval: 0, unit: UNITS.MINUTES },
-              })}
+              windowDelay={get(props, `detector.windowDelay.period`, 
+                { interval: 0, unit: UNITS.MINUTES },
+              )}
             />
             {index + 1 ===
             get(props, 'detector.featureAttributes', []).length ? null : (

--- a/public/pages/AnomalyCharts/containers/__tests__/FeatureBreakDown.frequency.test.tsx
+++ b/public/pages/AnomalyCharts/containers/__tests__/FeatureBreakDown.frequency.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getRandomDetector } from '../../../../redux/reducers/__tests__/utils';
+import { FeatureBreakDown } from '../FeatureBreakDown';
+import {
+  Detector,
+  FeatureAggregationData,
+  UNITS,
+} from '../../../../models/interfaces';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+import { coreServicesMock } from '../../../../../test/mocks';
+import * as FeatureChartModule from '../../components/FeatureChart/FeatureChart';
+
+const dateRange = {
+  startDate: 1587431440000,
+  endDate: 1587456780000,
+};
+
+const buildAnomaliesResult = (detector: Detector) => {
+  const featureData: { [key: string]: FeatureAggregationData[] } = {};
+
+  detector.featureAttributes.forEach((feature) => {
+    if (feature.featureId) {
+      featureData[feature.featureId] = [
+        {
+          endTime: 1587456740000,
+          startTime: 1587431540000,
+          data: 120,
+        },
+      ];
+    }
+  });
+
+  return {
+    anomalies: [
+      {
+        anomalyGrade: 0.3,
+        anomalyScore: 0.56,
+        confidence: 0.8,
+        detectorId: detector.id,
+        endTime: 1587456740000,
+        startTime: 1587431540000,
+      },
+    ],
+    featureData,
+  };
+};
+
+const renderFeatureBreakDown = (detector: Detector) => {
+  return render(
+    <CoreServicesContext.Provider value={coreServicesMock}>
+      <FeatureBreakDown
+        title="test"
+        detector={detector}
+        anomalyAndFeatureResults={[buildAnomaliesResult(detector)]}
+        annotations={[]}
+        isLoading={false}
+        dateRange={dateRange}
+        featureDataSeriesName="feature data"
+      />
+    </CoreServicesContext.Provider>
+  );
+};
+
+describe('FeatureBreakDown frequency handling', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('defaults detectorFrequency to detection interval when frequency is undefined', () => {
+    const detector = getRandomDetector(false);
+    const featureChartSpy = jest.spyOn(FeatureChartModule, 'FeatureChart');
+
+    renderFeatureBreakDown(detector);
+
+    expect(featureChartSpy).toHaveBeenCalled();
+    featureChartSpy.mock.calls.forEach((call) => {
+      const props = call[0] as any;
+      expect(props.detectorFrequency).toEqual(
+        detector.detectionInterval.period
+      );
+    });
+  });
+
+  test('passes detector frequency when defined on detector', () => {
+    const detector = getRandomDetector(false);
+    const customFrequency = {
+      interval: 5,
+      unit: UNITS.HOURS,
+    };
+    const detectorWithFrequency: Detector = {
+      ...detector,
+      frequency: { period: customFrequency },
+    };
+    const featureChartSpy = jest.spyOn(FeatureChartModule, 'FeatureChart');
+
+    renderFeatureBreakDown(detectorWithFrequency);
+
+    expect(featureChartSpy).toHaveBeenCalled();
+    featureChartSpy.mock.calls.forEach((call) => {
+      const props = call[0] as any;
+      expect(props.detectorFrequency).toEqual(customFrequency);
+    });
+  });
+});

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -209,6 +209,12 @@ export function AnomalyResults(props: AnomalyResultsProps) {
     1
   );
 
+  const detectorFrequencyInMin = get(
+    detector,
+    'frequency.period.interval',
+    1
+  );
+
   const isInitializingNormally =
     isDetectorInitializing &&
     isInitOvertime != undefined &&
@@ -231,9 +237,11 @@ export function AnomalyResults(props: AnomalyResultsProps) {
         windowDelayInterval * toDuration(windowDelayUnit).asMinutes();
     }
 
-    // The query in this function uses data start/end time. So we should consider window delay
+    const minutesToSkip = detectorFrequencyInMin !== detectorIntervalInMin ? detectorFrequencyInMin : detectorIntervalInMin;
+
+    // The query in this function uses data start/end time. So we should consider window delay and frequency
     let adjustedCurrentTime = moment().subtract(
-      windowDelayInMinutes,
+      windowDelayInMinutes + minutesToSkip,
       'minutes'
     );
 
@@ -245,7 +253,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
           .clone()
           .subtract(
             (FEATURE_DATA_POINTS_WINDOW + FEATURE_DATA_CHECK_WINDOW_OFFSET) *
-              detectorIntervalInMin,
+            detectorIntervalInMin,
             'minutes'
           )
           .valueOf(),
@@ -283,6 +291,7 @@ export function AnomalyResults(props: AnomalyResultsProps) {
         featuresData,
         detectorIntervalInMin,
         featureDataPointsRange,
+        true,
         true
       );
 

--- a/public/pages/DetectorResults/containers/__tests__/AnomalyResults.checkLatestFeatureDataPoints.test.tsx
+++ b/public/pages/DetectorResults/containers/__tests__/AnomalyResults.checkLatestFeatureDataPoints.test.tsx
@@ -1,0 +1,329 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+let mockCaptureNextUseStateSetter: ((value: any) => void) | null = null;
+let mockUseStateCaptureActive = false;
+let mockUseStateCallCount = 0;
+const captureFeatureMissingSeveritySetter = (
+  callback: (value: any) => void
+) => {
+  mockCaptureNextUseStateSetter = callback;
+  mockUseStateCaptureActive = true;
+  mockUseStateCallCount = 0;
+};
+
+jest.mock('react', () => {
+  const actualReact = jest.requireActual('react');
+  return {
+    ...actualReact,
+    useState: (initial?: any) => {
+      const state = actualReact.useState(initial);
+      if (mockUseStateCaptureActive) {
+        mockUseStateCallCount += 1;
+        if (mockUseStateCallCount === 1 && mockCaptureNextUseStateSetter) {
+          const [value, setter] = state;
+          const callback = mockCaptureNextUseStateSetter;
+          const wrappedSetter = (newValue: any) => {
+            callback?.(newValue);
+            return setter(newValue);
+          };
+          mockCaptureNextUseStateSetter = null;
+          mockUseStateCaptureActive = false;
+          mockUseStateCallCount = 0;
+          return [value, wrappedSetter];
+        }
+      }
+      return state;
+    },
+  };
+});
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { AnomalyResults } from '../AnomalyResults';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+import { MISSING_FEATURE_DATA_SEVERITY } from '../../../../utils/constants';
+import { UNITS } from '../../../../models/interfaces';
+import { DETECTOR_STATE } from '../../../../../server/utils/constants';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  getFeatureDataPointsForDetector,
+  getFeatureMissingSeverities,
+  buildParamsForGetAnomalyResultsWithDateRange,
+} from '../../../utils/anomalyResultUtils';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../../../components/ContentPanel/ContentPanel', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-test-subj="content-panel">{children}</div>
+  ),
+}));
+
+jest.mock('../AnomalyResultsLiveChart', () => ({
+  AnomalyResultsLiveChart: () => <div data-test-subj="live-chart" />,
+}));
+
+jest.mock('../AnomalyHistory', () => ({
+  AnomalyHistory: () => <div data-test-subj="history" />,
+}));
+
+jest.mock('../DetectorStateDetails', () => ({
+  DetectorStateDetails: () => <div data-test-subj="state-details" />,
+}));
+
+jest.mock('../../../Overview/components/SampleIndexDetailsCallout/SampleIndexDetailsCallout', () => ({
+  SampleIndexDetailsCallout: () => <div data-test-subj="sample-callout" />,
+}));
+
+jest.mock('../../../utils/anomalyResultUtils', () => ({
+  buildParamsForGetAnomalyResultsWithDateRange: jest.fn(),
+  getFeatureDataPointsForDetector: jest.fn(),
+  getFeatureMissingSeverities: jest.fn(),
+  getFeatureDataMissingMessageAndActionItem: jest.fn(() => ({
+    message: '',
+    actionItem: '',
+  })),
+  FEATURE_DATA_CHECK_WINDOW_OFFSET: 2,
+}));
+
+jest.mock('../../../Overview/utils/helpers', () => ({
+  detectorIsSample: jest.fn(() => false),
+}));
+
+jest.mock('../../../../redux/reducers/anomalyResults', () => ({
+  getDetectorResults: jest.fn(() => ({ type: 'ad/DETECTOR_RESULTS' })),
+}));
+
+jest.mock('../../../../redux/reducers/ad', () => ({
+  getDetector: jest.fn(() => ({ type: 'ad/GET_DETECTOR' })),
+}));
+
+jest.mock('../../../../pages/utils/helpers', () => ({
+  getDataSourceFromURL: jest.fn(() => ({ dataSourceId: 'test-data-source' })),
+}));
+
+jest.mock('../../../../services', () => ({
+  getDataSourceEnabled: jest.fn(() => ({ enabled: false })),
+}));
+
+jest.mock('react-router', () => ({
+  ...(jest.requireActual('react-router') as Record<string, unknown>),
+  useLocation: jest.fn(() => ({
+    pathname: '',
+    search: '',
+    hash: '',
+    state: undefined,
+  })),
+}));
+
+const useSelectorMock = useSelector as jest.Mock;
+const useDispatchMock = useDispatch as jest.Mock;
+const getFeatureDataPointsForDetectorMock =
+  getFeatureDataPointsForDetector as jest.Mock;
+const getFeatureMissingSeveritiesMock =
+  getFeatureMissingSeverities as jest.Mock;
+const buildParamsForGetAnomalyResultsWithDateRangeMock =
+  buildParamsForGetAnomalyResultsWithDateRange as jest.Mock;
+
+const detectorId = 'detector-id';
+const featureId = 'feature-id';
+const featureName = 'cpu_usage';
+
+const createDetector = (frequencyInterval: number) => ({
+  id: detectorId,
+  name: 'detector',
+  curState: DETECTOR_STATE.RUNNING,
+  enabled: true,
+  enabledTime: 1587431400000,
+  disabledTime: undefined,
+  lastUpdateTime: 1587431400000,
+  indices: ['index'],
+  featureAttributes: [
+    {
+      featureId,
+      featureName,
+      featureEnabled: true,
+      importance: 1,
+      aggregationQuery: {},
+    },
+  ],
+  detectionInterval: {
+    period: {
+      interval: 1,
+      unit: UNITS.MINUTES,
+    },
+  },
+  frequency: {
+    period: {
+      interval: frequencyInterval,
+      unit: UNITS.MINUTES,
+    },
+  },
+  windowDelay: {
+    period: {
+      interval: 0,
+      unit: UNITS.MINUTES,
+    },
+  },
+  resultIndex: '',
+  imputationOption: undefined,
+});
+
+const buildFeatureDataPoints = (isMissing: boolean) => ({
+  [featureName]: [
+    {
+      isMissing,
+      plotTime: 1587431700000,
+      startTime: 1587431640000,
+      endTime: 1587431700000,
+    },
+  ],
+});
+
+const renderWithCoreContext = (ui: React.ReactElement) => {
+  const coreServicesMock = {
+    chrome: {
+      setBreadcrumbs: jest.fn(),
+    },
+  } as any;
+
+  return render(
+    <CoreServicesContext.Provider value={coreServicesMock}>
+      {ui}
+    </CoreServicesContext.Provider>
+  );
+};
+
+const renderAnomalyResults = (frequencyInterval: number) => {
+  const detector = createDetector(frequencyInterval);
+  const store = {
+    ad: { detectors: { [detectorId]: detector } },
+    alerting: { monitors: {} },
+    anomalyResults: {
+      requesting: false,
+      total: 0,
+      anomalies: [],
+      errorMessage: '',
+      featureData: {},
+    },
+  };
+
+  useSelectorMock.mockImplementation((selector: any) => selector(store));
+
+  buildParamsForGetAnomalyResultsWithDateRangeMock.mockReturnValue({});
+
+  return renderWithCoreContext(
+    <AnomalyResults
+      detectorId={detectorId}
+      onStartDetector={jest.fn()}
+      onStopDetector={jest.fn()}
+      onSwitchToConfiguration={jest.fn()}
+      onSwitchToHistorical={jest.fn()}
+    />
+  );
+};
+
+describe('checkLatestFeatureDataPoints', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCaptureNextUseStateSetter = null;
+    mockUseStateCaptureActive = false;
+    mockUseStateCallCount = 0;
+  });
+
+  test('sets severity to GREEN when missing last 5 minutes, frequency 5 minutes', async () => {
+    const setFeatureMissingSeverityMock = jest.fn();
+    captureFeatureMissingSeveritySetter(setFeatureMissingSeverityMock);
+
+    const mockDispatch = jest.fn((action) => {
+      if (action?.type === 'ad/DETECTOR_RESULTS') {
+        return Promise.resolve({
+          response: {
+            featureResults: { [featureId]: [] },
+          },
+        });
+      }
+      return Promise.resolve();
+    });
+    useDispatchMock.mockReturnValue(mockDispatch);
+
+    getFeatureDataPointsForDetectorMock.mockReturnValue(
+      buildFeatureDataPoints(true)
+    );
+    const severityMap = new Map();
+    severityMap.set(MISSING_FEATURE_DATA_SEVERITY.GREEN, [featureName]);
+    getFeatureMissingSeveritiesMock.mockReturnValue(severityMap);
+
+    renderAnomalyResults(5);
+
+    await waitFor(() =>
+      expect(getFeatureDataPointsForDetectorMock).toHaveBeenCalled()
+    );
+
+    // Ensure the helper is called with detectorFrequencyAdjusted=true (6th arg)
+    const args = (getFeatureDataPointsForDetectorMock as jest.Mock).mock
+      .calls[0];
+    expect(args[5]).toBe(true);
+
+    await waitFor(() =>
+      expect(setFeatureMissingSeverityMock).toHaveBeenCalledWith(
+        MISSING_FEATURE_DATA_SEVERITY.GREEN
+      )
+    );
+  });
+
+  test('sets severity YELLOW when detector frequency matches interval and data is missing', async () => {
+    const setFeatureMissingSeverityMock = jest.fn();
+    captureFeatureMissingSeveritySetter(setFeatureMissingSeverityMock);
+
+    const mockDispatch = jest.fn((action) => {
+      if (action?.type === 'ad/DETECTOR_RESULTS') {
+        return Promise.resolve({
+          response: {
+            featureResults: { [featureId]: [] },
+          },
+        });
+      }
+      return Promise.resolve();
+    });
+    useDispatchMock.mockReturnValue(mockDispatch);
+
+    getFeatureDataPointsForDetectorMock.mockReturnValue(
+      buildFeatureDataPoints(true)
+    );
+    const severityMap = new Map();
+    severityMap.set(MISSING_FEATURE_DATA_SEVERITY.GREEN, []);
+    severityMap.set(MISSING_FEATURE_DATA_SEVERITY.YELLOW, [featureName]);
+    getFeatureMissingSeveritiesMock.mockReturnValue(severityMap);
+
+    renderAnomalyResults(1);
+
+    await waitFor(() =>
+      expect(getFeatureDataPointsForDetectorMock).toHaveBeenCalled()
+    );
+
+    await waitFor(() =>
+      expect(setFeatureMissingSeverityMock).toHaveBeenCalledWith(
+        MISSING_FEATURE_DATA_SEVERITY.YELLOW
+      )
+    );
+
+    // Ensure the helper is called with detectorFrequencyAdjusted=true (6th arg)
+    const args2 = (getFeatureDataPointsForDetectorMock as jest.Mock).mock
+      .calls[0];
+    expect(args2[5]).toBe(true);
+  });
+});

--- a/public/pages/utils/__tests__/anomalyResultUtils.test.ts
+++ b/public/pages/utils/__tests__/anomalyResultUtils.test.ts
@@ -298,6 +298,42 @@ describe('anomalyResultUtils', () => {
     });
   });
   describe('getFeatureMissingDataAnnotations', () => {
+    test('returns no missing data annotation when latest 5 minutes are missing but frequency is 5 minutes', () => {
+      const MIN = 60 * 1000;
+      const BASE = 1587431400000;
+
+      // Feature data for the first 5 minutes only; last 5 minutes are missing
+      const featureData = Array.from({ length: 5 })
+        .map((_, i) => {
+          const startTime = BASE + i * MIN;
+          const endTime = startTime + MIN;
+          return {
+            startTime,
+            endTime,
+            plotTime: endTime,
+            data: 1,
+          };
+        })
+        .reverse();
+
+      // Detection interval is 1 minute; frequency is 5 minutes
+      const interval = 1;
+      const windowDelay = { interval: 0, unit: UNITS.MINUTES };
+      const queryDateRange = { startDate: BASE, endDate: BASE + 10 * MIN };
+      const displayDateRange = queryDateRange;
+
+      const annotations = getFeatureMissingDataAnnotations(
+        featureData as any,
+        interval,
+        windowDelay as any,
+        queryDateRange as any,
+        displayDateRange as any,
+        false,
+        5 // frequency in minutes
+      );
+
+      expect(annotations).toEqual([]);
+    });
     test('returns missing data annotation with 20 seconds window delay', () => {
       expect(
         getFeatureMissingDataAnnotations(

--- a/public/pages/utils/__tests__/getFeatureDataPointsForDetector.test.ts
+++ b/public/pages/utils/__tests__/getFeatureDataPointsForDetector.test.ts
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  DateRange,
+  Detector,
+  FeatureAggregationData,
+  FeatureAttributes,
+  FEATURE_TYPE,
+  UNITS,
+} from '../../../models/interfaces';
+import { DETECTOR_STATE } from '../../../../server/utils/constants';
+import { getFeatureDataPointsForDetector } from '../anomalyResultUtils';
+
+const MINUTE_IN_MS = 60 * 1000;
+const BASE_TIME = 1587431400000;
+const FEATURE_ID = 'feature-id';
+const FEATURE_NAME = 'cpu_usage';
+
+const buildFeatureData = (minutesWithData: number[]): FeatureAggregationData[] =>
+  minutesWithData
+    .map((minute) => {
+      const startTime = BASE_TIME + minute * MINUTE_IN_MS;
+      const endTime = startTime + MINUTE_IN_MS;
+      return {
+        data: 1,
+        startTime,
+        endTime,
+        plotTime: endTime,
+      };
+    })
+    .sort((a, b) => b.startTime - a.startTime);
+
+const defaultFeature: FeatureAttributes = {
+  featureId: FEATURE_ID,
+  featureName: FEATURE_NAME,
+  featureEnabled: true,
+  importance: 1,
+  aggregationQuery: {},
+};
+
+const buildDetector = (frequencyMinutes: number): Detector => {
+  return {
+    id: 'detector-id',
+    primaryTerm: 1,
+    seqNo: 1,
+    name: 'detector',
+    description: '',
+    timeField: '@timestamp',
+    indices: ['index'],
+    filterQuery: {},
+    featureAttributes: [defaultFeature],
+    detectionInterval: {
+      period: {
+        interval: 1,
+        unit: UNITS.MINUTES,
+      },
+    },
+    windowDelay: {
+      period: {
+        interval: 0,
+        unit: UNITS.MINUTES,
+      },
+    },
+    frequency: {
+      period: {
+        interval: frequencyMinutes,
+        unit: UNITS.MINUTES,
+      },
+    },
+    shingleSize: 8,
+    uiMetadata: {
+      filters: [],
+      features: {
+        [FEATURE_NAME]: {
+          featureType: FEATURE_TYPE.SIMPLE,
+          aggregationBy: 'avg',
+          aggregationOf: FEATURE_NAME,
+        },
+      },
+    },
+    lastUpdateTime: BASE_TIME,
+    curState: DETECTOR_STATE.RUNNING,
+    stateError: '',
+  } as Detector;
+};
+
+const dateRange: DateRange = {
+  startDate: BASE_TIME,
+  endDate: BASE_TIME + 10 * MINUTE_IN_MS,
+};
+
+describe('getFeatureDataPointsForDetector', () => {
+  const featureDataWithMissingLastFiveMinutes = buildFeatureData([
+    0, 1, 2, 3, 4,
+  ]);
+
+  test('returns no missing points when last five minutes are skipped due to five minute frequency', () => {
+    const detector = buildDetector(5);
+
+    const featureDataPoints = getFeatureDataPointsForDetector(
+      detector,
+      {
+        [FEATURE_ID]: featureDataWithMissingLastFiveMinutes,
+      },
+      1,
+      dateRange,
+      true
+    );
+
+    const dataPoints = featureDataPoints[FEATURE_NAME];
+    expect(dataPoints).toBeDefined();
+    expect(dataPoints.length).toBeGreaterThan(0);
+    expect(dataPoints.some((point) => point.isMissing)).toBe(false);
+  });
+
+  test('returns missing points when detector frequency matches interval and last five minutes have no data', () => {
+    const detector = buildDetector(1);
+
+    const featureDataPoints = getFeatureDataPointsForDetector(
+      detector,
+      {
+        [FEATURE_ID]: featureDataWithMissingLastFiveMinutes,
+      },
+      1,
+      dateRange,
+      true
+    );
+
+    const dataPoints = featureDataPoints[FEATURE_NAME];
+    expect(dataPoints).toBeDefined();
+    expect(dataPoints.length).toBeGreaterThan(0);
+    expect(dataPoints.some((point) => point.isMissing)).toBe(true);
+  });
+
+  test('returns no missing points when frequency and interval are the same', () => {
+    const detector = buildDetector(5); 
+    // Modify buildDetector to also set detectionInterval to 5 minutes for this test
+    
+    const featureDataPoints = getFeatureDataPointsForDetector(
+      detector,
+      {
+        [FEATURE_ID]: featureDataWithMissingLastFiveMinutes,
+      },
+      5, // interval is now 5
+      dateRange,
+      true
+    );
+
+    const dataPoints = featureDataPoints[FEATURE_NAME];
+    expect(dataPoints.some((point) => point.isMissing)).toBe(false);
+  });
+
+  test('avoids double-applying frequency skip when dateRange is pre-adjusted', () => {
+    // Detector with 5-minute frequency and 1-minute interval
+    const detector = buildDetector(5);
+
+    // Feature data is missing in the last 5 minutes (minutes 5-9)
+    const featureDataPointsMap = {
+      [FEATURE_ID]: featureDataWithMissingLastFiveMinutes,
+    } as { [key: string]: FeatureAggregationData[] };
+
+    // Case A: Unadjusted range, rely on internal frequency skip logic
+    const unadjustedDateRange: DateRange = {
+      startDate: BASE_TIME,
+      endDate: BASE_TIME + 10 * MINUTE_IN_MS,
+    };
+    const resultUnadjusted = getFeatureDataPointsForDetector(
+      detector,
+      featureDataPointsMap,
+      1,
+      unadjustedDateRange,
+      true // windowDelayAdjusted
+      // detectorFrequencyAdjusted omitted (false)
+    );
+
+    // Case B: Pre-adjusted end time by frequency window (5 minutes), and tell helper not to skip again
+    const adjustedDateRange: DateRange = {
+      startDate: BASE_TIME,
+      endDate: BASE_TIME + 5 * MINUTE_IN_MS, // subtract 5 minutes
+    };
+    const resultAdjusted = getFeatureDataPointsForDetector(
+      detector,
+      featureDataPointsMap,
+      1,
+      adjustedDateRange,
+      true, // windowDelayAdjusted
+      true // detectorFrequencyAdjusted
+    );
+
+    const dataPointsUnadjusted = resultUnadjusted[FEATURE_NAME];
+    const dataPointsAdjusted = resultAdjusted[FEATURE_NAME];
+
+    expect(dataPointsUnadjusted).toBeDefined();
+    expect(dataPointsAdjusted).toBeDefined();
+    expect(dataPointsUnadjusted.length).toBeGreaterThan(0);
+    expect(dataPointsAdjusted.length).toBeGreaterThan(0);
+
+    // Both paths should identify no missing points because the last 5 minutes are either
+    // skipped internally (unadjusted) or excluded by the pre-adjusted dateRange (adjusted).
+    expect(dataPointsUnadjusted.some((p) => p.isMissing)).toBe(false);
+    expect(dataPointsAdjusted.some((p) => p.isMissing)).toBe(false);
+
+    // The computed ranges should be consistent between both approaches
+    expect(dataPointsAdjusted.length).toEqual(dataPointsUnadjusted.length);
+  });
+});


### PR DESCRIPTION
### Description

This mirrors the window delay fix in PR #278, but applies the same logic to detector frequency.

- plumb detector frequency through feature chart props and annotation helpers
- adjust latest-feature poll window to subtract the frequency cadence
- extend anomaly utils tests to cover frequency-aware missing data detection

Testing done:

- done e2e testing and verified the problem is fixed.
- added unit tests.

Before fix:
<img width="1823" height="430" alt="Screenshot 2025-11-05 at 7 25 55 AM" src="https://github.com/user-attachments/assets/9a93ed50-68b0-4771-b8a0-bd8d3c8a7470" />

After fix:
<img width="1281" height="446" alt="Screenshot 2025-11-05 at 7 26 32 AM" src="https://github.com/user-attachments/assets/008c4a46-073e-41a4-ad30-26bbadd8205b" />


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
