### PR TITLE
[Navigation] Use getIsIconSideNavEnabled API for nav registration

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -153,12 +153,26 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
     }
 
     // register applications with category and use case information
-    core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-      {
-        id: PLUGIN_NAME,
-        category: DEFAULT_APP_CATEGORIES.detect,
-      }
-    ]);
+    const enableIconSideNav = core.uiSettings.get('home:enableIconSideNav', false);
+
+    if (enableIconSideNav) {
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+        {
+          id: PLUGIN_NAME,
+          category: DEFAULT_APP_CATEGORIES.observabilityTools,
+          order: 5200,
+          title: 'Anomaly Detection',
+          euiIconType: 'navAnomalyDetection',
+        },
+      ]);
+    } else {
+      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+        {
+          id: PLUGIN_NAME,
+          category: DEFAULT_APP_CATEGORIES.detect,
+        },
+      ]);
+    }
     core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
       {
         id: PLUGIN_NAME,
@@ -173,12 +187,24 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
     ]);
 
     if (forecastingEnabled) {
-      core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
-        {
-          id: FORECASTING_FEATURE_NAME,
-          category: DEFAULT_APP_CATEGORIES.detect,
-        }
-      ]);
+      if (enableIconSideNav) {
+        core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+          {
+            id: FORECASTING_FEATURE_NAME,
+            category: DEFAULT_APP_CATEGORIES.observabilityTools,
+            order: 5300,
+            title: 'Forecasting',
+            euiIconType: 'visLine',
+          },
+        ]);
+      } else {
+        core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+          {
+            id: FORECASTING_FEATURE_NAME,
+            category: DEFAULT_APP_CATEGORIES.detect,
+          },
+        ]);
+      }
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.all, [
         {
           id: FORECASTING_FEATURE_NAME,

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -153,7 +153,7 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
     }
 
     // register applications with category and use case information
-    const enableIconSideNav = core.uiSettings.get('home:enableIconSideNav', false);
+    const enableIconSideNav = core.chrome.getIsIconSideNavEnabled();
 
     if (enableIconSideNav) {
       core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -57,6 +57,9 @@ describe('AnomalyDetectionPlugin nav registration', () => {
   beforeEach(() => {
     coreSetup = coreMock.createSetup();
     coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    if (!coreSetup.chrome.getIsIconSideNavEnabled) {
+      coreSetup.chrome.getIsIconSideNavEnabled = jest.fn();
+    }
     coreSetup.uiSettings.get = jest.fn().mockReturnValue(false);
     plugin = new AnomalyDetectionOpenSearchDashboardsPlugin();
   });

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -10,8 +10,20 @@
  */
 
 import { coreMock } from '../../../src/core/public/mocks';
-import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/public';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/utils';
 import { AnomalyDetectionOpenSearchDashboardsPlugin } from './plugin';
+
+jest.mock('@osd/monaco', () => ({
+  monaco: {
+    languages: {
+      CompletionItemKind: { Function: 1, Field: 4, Module: 6, Operator: 12, Keyword: 14 },
+      CompletionItemInsertTextRule: { InsertAsSnippet: 4 },
+      registerCompletionItemProvider: jest.fn(),
+    },
+    editor: { create: jest.fn(), defineTheme: jest.fn() },
+    Range: jest.fn(),
+  },
+}));
 
 // Mock dynamic imports used in mount functions
 jest.mock('./anomaly_detection_app', () => ({

--- a/public/plugin_nav.test.ts
+++ b/public/plugin_nav.test.ts
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { coreMock } from '../../../src/core/public/mocks';
+import { DEFAULT_APP_CATEGORIES, DEFAULT_NAV_GROUPS } from '../../../src/core/public';
+import { AnomalyDetectionOpenSearchDashboardsPlugin } from './plugin';
+
+// Mock dynamic imports used in mount functions
+jest.mock('./anomaly_detection_app', () => ({
+  renderApp: jest.fn(() => jest.fn()),
+}));
+jest.mock('./forecasting_app', () => ({
+  renderApp: jest.fn(() => jest.fn()),
+}));
+jest.mock('./daily_insights_app', () => ({
+  renderApp: jest.fn(() => jest.fn()),
+}));
+
+describe('AnomalyDetectionPlugin nav registration', () => {
+  let coreSetup: ReturnType<typeof coreMock.createSetup>;
+  let plugin: AnomalyDetectionOpenSearchDashboardsPlugin;
+
+  const mockPlugins = {
+    embeddable: { registerEmbeddableFactory: jest.fn() },
+    notifications: {},
+    visAugmenter: {},
+    dataSourceManagement: {},
+    dataSource: {},
+    data: {},
+    uiActions: {
+      addTriggerAction: jest.fn(),
+      registerTrigger: jest.fn(),
+    },
+    expressions: { registerFunction: jest.fn() },
+  } as any;
+
+  beforeEach(() => {
+    coreSetup = coreMock.createSetup();
+    coreSetup.chrome.navGroup.getNavGroupEnabled.mockReturnValue(true);
+    coreSetup.uiSettings.get = jest.fn().mockReturnValue(false);
+    plugin = new AnomalyDetectionOpenSearchDashboardsPlugin();
+  });
+
+  it('should use core.chrome.getIsIconSideNavEnabled() for flag check', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(true);
+
+    plugin.setup(coreSetup, mockPlugins);
+
+    // Verify getIsIconSideNavEnabled was called (the chrome API, not uiSettings)
+    expect(coreSetup.chrome.getIsIconSideNavEnabled).toHaveBeenCalled();
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    // When icon side nav is enabled, anomaly detection should be registered with
+    // observabilityTools category in observability group
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const iconSideNavCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'anomaly-detection-dashboards' &&
+          link.category === DEFAULT_APP_CATEGORIES.observabilityTools &&
+          link.euiIconType === 'navAnomalyDetection'
+      )
+    );
+    expect(iconSideNavCall).toBeDefined();
+  });
+
+  it('should register with detect category when icon side nav is disabled', () => {
+    (coreSetup.chrome.getIsIconSideNavEnabled as jest.Mock).mockReturnValue(false);
+
+    plugin.setup(coreSetup, mockPlugins);
+
+    expect(coreSetup.chrome.getIsIconSideNavEnabled).toHaveBeenCalled();
+
+    const calls = (coreSetup.chrome.navGroup.addNavLinksToGroup as jest.Mock).mock.calls;
+
+    const observabilityCalls = calls.filter(
+      (call: any) => call[0] === DEFAULT_NAV_GROUPS.observability
+    );
+    const defaultCall = observabilityCalls.find((call: any) =>
+      call[1].some(
+        (link: any) =>
+          link.id === 'anomaly-detection-dashboards' &&
+          link.category === DEFAULT_APP_CATEGORIES.detect
+      )
+    );
+    expect(defaultCall).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Migrates from reading the `home:enableIconSideNav` UI setting directly to using the new `core.chrome.getIsIconSideNavEnabled()` API for icon side nav detection in the Observability workspace.

**Changes:**
- Replace `core.uiSettings.get('home:enableIconSideNav', false)` with `core.chrome.getIsIconSideNavEnabled()`
- Add unit tests covering both icon side nav enabled and disabled paths
- Minor dependency version update

**Files changed:**
- `public/plugin.ts` — use `getIsIconSideNavEnabled()` API
- `public/plugin_nav.test.ts` — new test file with coverage for both nav modes
- `package.json` / `yarn.lock` — dependency update

## Related Issue

opensearch-project/OpenSearch-Dashboards#11545

## Test plan
- [ ] Verify anomaly detection nav links appear correctly in icon side nav (Observability workspace)
- [ ] Verify anomaly detection nav links appear correctly in default nav
- [ ] Run unit tests: `yarn test --testPathPattern=plugin_nav`