### PR TITLE
feat: disable unsupported features on multi-tenant services data sources

### DIFF
--- a/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
+++ b/public/pages/DefineDetector/components/CustomResultIndex/CustomResultIndex.tsx
@@ -43,10 +43,17 @@ interface CustomResultIndexProps {
   useDefaultResultIndex?: boolean;
   resultIndex?: string;
   formikProps: FormikProps<DetectorDefinitionFormikValues>;
+  // When true, the detector targets an OpenSearch Serverless (AOSS) collection.
+  // Serverless mandates a custom result index (no default index is created) and
+  // does not support the flattened-result-index ingest pipeline (script
+  // processor is not available). We hide the toggles and hard-wire the values.
+  isServerless?: boolean;
 }
 
 function CustomResultIndex(props: CustomResultIndexProps) {
-  const [enabled, setEnabled] = useState<boolean>(!!props.resultIndex);
+  const { isServerless = false } = props;
+  // On serverless, "Enable custom result index" is implicit — no toggle, always on.
+  const [enabled, setEnabled] = useState<boolean>(isServerless || !!props.resultIndex);
   const [customResultIndexConditionsEnabled, setCustomResultIndexConditionsEnabled] = useState<boolean>(true);
   const customResultIndexMinAge = get(props.formikProps, 'values.resultIndexMinAge');
   const customResultIndexMinSize = get(props.formikProps, 'values.resultIndexMinSize');
@@ -65,6 +72,16 @@ function CustomResultIndex(props: CustomResultIndexProps) {
       setFieldValue('resultIndexTtl', '');
     }
   },[customResultIndexConditionsEnabled])
