### PR TITLE
Bump picomatch and brace-expansion to resolve CVEs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -227,9 +227,9 @@ bn.js@^4.0.0, bn.js@^4.11.9, bn.js@^5.0.0, bn.js@^5.2.1, bn.js@^5.2.3:
   integrity sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==
 
 brace-expansion@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.2.tgz#b6c16d0791087af6c2bc463f52a8142046c06b6f"
-  integrity sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -1393,9 +1393,9 @@ pbkdf2@^3.0.3, pbkdf2@^3.1.3:
     to-buffer "^1.2.0"
 
 picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 please-upgrade-node@^3.1.1:
   version "3.2.0"


### PR DESCRIPTION
### Description

Resolve 5 known vulnerabilities found by `yarn audit` by bumping transitive dependency resolutions:

- **brace-expansion** ^5.0.2 → ^5.0.5 — fixes [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750) (CVSS 6.5, moderate): zero-step sequence causes process hang and memory exhaustion
- **picomatch** add ^2.3.2 resolution — fixes:
  - [CVE-2026-33671](https://nvd.nist.gov/vuln/detail/CVE-2026-33671) (CVSS 7.5, high): ReDoS via crafted extglob patterns
  - [CVE-2026-33672](https://nvd.nist.gov/vuln/detail/CVE-2026-33672) (CVSS 5.3, moderate): method injection in POSIX character classes

### Issues Resolved

- [CVE-2026-33750](https://github.com/advisories/GHSA-f886-m6hf-6m8v)
- [CVE-2026-33671](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj)
- [CVE-2026-33672](https://github.com/advisories/GHSA-3v7f-55p6-f55p)

### Check List
- [x] New functionality includes testing.
  - N/A — dependency version bump only
- [x] Commits are signed per the DCO using `--signoff`.

```
yarn audit v1.22.22
0 vulnerabilities found - Packages audited: 189
```