### PR TITLE
 Daily Insights: Agent task polling, ML task API, and page stability fixes

### DIFF
--- a/public/pages/DailyInsights/components/IndicesManagement.tsx
+++ b/public/pages/DailyInsights/components/IndicesManagement.tsx
@@ -22,9 +22,9 @@ import {
   EuiPanel,
   EuiTitle,
   EuiLink,
-  EuiToolTip,
   EuiIcon,
   EuiLoadingSpinner,
+  EuiCallOut,
 } from '@elastic/eui';
 import React, { useState, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -38,6 +38,8 @@ import { AppState } from '../../../redux/reducers';
 import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
 import { CoreStart, MountPoint } from '../../../../../../src/core/public';
 import { getDataSourceEnabled, getApplication, getNotifications, getDataSourceManagementPlugin, getSavedObjectsClient } from '../../../services';
+import { useAgentTaskPolling } from '../hooks/useAgentTaskPolling';
+import { getAgentTask } from '../utils/agentTaskStorage';
 import { DataSourceSelectableConfig } from '../../../../../../src/plugins/data_source_management/public';
 import { BREADCRUMBS, MDS_BREADCRUMBS, DAILY_INSIGHTS_OVERVIEW_PAGE_NAV_ID, PLUGIN_NAME } from '../../../utils/constants';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -78,6 +80,11 @@ export function IndicesManagement(props: IndicesManagementProps) {
       ? (dataSourceId || undefined)
       : undefined,
   });
+
+  const { isPolling, startPolling } = useAgentTaskPolling(
+    MDSInsightsState.selectedDataSourceId || '',
+    (outcome) => loadDetectors()
+  );
 
   const history = useHistory();
 