+
+  // On serverless, flattened custom result index is unsupported because AOSS
+  // does not allow the `script` processor in ingest pipelines. Force the field
+  // to false so the detector payload never carries an enabled flag.
+  useEffect(() => {
+    if (isServerless) {
+      setEnabled(true);
+      setFieldValue('flattenCustomResultIndex', false);
+    }
+  }, [isServerless, setFieldValue]);
 
   const hintTextStyle = {
     color: '#69707d',
@@ -101,20 +118,32 @@ function CustomResultIndex(props: CustomResultIndexProps) {
       >
         {({ field, form }: FieldProps) => (
           <EuiFlexGroup direction="column">
-            <EuiFlexItem>
-              <EuiCompressedCheckbox
-                id={'resultIndexCheckbox'}
-                label="Enable custom result index"
-                checked={enabled}
-                disabled={props.isEdit}
-                onChange={() => {
-                  if (enabled) {
-                    form.setFieldValue('resultIndex', undefined);
-                  }
-                  setEnabled(!enabled);
-                }}
-              />
-            </EuiFlexItem>
+            {isServerless ? (
+              <EuiFlexItem>
+                <EuiCallOut
+                  data-test-subj="serverlessCustomResultIndexRequiredCallout"
+                  title="Custom result index is required on OpenSearch Serverless."
+                  color="primary"
+                  iconType="iInCircle"
+                  size="s"
+                />
+              </EuiFlexItem>
+            ) : (
+              <EuiFlexItem>
+                <EuiCompressedCheckbox
+                  id={'resultIndexCheckbox'}
+                  label="Enable custom result index"
+                  checked={enabled}
+                  disabled={props.isEdit}
+                  onChange={() => {
+                    if (enabled) {
+                      form.setFieldValue('resultIndex', undefined);
+                    }
+                    setEnabled(!enabled);
+                  }}
+                />
+              </EuiFlexItem>
+            )}
 
             {enabled ? (
               <EuiFlexItem>
@@ -152,7 +181,7 @@ function CustomResultIndex(props: CustomResultIndexProps) {
 
       <EuiFlexGroup direction="column">
         <EuiFlexItem>
-          { enabled ? (
+          { (enabled && !isServerless) ? (
             <Field
               name="flattenCustomResultIndex">
             {({ field, form }: FieldProps) => (

--- a/public/pages/DefineDetector/containers/DefineDetector.tsx
+++ b/public/pages/DefineDetector/containers/DefineDetector.tsx
@@ -61,6 +61,7 @@ import {
   getNotifications,
   getSavedObjectsClient,
 } from '../../../services';
+import { isServerlessDataSource } from '../../../utils/dataSourceUtils';
 import { DataSourceSelectableConfig, DataSourceViewConfig } from '../../../../../../src/plugins/data_source_management/public';
 import {
   constructHrefWithDataSourceId,
@@ -101,6 +102,22 @@ export const DefineDetector = (props: DefineDetectorProps) => {
     queryParams: MDSQueryParams,
     selectedDataSourceId: dataSourceId === undefined? undefined : dataSourceId,
   });
+
+  // Tracks whether the currently selected data source is an OpenSearch
+  // Serverless (AOSS) collection. Resolved asynchronously from the data-source
+  // saved object. Serverless disables several AD features (historical
+  // analysis, default result index, flattened result index) so child
+  // components must branch on this value.
+  const [isServerless, setIsServerless] = useState<boolean>(false);
+  useEffect(() => {
+    let cancelled = false;
+    isServerlessDataSource(MDSCreateState.selectedDataSourceId).then((result) => {
+      if (!cancelled) setIsServerless(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [MDSCreateState.selectedDataSourceId]);
 
   // To handle backward compatibility, we need to pass some fields via
   // props to the subcomponents so they can render correctly
@@ -392,6 +409,7 @@ export const DefineDetector = (props: DefineDetectorProps) => {
                   isEdit={props.isEdit}
                   resultIndex={get(formikProps, 'values.resultIndex')}
                   formikProps={formikProps}
+                  isServerless={isServerless}
                 />
               </Fragment>
             </EuiPageBody>

--- a/public/pages/DetectorDetail/containers/DetectorDetail.tsx
+++ b/public/pages/DetectorDetail/containers/DetectorDetail.tsx
@@ -71,6 +71,7 @@ import {
   getUISettings,
 } from '../../../services';
 import { constructHrefWithDataSourceId, getDataSourceFromURL } from '../../../pages/utils/helpers';
+import { isServerlessDataSource } from '../../../utils/dataSourceUtils';
 
 export interface DetectorRouterProps {
   detectorId?: string;
@@ -121,6 +122,21 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
   const location = useLocation();
   const MDSQueryParams = getDataSourceFromURL(location);
   const dataSourceId = MDSQueryParams.dataSourceId;
+
+  // Serverless (AOSS) does not support AD historical analysis in P0. Resolve
+  // this once from the data-source saved object and gate the tab, route, and
+  // downstream CTAs accordingly. Starts as false so local-cluster detectors
+  // render immediately; flips to true after the async lookup if applicable.
+  const [isServerless, setIsServerless] = useState<boolean>(false);
+  useEffect(() => {
+    let cancelled = false;
+    isServerlessDataSource(dataSourceId).then((result) => {
+      if (!cancelled) setIsServerless(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSourceId]);
 
   const { detector, hasError, isLoadingDetector, errorMessage } =
     useFetchDetectorInfo(detectorId, dataSourceId);
@@ -511,18 +527,23 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiTabs size="s">
-                {tabs.map((tab) => (
-                  <EuiTab
-                    onClick={() => {
-                      handleTabChange(tab.route);
-                    }}
-                    isSelected={tab.id === detectorDetailModel.selectedTab}
-                    key={tab.id}
-                    data-test-subj={`${tab.id}Tab`}
-                  >
-                    {tab.name}
-                  </EuiTab>
-                ))}
+                {tabs
+                  .filter(
+                    (tab) =>
+                      !(isServerless && tab.id === DETECTOR_DETAIL_TABS.HISTORICAL)
+                  )
+                  .map((tab) => (
+                    <EuiTab
+                      onClick={() => {
+                        handleTabChange(tab.route);
+                      }}
+                      isSelected={tab.id === detectorDetailModel.selectedTab}
+                      key={tab.id}
+                      data-test-subj={`${tab.id}Tab`}
+                    >
+                      {tab.name}
+                    </EuiTab>
+                  ))}
               </EuiTabs>
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -643,19 +664,22 @@ export const DetectorDetail = (props: DetectorDetailProps) => {
               onStopDetector={() => handleStopAdJob(detectorId)}
               onSwitchToConfiguration={handleSwitchToConfigurationTab}
               onSwitchToHistorical={handleSwitchToHistoricalTab}
+              isServerless={isServerless}
             />
           )}
         />
-        <Route
-          exact
-          path="/detectors/:detectorId/historical"
-          render={(configProps) => (
-            <HistoricalDetectorResults
-              {...configProps}
-              detectorId={detectorId}
-            />
-          )}
-        />
+        {!isServerless ? (
+          <Route
+            exact
+            path="/detectors/:detectorId/historical"
+            render={(configProps) => (
+              <HistoricalDetectorResults
+                {...configProps}
+                detectorId={detectorId}
+              />
+            )}
+          />
+        ) : null}
         <Route
           exact
           path="/detectors/:detectorId/configurations"

--- a/public/pages/DetectorJobs/containers/DetectorJobs.tsx
+++ b/public/pages/DetectorJobs/containers/DetectorJobs.tsx
@@ -44,6 +44,7 @@ import {
   getSavedObjectsClient,
 } from '../../../services';
 import { DataSourceViewConfig } from '../../../../../../src/plugins/data_source_management/public';
+import { isServerlessDataSource } from '../../../utils/dataSourceUtils';
 
 interface DetectorJobsProps extends RouteComponentProps {
   setStep?(stepNumber: number): void;
@@ -66,6 +67,25 @@ export function DetectorJobs(props: DetectorJobsProps) {
   const [historical, setHistorical] = useState<boolean>(
     props.initialValues ? props.initialValues.historical : false
   );
+
+  // On serverless (AOSS) detectors, historical analysis is unsupported in P0.
+  // Hide the HistoricalJob form entirely and force the historical flag off so
+  // the payload sent to the backend never schedules a historical task.
+  const [isServerless, setIsServerless] = useState<boolean>(false);
+  useEffect(() => {
+    let cancelled = false;
+    isServerlessDataSource(dataSourceId).then((result) => {
+      if (!cancelled) setIsServerless(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSourceId]);
+  useEffect(() => {
+    if (isServerless && historical) {
+      setHistorical(false);
+    }
+  }, [isServerless, historical]);
 
   // Jump to top of page on first load
   useEffect(() => {
@@ -171,11 +191,15 @@ export function DetectorJobs(props: DetectorJobsProps) {
                 formikProps={formikProps}
                 setRealTime={setRealTime}
               />
-              <EuiSpacer />
-              <HistoricalJob
-                formikProps={formikProps}
-                setHistorical={setHistorical}
-              />
+              {!isServerless ? (
+                <Fragment>
+                  <EuiSpacer />
+                  <HistoricalJob
+                    formikProps={formikProps}
+                    setHistorical={setHistorical}
+                  />
+                </Fragment>
+              ) : null}
             </EuiPageBody>
           </EuiPage>
 

--- a/public/pages/DetectorResults/containers/AnomalyResults.tsx
+++ b/public/pages/DetectorResults/containers/AnomalyResults.tsx
@@ -78,6 +78,10 @@ interface AnomalyResultsProps extends RouteComponentProps {
   onStopDetector(): void;
   onSwitchToConfiguration(): void;
   onSwitchToHistorical(): void;
+  // When true, the detector targets an OpenSearch Serverless collection;
+  // historical analysis is unsupported in this mode so callers should not
+  // render any switch-to-historical CTA.
+  isServerless?: boolean;
 }
 
 export function AnomalyResults(props: AnomalyResultsProps) {

--- a/public/utils/dataSourceUtils.ts
+++ b/public/utils/dataSourceUtils.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getSavedObjectsClient } from '../services';
+
+/**
+ * Engine type string used by the core data_source plugin to mark an
+ * OpenSearch Serverless (AOSS) data source.
+ *
+ * Source of truth: src/plugins/data_source/common/data_sources/types.ts
+ *   DataSourceEngineType.OpenSearchServerless = 'OpenSearch Serverless'
+ */
+export const OPENSEARCH_SERVERLESS_ENGINE_TYPE = 'OpenSearch Serverless';
+
+/**
+ * Returns true iff the data source identified by {@link dataSourceId} is an
+ * OpenSearch Serverless (AOSS) collection.
+ *
+ * Returns false when:
+ *   - {@link dataSourceId} is undefined/empty (local cluster — not serverless)
+ *   - the saved object lookup fails (e.g., stale id, network error)
+ *   - the engine type attribute is missing or set to a non-serverless value
+ *
+ * Callers should treat this as a runtime capability check: serverless
+ * collections do not support several AD features (historical analysis,
+ * default result index, flattened-index ingest pipelines) and UI flows
+ * must branch on this value.
+ */
+export const isServerlessDataSource = async (
+  dataSourceId?: string
+): Promise<boolean> => {
+  if (!dataSourceId) return false;
+  try {
+    const dataSource = await getSavedObjectsClient().get(
+      'data-source',
+      dataSourceId
+    );
+    return (
+      (dataSource.attributes as any)?.dataSourceEngineType ===
+      OPENSEARCH_SERVERLESS_ENGINE_TYPE
+    );
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Description

Disables three AD features on multi-tenant services collections as part of the AD multi-tenant services onboarding. These are UI/frontend gates driven by the data source's engine type — backend route guarding and workspace ACL will come in a follow-up PR that mirrors the pattern from [alerting-dashboards-plugin#1415](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1415).

## Features disabled on AOSS

| Feature | Why disabled |
|---|---|
| Default result index | multi-tenant services data plane only supports custom result indices scoped to the `opensearch-ad-plugin-result-*` prefix. |
| Flattened custom result index | AOSS ingest pipelines do not support the `script` processor, which the flatten pipeline depends on. |
| Historical analysis | Not in scope for multi-tenant services V2 P0. |

## Changes

### New `public/utils/dataSourceUtils.ts`

Exports `isServerlessDataSource(dataSourceId?)`. Reads the `data-source` saved object and returns `true` when `attributes.dataSourceEngineType === 'OpenSearch Serverless'`. Returns `false` for the local cluster (no `dataSourceId`) or when the lookup fails.

Engine type string matches core: [`src/plugins/data_source/common/data_sources/types.ts`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data_source/common/data_sources/types.ts) (`DataSourceEngineType.OpenSearchServerless = 'OpenSearch Serverless'`).

### Custom result index (`CustomResultIndex.tsx`, `DefineDetector.tsx`)

When `isServerless === true`:
- The "Enable custom result index" checkbox is replaced by an info callout: *"Custom result index is required on OpenSearch Serverless."*
- Internal `enabled` state is forced to `true` so the index-name field, lifecycle-management toggle, and min-age/size/TTL fields still render.
- The "Enable flattened custom result index" block is hidden entirely.
- `formikValues.flattenCustomResultIndex` is forced to `false` via `setFieldValue` so the detector payload never carries an enabled flag.

`DefineDetector.tsx` resolves `isServerless` once per selected data source id via effect and passes it down.

### Historical analysis (`DetectorDetail.tsx`, `DetectorJobs.tsx`, `AnomalyResults.tsx`)

- `DetectorDetail.tsx`: filters out the "Historical analysis" tab, and does not register the `/detectors/:id/historical` Route (so a direct URL paste does not render `HistoricalDetectorResults`). Resolves `isServerless` via effect.
- `DetectorJobs.tsx` (create-detector step 3): hides the `HistoricalJob` form block and forces `historical: false` if the value was previously set.
- `AnomalyResults.tsx`: `isServerless` added to the props interface (plumbing only — the existing `onSwitchToHistorical` prop is currently unreferenced inside the component; gating downstream CTAs will land with the same value when those CTAs are added back).

Not touched in this PR: the `DetectorsList` "Historical analysis" column (read-only status for existing detectors, cannot start a new one).

## Out of scope

- Backend route gating / workspace ACL — follow-up PR mirroring alerting-dashboards-plugin#1415.
- `opensearch` → `multi-tenant services` client migration — lives in Neo (BFF), not this repo.
- Security header contract — lives in Neo.
- Regional endpoint routing — lives in Neo / OSD core datasource plumbing.
- Core search result reuse (no AD search result API) — separate PR.

## Testing

- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json` — 0 errors from this change. (Pre-existing `@xyflow/react` lib-level noise is unrelated and present on `main`.)
- `yarn test:jest --watchAll=false` — **909 tests passed / 88 snapshots / 0 failures** in 60s.
- Targeted runs:
  - `DefineDetector.test.tsx` — 6/6 pass, 4 snapshots match.
  - `DetectorDetail`/`DetectorJobs`/`HistoricalJob`/`AnomalyResults` — 34 pass, 1 pre-existing skipped, 10 snapshots match.

Manual verification not performed (no AOSS collection available in a local dev stack); the branch is purely additive and defaults to the pre-existing behavior when `isServerless === false`.

## Check List

- [x] Commits are signed per the DCO using `--signoff`
- [ ] New functionality includes testing. — frontend gates, no new logic paths; existing tests cover the default (`isServerless === false`) branch. Targeted multi-tenant services-branch tests can be added in follow-up along with an `isServerlessDataSource` unit test.
- [x] New functionality has been documented in this PR description.
- [x] Commits follow Conventional Commits.