@@ -199,8 +206,6 @@ const fetchInsightsStatus = async () => {
   };
 
   const processDetectors = () => {
-    setIsLoading(true);
-    
     let detectors = [];
     if (adState.detectorList) {
       if (Array.isArray(adState.detectorList)) {
@@ -254,7 +259,7 @@ const fetchInsightsStatus = async () => {
   };
 
   const [selectedModalIndices, setSelectedModalIndices] = useState<string[]>([]);
-  const [agentId, setAgentId] = useState('auto-create-detector-agent');
+  const agentId = 'auto-create-detector-agent';
 
   const handleStartAutoInsights = async (selectedIndices: string[], agentIdToUse: string) => {
     if (selectedIndices.length === 0) {
@@ -263,22 +268,25 @@ const fetchInsightsStatus = async () => {
     }
 
     setIsStartingInsights(true);
-    
-    // Execute ML agent to create detectors
-    dispatch(
-      executeAutoCreateAgent(
-        selectedIndices, 
-        agentIdToUse,
-        MDSInsightsState.selectedDataSourceId || ''
-      )
-    ).then((resp: any) => {      
+
+    try {
+      const resp: any = await dispatch(
+        executeAutoCreateAgent(
+          selectedIndices,
+          agentIdToUse,
+          MDSInsightsState.selectedDataSourceId || ''
+        )
+      );
+
       if (!resp || resp.error) {
         const errorMsg = resp?.error?.message || resp?.error || 'Unknown error';
-        getNotifications().toasts.addDanger(
-          `Failed to execute ML agent: ${errorMsg}`
-        );
-        setIsStartingInsights(false);
+        getNotifications().toasts.addDanger(`Failed to execute ML agent: ${errorMsg}`);
         return;
+      }
+
+      const taskId = resp.response?.task_id || resp.task_id;
+      if (taskId) {
+        startPolling(taskId);
       }
 
       getNotifications().toasts.addSuccess(
@@ -286,16 +294,12 @@ const fetchInsightsStatus = async () => {
       );
       setIsModalVisible(false);
       setSelectedModalIndices([]);
+    } catch (error: any) {
+      const errorMsg = error?.body?.message || error?.message || 'Unknown error';
+      getNotifications().toasts.addDanger(`Failed to start auto insights: ${errorMsg}`);
+    } finally {
       setIsStartingInsights(false);
-      loadDetectors();
-    }).catch((error: any) => {
-      console.error('Error starting auto insights:', error);
-      const errorMsg = error?.body?.message || error?.message || error?.toString() || 'Unknown error';
-      getNotifications().toasts.addDanger(
-        `Failed to start auto insights: ${errorMsg}`
-      );
-      setIsStartingInsights(false);
-    });
+    }
   };
 
 
@@ -430,6 +434,7 @@ const fetchInsightsStatus = async () => {
             color="primary"
             iconType="plus"
             onClick={() => setIsModalVisible(true)}
+            isDisabled={isPolling}
           >
             Add Indices
           </EuiSmallButton>
@@ -472,13 +477,41 @@ const fetchInsightsStatus = async () => {
       );
     }
 
-    // Scenario 2: Job active, no detectors yet - Show "detectors being created" message
-    if (insightsEnabled && indicesData.length === 0) {
+    // Scenario 2: Job active or agent polling, no detectors yet
+    if ((insightsEnabled || isPolling) && indicesData.length === 0) {
+      // Check if the last agent task failed
+      const lastTask = getAgentTask();
+      if (lastTask?.finalState === 'FAILED' || lastTask?.finalState === 'TIMEOUT') {
+        return (
+          <>
+            <EuiCallOut
+              title="Detector creation failed"
+              color="danger"
+              iconType="alert"
+              data-test-subj="detectorCreationFailedCallout"
+            >
+              <p>The last attempt to create detectors did not succeed. Try adding indices again with a different selection.</p>
+            </EuiCallOut>
+            <EuiSpacer size="l" />
+            <EuiEmptyPrompt
+              actions={
+                <EuiSmallButton
+                  fill
+                  iconType="plus"
+                  onClick={() => setIsModalVisible(true)}
+                >
+                  Add Indices
+                </EuiSmallButton>
+              }
+            />
+          </>
+        );
+      }
       return (
         <EuiEmptyPrompt
           data-test-subj="detectorsBeingCreatedPrompt"
           icon={<EuiLoadingSpinner size="xl" />}
-          title={<h3>Job has started and detectors are being created</h3>}
+          title={<h3>Detectors are being created</h3>}
           body={
             <p>
               Please wait while we create detectors for your indices. This process may take a few minutes.
@@ -496,10 +529,34 @@ const fetchInsightsStatus = async () => {
   return (
     <React.Fragment>
         {dataSourceEnabled && renderDataSourceComponent}
+        <EuiSpacer size="xl" />
         {insightsEnabled && renderAddIndicesPanel()}
       <EuiSpacer size="l" />
 
       <div style={{ margin: '0 24px' }}>
+        {(() => {
+          const lastTask = getAgentTask();
+          if (lastTask?.failedIndices && lastTask.failedIndices.length > 0 && indicesData.length > 0) {
+            return (
+              <>
+                <EuiCallOut
+                  title="Some detectors failed to create"
+                  color="warning"
+                  iconType="alert"
+                  data-test-subj="partialDetectorFailureCallout"
+                >
+                  <ul>
+                    {lastTask.failedIndices.map((f, i) => (
+                      <li key={i}><strong>{f.index}</strong>: {f.error}</li>
+                    ))}
+                  </ul>
+                </EuiCallOut>
+                <EuiSpacer size="m" />
+              </>
+            );
+          }
+          return null;
+        })()}
         <ContentPanel 
           title="Configured Indices" 
           titleSize="m"

--- a/public/pages/DailyInsights/containers/DailyInsights.tsx
+++ b/public/pages/DailyInsights/containers/DailyInsights.tsx
@@ -187,7 +187,15 @@ export function DailyInsights(props: DailyInsightsProps) {
   const [insightsSchedule, setInsightsSchedule] = useState<InsightsSchedule | null>(null);
   const [insightsResults, setInsightsResults] = useState<InsightResult[]>([]);
   const [selectedEvent, setSelectedEvent] = useState<{cluster: InsightCluster, result: InsightResult} | null>(null);
-  const [featureEnabled, setFeatureEnabled] = useState<boolean>(false);
+  // Read once at mount — core.uiSettings.get() is synchronous and the setting
+  // does not change during the component lifecycle without a full page reload.
+  const [featureEnabled] = useState<boolean>(() => {
+    try {
+      return core.uiSettings.get(DAILY_INSIGHTS_ENABLED, false);
+    } catch {
+      return false;
+    }
+  });
   
   // Index selection for setup flow
   const [selectedIndicesForSetup, setSelectedIndicesForSetup] = useState<string[]>([]);
@@ -207,23 +215,6 @@ export function DailyInsights(props: DailyInsightsProps) {
       ? (queryParams.dataSourceId || undefined)
       : undefined,
   });
-
-  // Check if the feature is enabled via UI settings
-  useEffect(() => {
-    const checkFeatureFlag = async () => {
-      try {
-        const isEnabled = core.uiSettings.get(DAILY_INSIGHTS_ENABLED, false);
-        setFeatureEnabled(isEnabled);
-        if (!isEnabled) {
-          setIsLoading(false);
-        }
-      } catch (error) {
-        console.error('Error checking Daily Insights feature flag:', error);
-        setFeatureEnabled(false);
-      }
-    };
-    checkFeatureFlag();
-  }, [core]);
 
   const handleDataSourceChange = (dataSources: any[]) => {
     const dataSourceId = dataSources[0]?.id;
@@ -268,12 +259,16 @@ export function DailyInsights(props: DailyInsightsProps) {
     }
   }, [MDSInsightsState]);
 
-  // Fetch status and results
+  // Fetch status and results in a single load sequence to avoid flash
   useEffect(() => {
-    fetchInsightsStatus();
+    if (!featureEnabled) {
+      setIsLoading(false);
+      return;
+    }
+    fetchInsightsStatusAndResults();
   }, [MDSInsightsState]);
 
-  const fetchInsightsStatus = async () => {
+  const fetchInsightsStatusAndResults = async () => {
     setIsLoading(true);
     try {
       const statusResponse = await dispatch(
@@ -281,9 +276,13 @@ export function DailyInsights(props: DailyInsightsProps) {
       );
       const enabled = statusResponse?.response?.enabled || false;
       const schedule = statusResponse?.response?.schedule || null;
-      
+
       setInsightsEnabled(enabled);
       setInsightsSchedule(schedule);
+
+      if (enabled) {
+        await fetchInsightsResults(schedule);
+      }
     } catch (error: any) {
       console.error('Error fetching insights status:', error);
       setInsightsEnabled(false);
@@ -293,13 +292,7 @@ export function DailyInsights(props: DailyInsightsProps) {
     }
   };
 
-  useEffect(() => {
-    if (insightsEnabled) {
-      fetchInsightsResults();
-    }
-  }, [insightsEnabled, insightsSchedule, MDSInsightsState.selectedDataSourceId]);
-
-  const fetchInsightsResults = async () => {
+  const fetchInsightsResults = async (scheduleOverride?: InsightsSchedule | null) => {
     try {
       const resultsResponse = await dispatch(
         getInsightsResultsAction(MDSInsightsState.selectedDataSourceId || '')
@@ -312,10 +305,11 @@ export function DailyInsights(props: DailyInsightsProps) {
       // use current job schedule, or default to 24 hours
       let filterPeriod = 24;
       let filterUnit: moment.unitOfTime.DurationConstructor = 'hours';
-      
-      if (insightsSchedule?.interval) {
-        filterPeriod = insightsSchedule.interval.period;
-        const apiUnit = insightsSchedule.interval.unit.toLowerCase();
+
+      const schedule = scheduleOverride !== undefined ? scheduleOverride : insightsSchedule;
+      if (schedule?.interval) {
+        filterPeriod = schedule.interval.period;
+        const apiUnit = schedule.interval.unit.toLowerCase();
         filterUnit = apiUnit as moment.unitOfTime.DurationConstructor;
       }
       
@@ -409,7 +403,7 @@ export function DailyInsights(props: DailyInsightsProps) {
                 text: `Auto-created detectors for ${selectedIndicesForSetup.length} indices.`,
               });
               
-              await fetchInsightsStatus();
+              await fetchInsightsStatusAndResults();
             } catch (error: any) {              
               core?.notifications.toasts.addDanger(
                 prettifyErrorMessage(
@@ -446,7 +440,7 @@ export function DailyInsights(props: DailyInsightsProps) {
       setIsRefreshing(true);
       
       await new Promise(resolve => setTimeout(resolve, 2000));
-      await fetchInsightsStatus();
+      await fetchInsightsStatusAndResults();
       
       setIsRefreshing(false);
     } catch (error: any) {
@@ -817,45 +811,39 @@ export function DailyInsights(props: DailyInsightsProps) {
       {dataSourceEnabled && renderDataSourceComponent}
       
       {selectedEvent && renderEventModal()}
-      
-      {isLoading || isRefreshing ? (
-        <EuiEmptyPrompt
-          icon={<EuiLoadingSpinner size="xl" />}
+
+      {useUpdatedUX && (
+        <HeaderControl
+          setMountPoint={setAppDescriptionControls}
+          controls={[
+            {
+              description: 'Automated insights showing correlated anomalies across your detectors',
+            },
+          ]}
         />
-      ) : insightsEnabled ? (
-        <Fragment>
-          {useUpdatedUX && (
-            <HeaderControl
-              setMountPoint={setAppDescriptionControls}
-              controls={[
-                {
-                  description: 'Automated insights showing correlated anomalies across your detectors',
-                },
-              ]}
-            />
-          )}
-          {!useUpdatedUX && (
-            <>
-              <EuiSpacer size="m" />
-              <EuiText size="s">
-                Automated insights showing correlated anomalies across your detectors
-              </EuiText>
-            </>
-          )}
-          <EuiSpacer size="xl" />
-          <div style={{ paddingLeft: '24px', paddingRight: '24px' }}>
-            {renderInsightsView()}
-          </div>
-        </Fragment>
-      ) : (
-        <div style={{ paddingLeft: '24px', paddingRight: '24px' }}>
-          <EuiSpacer size="l" />
+      )}
+      {!useUpdatedUX && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiText size="s">
+            Automated insights showing correlated anomalies across your detectors
+          </EuiText>
+        </>
+      )}
+      <EuiSpacer size="xl" />
+      <div style={{ paddingLeft: '24px', paddingRight: '24px' }}>
+        {(isLoading || isRefreshing) ? (
+          <EuiEmptyPrompt
+            icon={<EuiLoadingSpinner size="xl" />}
+          />
+        ) : insightsEnabled ? (
+          renderInsightsView()
+        ) : (
           <EuiPanel hasBorder paddingSize="l" data-test-subj="dailyInsightsSetupPanel">
             {renderSetupView()}
-            
           </EuiPanel>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Index Selection Modal */}
       <EnhancedSelectionModal

--- a/public/pages/DailyInsights/containers/DailyInsights.tsx
+++ b/public/pages/DailyInsights/containers/DailyInsights.tsx
@@ -26,6 +26,8 @@ import {
   EuiButtonEmpty,
   EuiDescriptionList,
   EuiCodeBlock,
+  EuiCallOut,
+  EuiLink,
 } from '@elastic/eui';
 import React, { useState, useEffect, useMemo, Fragment } from 'react';
 import { useDispatch } from 'react-redux';
@@ -34,6 +36,8 @@ import { RouteComponentProps } from 'react-router-dom';
 import queryString from 'querystring';
 import { CoreServicesContext } from '../../../components/CoreServices/CoreServices';
 import { executeAutoCreateAgent } from '../../../redux/reducers/ml';
+import { useAgentTaskPolling } from '../hooks/useAgentTaskPolling';
+import { getAgentTask } from '../utils/agentTaskStorage';
 import {
   getInsightsResults as getInsightsResultsAction,
   getInsightsStatus as getInsightsStatusAction,
@@ -47,7 +51,7 @@ import {
   getDataSourceFromURL,
   isDataSourceCompatible,
 } from '../../utils/helpers';
-import { BREADCRUMBS, MDS_BREADCRUMBS, USE_NEW_HOME_PAGE } from '../../../utils/constants';
+import { BREADCRUMBS, MDS_BREADCRUMBS, USE_NEW_HOME_PAGE, DAILY_INSIGHTS_INDICES_PAGE_NAV_ID } from '../../../utils/constants';
 import { CoreStart, MountPoint } from '../../../../../../src/core/public';
 import { DataSourceSelectableConfig } from '../../../../../../src/plugins/data_source_management/public';
 import {
@@ -216,6 +220,11 @@ export function DailyInsights(props: DailyInsightsProps) {
       : undefined,
   });
 
+  const { isPolling, startPolling } = useAgentTaskPolling(
+    MDSInsightsState.selectedDataSourceId || '',
+    (outcome) => fetchInsightsStatusAndResults()
+  );
+
   const handleDataSourceChange = (dataSources: any[]) => {
     const dataSourceId = dataSources[0]?.id;
     if (dataSourceEnabled && dataSourceId === undefined) {
@@ -372,57 +381,50 @@ export function DailyInsights(props: DailyInsightsProps) {
       setIsIndexSelectionModalVisible(true);
       return;
     }
+    if (!agentId) return;
 
+    const dsId = MDSInsightsState.selectedDataSourceId || '';
     setIsStarting(true);
-    
-    if (agentId) {
-      // Step 1: Execute ML agent - following ReviewAndCreate pattern exactly
-      dispatch(
-        executeAutoCreateAgent(selectedIndicesForSetup, agentId, MDSInsightsState.selectedDataSourceId || '')
-      ).then((resp: any) => {
-          // Check if response indicates success
-          if (!resp || resp.error || !resp.response) {     
-            core?.notifications.toasts.addDanger(
-              'Failed to execute ML agent - API endpoint not available'
-            );
-            setIsStarting(false);
-            return;
-          }
-          // Step 2: Start insights job after delay
-          setTimeout(async () => {
-            try {
-              await dispatch(
-                startInsightsJobAction(
-                  '24h',
-                  MDSInsightsState.selectedDataSourceId || ''
-                )
-              );
-              
-              core?.notifications.toasts.addSuccess({
-                title: 'Insights job started successfully',
-                text: `Auto-created detectors for ${selectedIndicesForSetup.length} indices.`,
-              });
-              
-              await fetchInsightsStatusAndResults();
-            } catch (error: any) {              
-              core?.notifications.toasts.addDanger(
-                prettifyErrorMessage(
-                  getErrorMessage(error, 'There was a problem starting the insights job')
-                )
-              );
-            } finally {
-              setIsStarting(false);
-            }
-          }, 3000);
-        })
-        .catch((err: any) => {          
-          core?.notifications.toasts.addDanger(
-            prettifyErrorMessage(
-              getErrorMessage(err, 'There was a problem executing the ML agent')
-            )
-          );
-          setIsStarting(false);
-        });
+
+    try {
+      // Start insights job first — if this fails, don't create detectors
+      if (!insightsEnabled) {
+        try {
+          await dispatch(startInsightsJobAction('24h', dsId));
+        } catch (error: any) {
+          core?.notifications.toasts.addDanger({
+            title: 'Failed to start insights job',
+            text: 'Detector creation was not started. Please try again.',
+          });
+          return;
+        }
+      }
+
+      const resp: any = await dispatch(
+        executeAutoCreateAgent(selectedIndicesForSetup, agentId, dsId)
+      );
+      if (!resp || resp.error || !resp.response) {
+        core?.notifications.toasts.addDanger('Failed to execute ML agent');
+        return;
+      }
+
+      const taskId = resp.response?.task_id || resp.task_id;
+      if (taskId) {
+        startPolling(taskId);
+      }
+
+      core?.notifications.toasts.addSuccess({
+        title: 'Insights job started',
+        text: `Creating detectors for ${selectedIndicesForSetup.length} ${selectedIndicesForSetup.length === 1 ? 'index' : 'indices'}. You'll be notified when complete.`,
+      });
+
+      await fetchInsightsStatusAndResults();
+    } catch (err: any) {
+      core?.notifications.toasts.addDanger(
+        prettifyErrorMessage(getErrorMessage(err, 'There was a problem executing the ML agent'))
+      );
+    } finally {
+      setIsStarting(false);
     }
   };
 
@@ -636,6 +638,29 @@ export function DailyInsights(props: DailyInsightsProps) {
 
   const renderInsightsView = () => {
     if (insightsResults.length === 0) {
+      // Check if the last agent task failed — show error instead of generic "no insights"
+      const lastTask = getAgentTask();
+      if (lastTask?.finalState === 'FAILED' || lastTask?.finalState === 'TIMEOUT') {
+        return (
+          <Fragment>
+            <EuiCallOut
+              title="Detector creation failed"
+              color="danger"
+              iconType="alert"
+            >
+              <p>
+                The last attempt to create detectors did not succeed.{' '}
+                <EuiLink
+                  href={`/app/${DAILY_INSIGHTS_INDICES_PAGE_NAV_ID}`}
+                >
+                  Go to Indices Management
+                </EuiLink>
+                {' '}to try again with different indices.
+              </p>
+            </EuiCallOut>
+          </Fragment>
+        );
+      }
       return (
         <Fragment>
           <EuiPanel hasBorder>
@@ -858,11 +883,8 @@ export function DailyInsights(props: DailyInsightsProps) {
         onConfirm={() => {}}
         onStartInsights={async (indices, agentId) => {
           setSelectedIndicesForSetup(indices);
-          try {
-            await handleStartInsights(agentId);
-            setIsIndexSelectionModalVisible(false);
-          } catch (error: any) {
-          }
+          await handleStartInsights(agentId);
+          setIsIndexSelectionModalVisible(false);
         }}
         isLoading={isStarting}
       />

--- a/public/pages/DailyInsights/hooks/__tests__/useAgentTaskPolling.test.ts
+++ b/public/pages/DailyInsights/hooks/__tests__/useAgentTaskPolling.test.ts
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useAgentTaskPolling } from '../useAgentTaskPolling';
+import * as storage from '../../utils/agentTaskStorage';
+
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../../redux/reducers/ml', () => ({
+  getMLTaskStatus: (taskId: string, dsId: string) => ({
+    type: 'ml/GET_ML_TASK',
+    taskId,
+    dsId,
+  }),
+}));
+
+jest.mock('../../../../services', () => ({
+  getNotifications: () => ({
+    toasts: {
+      addSuccess: jest.fn(),
+      addDanger: jest.fn(),
+      addWarning: jest.fn(),
+    },
+  }),
+}));
+
+jest.mock('../../utils/agentTaskStorage', () => {
+  const actual = jest.requireActual('../../utils/agentTaskStorage');
+  return {
+    ...actual,
+    showCompletionToasts: jest.fn(),
+    showAgentFailureToast: jest.fn(),
+  };
+});
+
+describe('useAgentTaskPolling', () => {
+  let hookUnmount: () => void;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    // Unmount hook to trigger cleanup (clears intervals)
+    if (hookUnmount) hookUnmount();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('startPolling sets isPolling=true and saves to sessionStorage', () => {
+    const onComplete = jest.fn();
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    expect(result.current.isPolling).toBe(false);
+
+    act(() => {
+      result.current.startPolling('task-123');
+    });
+
+    expect(result.current.isPolling).toBe(true);
+    const task = storage.getAgentTask();
+    expect(task).toMatchObject({ taskId: 'task-123', dsId: 'ds-1' });
+  });
+
+  test('calls onComplete with COMPLETED when task finishes', async () => {
+    const onComplete = jest.fn();
+    mockDispatch.mockResolvedValue({
+      response: { state: 'COMPLETED', response: { inference_results: [] } },
+    });
+
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    act(() => {
+      result.current.startPolling('task-1');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith('COMPLETED', expect.anything());
+    expect(result.current.isPolling).toBe(false);
+    expect(storage.getAgentTask()!.finalState).toBe('COMPLETED');
+  });
+
+  test('calls onComplete with FAILED when task fails', async () => {
+    const onComplete = jest.fn();
+    mockDispatch.mockResolvedValue({
+      response: { state: 'FAILED', error: 'tool not found' },
+    });
+
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    act(() => {
+      result.current.startPolling('task-1');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith('FAILED', expect.anything());
+    expect(result.current.isPolling).toBe(false);
+    expect(storage.showAgentFailureToast).toHaveBeenCalled();
+  });
+
+  test('times out after MAX_POLLS (60 polls = 5 min)', async () => {
+    const onComplete = jest.fn();
+    mockDispatch.mockResolvedValue({ response: { state: 'RUNNING' } });
+
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    act(() => {
+      result.current.startPolling('task-1');
+    });
+
+    for (let i = 0; i < 61; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+      });
+    }
+
+    expect(onComplete).toHaveBeenCalledWith('TIMEOUT');
+    expect(result.current.isPolling).toBe(false);
+    expect(storage.getAgentTask()!.finalState).toBe('TIMEOUT');
+  });
+
+  test('stops after MAX_CONSECUTIVE_ERRORS (3) dispatch failures', async () => {
+    const onComplete = jest.fn();
+    mockDispatch.mockRejectedValue(new Error('network error'));
+
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    act(() => {
+      result.current.startPolling('task-1');
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+      });
+    }
+
+    expect(onComplete).toHaveBeenCalledWith('FAILED');
+    expect(result.current.isPolling).toBe(false);
+  });
+
+  test('does not poll when task already has finalState', async () => {
+    const onComplete = jest.fn();
+    storage.saveAgentTask('task-old', 'ds-1');
+    storage.updateAgentTaskState('COMPLETED');
+
+    mockDispatch.mockResolvedValue({ response: { state: 'RUNNING' } });
+
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    expect(result.current.isPolling).toBe(false);
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  test('resumes polling on mount when active task exists in sessionStorage', async () => {
+    const onComplete = jest.fn();
+    storage.saveAgentTask('task-active', 'ds-1');
+
+    mockDispatch.mockResolvedValue({ response: { state: 'COMPLETED', response: {} } });
+
+    const { result, unmount } = renderHook(() => useAgentTaskPolling('ds-1', onComplete));
+    hookUnmount = unmount;
+
+    expect(result.current.isPolling).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onComplete).toHaveBeenCalledWith('COMPLETED', expect.anything());
+  });
+});

--- a/public/pages/DailyInsights/hooks/useAgentTaskPolling.ts
+++ b/public/pages/DailyInsights/hooks/useAgentTaskPolling.ts
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { getMLTaskStatus } from '../../../redux/reducers/ml';
+import { getNotifications } from '../../../services';
+import { getAgentTask, saveAgentTask, updateAgentTaskState, extractFailedIndices, showCompletionToasts, showAgentFailureToast } from '../utils/agentTaskStorage';
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLLS = 60; // 5 minutes
+const MAX_CONSECUTIVE_ERRORS = 3;
+
+type PollOutcome = 'COMPLETED' | 'FAILED' | 'TIMEOUT';
+
+export function useAgentTaskPolling(
+  dataSourceId: string,
+  onComplete: (outcome: PollOutcome, response?: any) => void
+) {
+  const dispatch = useDispatch();
+  const [isPolling, setIsPolling] = useState(false);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollCountRef = useRef(0);
+  const errorCountRef = useRef(0);
+  const tickActiveRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+
+  const stopPolling = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    pollCountRef.current = 0;
+    errorCountRef.current = 0;
+    setIsPolling(false);
+  };
+
+  const poll = async () => {
+    if (tickActiveRef.current) return;
+    tickActiveRef.current = true;
+    try {
+      // Read task info from sessionStorage each tick to avoid stale closures
+      const task = getAgentTask();
+      if (!task || task.finalState) {
+        stopPolling();
+        return;
+      }
+
+      pollCountRef.current += 1;
+      if (pollCountRef.current > MAX_POLLS) {
+        updateAgentTaskState('TIMEOUT');
+        stopPolling();
+        getNotifications().toasts.addWarning('Agent task polling timed out after 5 minutes.');
+        onCompleteRef.current('TIMEOUT');
+        return;
+      }
+
+      try {
+        const resp: any = await dispatch(
+          getMLTaskStatus(task.taskId, task.dsId)
+        );
+        errorCountRef.current = 0;
+        const state = resp?.response?.state || '';
+
+        if (state === 'COMPLETED') {
+          const failures = extractFailedIndices(resp.response);
+          updateAgentTaskState('COMPLETED', failures.length > 0 ? failures : undefined);
+          stopPolling();
+          showCompletionToasts(resp.response);
+          onCompleteRef.current('COMPLETED', resp);
+        } else if (state === 'FAILED' || state === 'CANCELLED') {
+          updateAgentTaskState('FAILED');
+          stopPolling();
+          showAgentFailureToast(
+            resp?.response?.response?.error_message || resp?.response?.error || 'Check logs for details.'
+          );
+          onCompleteRef.current('FAILED', resp);
+        }
+      } catch {
+        errorCountRef.current += 1;
+        if (errorCountRef.current >= MAX_CONSECUTIVE_ERRORS) {
+          updateAgentTaskState('FAILED');
+          stopPolling();
+          getNotifications().toasts.addWarning(
+            'Lost connection while tracking agent task. Check the Insight Management page for results.'
+          );
+          onCompleteRef.current('FAILED');
+        }
+      }
+    } finally {
+      tickActiveRef.current = false;
+    }
+  };
+
+  // Note: if user has multiple browser tabs, startPolling uses last-write-wins
+  // for sessionStorage. This is acceptable — the latest task is the most relevant.
+  const startPolling = (taskId: string) => {
+    stopPolling();
+    saveAgentTask(taskId, dataSourceId);
+    setIsPolling(true);
+    pollCountRef.current = 0;
+    errorCountRef.current = 0;
+    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+  };
+
+  // Resume polling on mount if there's an active task in sessionStorage
+  useEffect(() => {
+    const task = getAgentTask();
+    if (task && !task.finalState) {
+      setIsPolling(true);
+      intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+    }
+    return () => stopPolling();
+  }, []);
+
+  return { isPolling, startPolling };
+}

--- a/public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.ts
+++ b/public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.ts
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  saveAgentTask,
+  getAgentTask,
+  updateAgentTaskState,
+  extractFailedIndices,
+} from '../agentTaskStorage';
+
+const STORAGE_KEY = 'ad_agent_task';
+
+describe('agentTaskStorage', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe('saveAgentTask / getAgentTask', () => {
+    test('round-trips task info', () => {
+      saveAgentTask('task-1', 'ds-1');
+      const task = getAgentTask();
+      expect(task).toMatchObject({ taskId: 'task-1', dsId: 'ds-1' });
+      expect(task!.finalState).toBeUndefined();
+    });
+
+    test('returns null when empty', () => {
+      expect(getAgentTask()).toBeNull();
+    });
+
+    test('returns null for corrupted JSON', () => {
+      sessionStorage.setItem(STORAGE_KEY, '{bad');
+      expect(getAgentTask()).toBeNull();
+    });
+
+    test('expires after 24h and cleans up storage', () => {
+      sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ taskId: 't', dsId: 'd', startTime: Date.now() - 25 * 3600 * 1000 })
+      );
+      expect(getAgentTask()).toBeNull();
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    test('keeps entries under 24h', () => {
+      sessionStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ taskId: 't', dsId: 'd', startTime: Date.now() - 23 * 3600 * 1000 })
+      );
+      expect(getAgentTask()!.taskId).toBe('t');
+    });
+
+    test('new save overwrites previous (last-write-wins)', () => {
+      saveAgentTask('old', 'ds-1');
+      updateAgentTaskState('FAILED');
+      saveAgentTask('new', 'ds-2');
+      const task = getAgentTask()!;
+      expect(task.taskId).toBe('new');
+      expect(task.finalState).toBeUndefined();
+    });
+  });
+
+  describe('updateAgentTaskState', () => {
+    test('sets finalState', () => {
+      saveAgentTask('t', 'd');
+      updateAgentTaskState('COMPLETED');
+      expect(getAgentTask()!.finalState).toBe('COMPLETED');
+    });
+
+    test('stores failedIndices when provided', () => {
+      saveAgentTask('t', 'd');
+      updateAgentTaskState('COMPLETED', [{ index: 'idx', error: 'bad mapping' }]);
+      expect(getAgentTask()!.failedIndices).toEqual([{ index: 'idx', error: 'bad mapping' }]);
+    });
+
+    test('omits failedIndices key when not provided', () => {
+      saveAgentTask('t', 'd');
+      updateAgentTaskState('COMPLETED');
+      const raw = JSON.parse(sessionStorage.getItem(STORAGE_KEY)!);
+      expect(raw).not.toHaveProperty('failedIndices');
+    });
+
+    test('no-ops when storage is empty', () => {
+      updateAgentTaskState('FAILED');
+      expect(getAgentTask()).toBeNull();
+    });
+  });
+
+  describe('extractFailedIndices', () => {
+    const wrap = (obj: Record<string, any[]>) => ({
+      response: {
+        inference_results: [{ output: [{ result: JSON.stringify(obj) }] }],
+      },
+    });
+
+    test('extracts failures, ignores successes', () => {
+      const resp = wrap({
+        'idx-a': [
+          { status: 'success', detectorName: 'd1' },
+          { status: 'failed', error: 'conflict' },
+        ],
+        'idx-b': [{ status: 'error', error: 'timeout' }],
+      });
+      expect(extractFailedIndices(resp)).toEqual([
+        { index: 'idx-a', error: 'conflict' },
+        { index: 'idx-b', error: 'timeout' },
+      ]);
+    });
+
+    test('returns empty when all succeed', () => {
+      expect(extractFailedIndices(wrap({ i: [{ status: 'success' }] }))).toEqual([]);
+    });
+
+    test('returns empty for null/undefined/empty', () => {
+      expect(extractFailedIndices(null)).toEqual([]);
+      expect(extractFailedIndices(undefined)).toEqual([]);
+      expect(extractFailedIndices({})).toEqual([]);
+    });
+
+    test('returns empty for malformed JSON in result', () => {
+      const resp = { response: { inference_results: [{ output: [{ result: 'not json' }] }] } };
+      expect(extractFailedIndices(resp)).toEqual([]);
+    });
+
+    test('defaults to "Unknown error" when error field missing', () => {
+      expect(extractFailedIndices(wrap({ i: [{ status: 'failed' }] }))).toEqual([
+        { index: 'i', error: 'Unknown error' },
+      ]);
+    });
+  });
+});

--- a/public/pages/DailyInsights/utils/agentTaskStorage.tsx
+++ b/public/pages/DailyInsights/utils/agentTaskStorage.tsx
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiLink, EuiText } from '@elastic/eui';
+import { getNotifications } from '../../../services';
+import { mountReactNode } from '../../../../../../src/core/public/utils';
+import { DAILY_INSIGHTS_INDICES_PAGE_NAV_ID } from '../../../utils/constants';
+
+const STORAGE_KEY = 'ad_agent_task';
+const IM_URL = `/app/${DAILY_INSIGHTS_INDICES_PAGE_NAV_ID}`;
+
+export interface AgentTaskInfo {
+  taskId: string;
+  dsId: string;
+  startTime: number;
+  finalState?: string;
+  failedIndices?: Array<{ index: string; error: string }>;
+}
+
+export function saveAgentTask(taskId: string, dsId: string) {
+  sessionStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ taskId, dsId, startTime: Date.now() })
+  );
+}
+
+export function getAgentTask(): AgentTaskInfo | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const task = JSON.parse(raw);
+    // Expire after 24h
+    if (Date.now() - task.startTime > 24 * 60 * 60 * 1000) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return task;
+  } catch {
+    return null;
+  }
+}
+
+export function updateAgentTaskState(
+  finalState: string,
+  failedIndices?: Array<{ index: string; error: string }>
+) {
+  const task = getAgentTask();
+  if (task) {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...task, finalState, ...(failedIndices && { failedIndices }) })
+    );
+  }
+}
+
+export function extractFailedIndices(response: any): Array<{ index: string; error: string }> {
+  try {
+    const raw = response?.response?.inference_results?.[0]?.output?.[0]?.result;
+    if (!raw) return [];
+    const result = JSON.parse(raw);
+    const failures: Array<{ index: string; error: string }> = [];
+    for (const idx of Object.keys(result)) {
+      const dets = result[idx] || [];
+      for (const d of dets) {
+        if (d.status !== 'success') {
+          failures.push({ index: idx, error: d.error || 'Unknown error' });
+        }
+      }
+    }
+    return failures;
+  } catch {
+    return [];
+  }
+}
+
+export function showCompletionToasts(response: any) {
+  const notifications = getNotifications();
+  try {
+    const raw =
+      response?.response?.inference_results?.[0]?.output?.[0]?.result;
+    if (!raw) {
+      notifications.toasts.addSuccess('Agent task completed');
+      return;
+    }
+    const result = JSON.parse(raw);
+    const successEntries: string[] = [];
+    const failureEntries: string[] = [];
+
+    for (const idx of Object.keys(result)) {
+      const dets = result[idx] || [];
+      const successes = dets.filter((d: any) => d.status === 'success');
+      const failures = dets.filter((d: any) => d.status !== 'success');
+      if (successes.length > 0) {
+        successEntries.push(`${idx}: ${successes.length} detector(s)`);
+      }
+      for (const f of failures) {
+        failureEntries.push(`${idx}: ${f.error || 'Unknown error'}`);
+      }
+    }
+
+    if (successEntries.length > 0) {
+      notifications.toasts.addSuccess({
+        title: `${successEntries.length} ${successEntries.length === 1 ? 'index' : 'indices'} configured`,
+        text: mountReactNode(
+          <EuiText size="s">
+            <p>{successEntries.join(', ')}</p>
+            <EuiLink href={IM_URL}>
+              View in Indices Management
+            </EuiLink>
+          </EuiText>
+        ),
+      });
+    }
+
+    if (failureEntries.length > 0) {
+      notifications.toasts.addDanger({
+        title: `${failureEntries.length} ${failureEntries.length === 1 ? 'index' : 'indices'} failed`,
+        text: mountReactNode(
+          <EuiText size="s">
+            {failureEntries.map((entry, i) => (
+              <p key={i}>{entry}</p>
+            ))}
+            <EuiLink href={IM_URL}>
+              Go to Indices Management to retry
+            </EuiLink>
+          </EuiText>
+        ),
+        toastLifeTimeMs: 60000,
+      });
+    }
+  } catch {
+    notifications.toasts.addSuccess('Agent task completed');
+  }
+}
+
+export function showAgentFailureToast(errorMessage: string) {
+  const notifications = getNotifications();
+  notifications.toasts.addDanger({
+    title: 'Detector creation failed',
+    text: mountReactNode(
+      <EuiText size="s">
+        <p>{errorMessage}</p>
+        <EuiLink
+          href={IM_URL}
+        >
+          Go to Indices Management to retry
+        </EuiLink>
+      </EuiText>
+    ),
+    toastLifeTimeMs: 60000,
+  });
+}

--- a/public/redux/reducers/__tests__/ml.test.ts
+++ b/public/redux/reducers/__tests__/ml.test.ts
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MockStore } from 'redux-mock-store';
+import httpMockedClient from '../../../../test/mocks/httpClientMock';
+import { ML_COMMONS_NODE_API } from '../../../../utils/constants';
+import { mockedStore } from '../../utils/testUtils';
+import reducer, {
+  executeAutoCreateAgent,
+  getMLTaskStatus,
+  initialMLState,
+} from '../ml';
+
+describe('ml reducer actions', () => {
+  let store: MockStore;
+  beforeEach(() => {
+    store = mockedStore();
+  });
+
+  describe('executeAutoCreateAgent', () => {
+    test('should invoke [REQUEST, SUCCESS] and extract task_id', async () => {
+      httpMockedClient.post = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { task_id: 'task-abc' },
+      });
+      await store.dispatch(executeAutoCreateAgent(['index-1'], 'agent-1', ''));
+      const actions = store.getActions();
+      expect(actions[0].type).toBe('ml/EXECUTE_ML_AGENT_REQUEST');
+      expect(reducer(initialMLState, actions[0])).toEqual({
+        ...initialMLState,
+        requesting: true,
+        taskId: '',
+        taskState: '',
+        taskError: '',
+      });
+      expect(actions[1].type).toBe('ml/EXECUTE_ML_AGENT_SUCCESS');
+      expect(reducer(initialMLState, actions[1]).taskId).toBe('task-abc');
+      expect(reducer(initialMLState, actions[1]).requesting).toBe(false);
+    });
+
+    test('should invoke [REQUEST, FAILURE]', async () => {
+      httpMockedClient.post = jest.fn().mockRejectedValue('Agent not found');
+      try {
+        await store.dispatch(executeAutoCreateAgent(['index-1'], 'bad-agent', ''));
+      } catch {
+        const actions = store.getActions();
+        expect(actions[1].type).toBe('ml/EXECUTE_ML_AGENT_FAILURE');
+        expect(reducer(initialMLState, actions[1]).errorMessage).toBe('Agent not found');
+      }
+    });
+
+    test('builds correct URL without dataSourceId', async () => {
+      httpMockedClient.post = jest.fn().mockResolvedValue({ ok: true, response: {} });
+      await store.dispatch(executeAutoCreateAgent(['idx'], 'agent-1', ''));
+      expect(httpMockedClient.post).toHaveBeenCalledWith(
+        `${ML_COMMONS_NODE_API.AGENT_EXECUTE}/agent-1/execute`,
+        expect.objectContaining({
+          body: JSON.stringify({ indices: ['idx'] }),
+          query: { async: 'true' },
+        })
+      );
+    });
+
+    test('appends dataSourceId to URL when provided', async () => {
+      httpMockedClient.post = jest.fn().mockResolvedValue({ ok: true, response: {} });
+      await store.dispatch(executeAutoCreateAgent(['idx'], 'agent-1', 'ds-99'));
+      expect(httpMockedClient.post).toHaveBeenCalledWith(
+        `${ML_COMMONS_NODE_API.AGENT_EXECUTE}/agent-1/execute/ds-99`,
+        expect.anything()
+      );
+    });
+
+    test('extracts task_id from nested response', async () => {
+      httpMockedClient.post = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { task_id: 'nested-id' },
+      });
+      await store.dispatch(executeAutoCreateAgent(['idx'], 'agent-1', ''));
+      const actions = store.getActions();
+      const state = reducer(initialMLState, actions[1]);
+      expect(state.taskId).toBe('nested-id');
+    });
+  });
+
+  describe('getMLTaskStatus', () => {
+    test('should invoke [REQUEST, SUCCESS] and set taskState', async () => {
+      httpMockedClient.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { state: 'COMPLETED', error: '' },
+      });
+      await store.dispatch(getMLTaskStatus('task-1', ''));
+      const actions = store.getActions();
+      expect(actions[0].type).toBe('ml/GET_ML_TASK_REQUEST');
+      // REQUEST should not mutate state
+      expect(reducer(initialMLState, actions[0])).toEqual(initialMLState);
+      expect(actions[1].type).toBe('ml/GET_ML_TASK_SUCCESS');
+      const state = reducer(initialMLState, actions[1]);
+      expect(state.taskState).toBe('COMPLETED');
+      expect(state.taskError).toBe('');
+    });
+
+    test('sets taskState to FAILED on network error', async () => {
+      httpMockedClient.get = jest.fn().mockRejectedValue('Network error');
+      try {
+        await store.dispatch(getMLTaskStatus('task-1', ''));
+      } catch {
+        const actions = store.getActions();
+        expect(actions[1].type).toBe('ml/GET_ML_TASK_FAILURE');
+        const state = reducer(initialMLState, actions[1]);
+        expect(state.taskState).toBe('FAILED');
+        expect(state.taskError).toBeTruthy();
+      }
+    });
+
+    test('builds correct URL with dataSourceId', async () => {
+      httpMockedClient.get = jest.fn().mockResolvedValue({ ok: true, response: { state: 'RUNNING' } });
+      await store.dispatch(getMLTaskStatus('task-1', 'ds-5'));
+      expect(httpMockedClient.get).toHaveBeenCalledWith(
+        `${ML_COMMONS_NODE_API.TASK_STATUS}/task-1/ds-5`
+      );
+    });
+
+    test('builds correct URL without dataSourceId', async () => {
+      httpMockedClient.get = jest.fn().mockResolvedValue({ ok: true, response: { state: 'RUNNING' } });
+      await store.dispatch(getMLTaskStatus('task-1', ''));
+      expect(httpMockedClient.get).toHaveBeenCalledWith(
+        `${ML_COMMONS_NODE_API.TASK_STATUS}/task-1`
+      );
+    });
+
+    test('preserves existing taskId when polling', async () => {
+      const stateWithTask = { ...initialMLState, taskId: 'existing-task' };
+      httpMockedClient.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { state: 'RUNNING' },
+      });
+      await store.dispatch(getMLTaskStatus('task-1', ''));
+      const actions = store.getActions();
+      const newState = reducer(stateWithTask, actions[1]);
+      expect(newState.taskId).toBe('existing-task');
+      expect(newState.taskState).toBe('RUNNING');
+    });
+  });
+});

--- a/public/redux/reducers/ml.ts
+++ b/public/redux/reducers/ml.ts
@@ -7,17 +7,22 @@ import handleActions from '../utils/handleActions';
 import { ML_COMMONS_NODE_API } from '../../../utils/constants';
 
 const EXECUTE_ML_AGENT = 'ml/EXECUTE_ML_AGENT';
+const GET_ML_TASK = 'ml/GET_ML_TASK';
 
 export interface MLState {
   requesting: boolean;
   taskId: string;
   errorMessage: string;
+  taskState: string;
+  taskError: string;
 }
 
 export const initialMLState: MLState = {
   requesting: false,
   taskId: '',
   errorMessage: '',
+  taskState: '',
+  taskError: '',
 };
 
 const reducer = handleActions<MLState>(
@@ -27,16 +32,32 @@ const reducer = handleActions<MLState>(
         ...state,
         requesting: true,
         errorMessage: '',
+        taskId: '',
+        taskState: '',
+        taskError: '',
       }),
       SUCCESS: (state: MLState, action: APIResponseAction): MLState => ({
         ...state,
         requesting: false,
-        taskId: action.result.task_id,
+        taskId: action.result.response?.task_id || action.result.task_id || '',
       }),
       FAILURE: (state: MLState, action: APIResponseAction): MLState => ({
         ...state,
         requesting: false,
         errorMessage: action.error,
+      }),
+    },
+    [GET_ML_TASK]: {
+      REQUEST: (state: MLState): MLState => state,
+      SUCCESS: (state: MLState, action: APIResponseAction): MLState => ({
+        ...state,
+        taskState: action.result.response?.state || '',
+        taskError: action.result.response?.error || '',
+      }),
+      FAILURE: (state: MLState, action: APIResponseAction): MLState => ({
+        ...state,
+        taskState: 'FAILED',
+        taskError: action.error || 'Failed to fetch task status',
       }),
     },
   },
@@ -56,12 +77,24 @@ export const executeAutoCreateAgent = (
     request: (client: HttpSetup) =>
       client.post(url, {
         body: JSON.stringify({ indices }),
-        query: { 
-          async: 'true'
+        query: {
+          async: 'true',
         },
       }),
   };
 };
 
-export default reducer;
+export const getMLTaskStatus = (
+  taskId: string,
+  dataSourceId: string = ''
+): APIAction => {
+  const baseUrl = `${ML_COMMONS_NODE_API.TASK_STATUS}/${taskId}`;
+  const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
 
+  return {
+    type: GET_ML_TASK,
+    request: (client: HttpSetup) => client.get(url),
+  };
+};
+
+export default reducer;

--- a/server/cluster/ad/mlPlugin.ts
+++ b/server/cluster/ad/mlPlugin.ts
@@ -29,4 +29,17 @@ export default function mlPlugin(
     needBody: true,
     method: 'POST',
   });
+
+  ml.getTask = ca({
+    url: {
+      fmt: `/_plugins/_ml/tasks/<%=taskId%>`,
+      req: {
+        taskId: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'GET',
+  });
 }

--- a/server/routes/ml.ts
+++ b/server/routes/ml.ts
@@ -25,6 +25,8 @@ export function registerMLRoutes(
 ) {
   apiRouter.post('/agents/{agentId}/execute', mlService.executeAgent);
   apiRouter.post('/agents/{agentId}/execute/{dataSourceId}', mlService.executeAgent);
+  apiRouter.get('/tasks/{taskId}', mlService.getTask);
+  apiRouter.get('/tasks/{taskId}/{dataSourceId}', mlService.getTask);
 }
 
 export default class MLService {
@@ -78,6 +80,39 @@ export default class MLService {
         body: {
           ok: false,
           error: errorDetails,
+        },
+      });
+    }
+  };
+
+  getTask = async (
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    try {
+      const { taskId, dataSourceId = '' } = request.params as { taskId: string; dataSourceId?: string };
+      const callWithRequest = getClientBasedOnDataSource(
+        context,
+        this.dataSourceEnabled,
+        request,
+        dataSourceId,
+        this.client
+      );
+
+      const response = await callWithRequest('ml.getTask', { taskId });
+
+      return opensearchDashboardsResponse.ok({
+        body: {
+          ok: true,
+          response,
+        },
+      });
+    } catch (err: any) {
+      return opensearchDashboardsResponse.ok({
+        body: {
+          ok: false,
+          error: err?.body?.error?.reason || err?.message || 'Failed to get task status',
         },
       });
     }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -36,6 +36,7 @@ export const ALERTING_NODE_API = Object.freeze({
 
 export const ML_COMMONS_NODE_API = Object.freeze({
   AGENT_EXECUTE: `/api/ml/agents`,
+  TASK_STATUS: `/api/ml/tasks`,
 });
 
 export const FORECAST_BASE_NODE_API_PATH = '/api/forecasting';


### PR DESCRIPTION
### Description

Adds async agent task tracking for the auto-detector creation flow. When users start insights, the ML agent runs asynchronously, this PR polls task status, persists state across navigation via sessionStorage, and shows per-index results as toasts. Also fixes UI flash issues on the Overview page.

### Changes

- **Page stability**: Synchronous featureEnabled init, combined status+results fetch, guarded history.replace which eliminates flash on load
- **ML task API**: Server route + Redux action for GET /_plugins/_ml/tasks/{taskId} with MDS support
- **Polling hook** (useAgentTaskPolling): 5s interval, 5min timeout, overlap guard, consecutive error handling. Persists task ID in sessionStorage (24h expiry) so polling survives page navigation
- **Error handling**: Insights job must succeed before agent fires. Consolidated toasts (one success, one failure). Error callouts on both Overview and Indices Management. Partial failure callout above detector table

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
