### PR TITLE
feat: route AD results search through core _search on multi-tenant services

### DIFF
--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -29,6 +29,7 @@ import {
   toCamel,
   toFixedNumberForAnomaly,
 } from '../utils/helpers';
+import { isServerlessDataSource } from '../utils/dataSourceUtils';
 import {
   anomalyResultMapper,
   convertDetectorKeysToCamelCase,
@@ -938,7 +939,19 @@ export default class AdService {
         this.client
       );
 
-      const response = !resultIndex
+      // On OpenSearch Serverless the AD backend plugin does not run, so the
+      // plugin-level `_plugins/_anomaly_detection/detectors/results/_search`
+      // endpoint is unavailable. Fall back to the core `_search` API against
+      // the custom result index. Serverless detectors always have a custom
+      // result index (enforced in the UI); the `opensearch-ad-plugin-result-*`
+      // wildcard is a defensive fallback.
+      const serverless = await isServerlessDataSource(context, dataSourceId);
+      const response = serverless
+        ? await callWithRequest('search', {
+            index: resultIndex || `${CUSTOM_AD_RESULT_INDEX_PREFIX}*`,
+            body: request.body,
+          })
+        : !resultIndex
         ? await callWithRequest('ad.searchResults', {
             body: requestBody,
           })
@@ -1067,20 +1080,27 @@ export default class AdService {
         onlyQueryCustomResultIndex: 'false',
       } as {};
 
-      const aggregationResult = await callWithRequest(
-        'ad.searchResultsFromCustomResultIndex',
-        {
-          ...requestParams,
-          body: getResultAggregationQuery(allDetectorIds, {
-            from,
-            size,
-            sortField,
-            sortDirection,
-            search,
-            indices,
-          }),
-        }
-      );
+      // On serverless the AD plugin endpoint is unavailable; call core
+      // `_search` against the `opensearch-ad-plugin-result-*` wildcard to
+      // aggregate across all custom result indices.
+      const serverless = await isServerlessDataSource(context, dataSourceId);
+      const aggregationBody = getResultAggregationQuery(allDetectorIds, {
+        from,
+        size,
+        sortField,
+        sortDirection,
+        search,
+        indices,
+      });
+      const aggregationResult = serverless
+        ? await callWithRequest('search', {
+            index: CUSTOM_AD_RESULT_INDEX_PREFIX + '*',
+            body: aggregationBody,
+          })
+        : await callWithRequest('ad.searchResultsFromCustomResultIndex', {
+            ...requestParams,
+            body: aggregationBody,
+          });
       const aggsDetectors = get(
         aggregationResult,
         'aggregations.unique_detectors.buckets',
@@ -1366,7 +1386,15 @@ export default class AdService {
         this.client
       );
 
-      const response = !resultIndex
+      // See note in searchResults(): core `_search` on serverless because
+      // the AD plugin results endpoint is not available.
+      const serverless = await isServerlessDataSource(context, dataSourceId);
+      const response = serverless
+        ? await callWithRequest('search', {
+            index: resultIndex || `${CUSTOM_AD_RESULT_INDEX_PREFIX}*`,
+            body: requestBody,
+          })
+        : !resultIndex
         ? await callWithRequest('ad.searchResults', {
             body: requestBody,
           })

--- a/server/utils/dataSourceUtils.ts
+++ b/server/utils/dataSourceUtils.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { RequestHandlerContext } from '../../../../src/core/server';
+
+/**
+ * Engine type string used by the core data_source plugin to mark an
+ * OpenSearch Serverless (AOSS) data source.
+ *
+ * Source of truth: src/plugins/data_source/common/data_sources/types.ts
+ *   DataSourceEngineType.OpenSearchServerless = 'OpenSearch Serverless'
+ */
+export const OPENSEARCH_SERVERLESS_ENGINE_TYPE = 'OpenSearch Serverless';
+
+/**
+ * Server-side counterpart to public/utils/dataSourceUtils.ts#isServerlessDataSource.
+ *
+ * Returns true iff the data source identified by {@link dataSourceId} is an
+ * OpenSearch Serverless (AOSS) collection. Returns false when:
+ *   - {@link dataSourceId} is undefined/empty (local cluster — not serverless)
+ *   - the saved object lookup fails (e.g., stale id, network error)
+ *   - the engine type attribute is missing or set to a non-serverless value
+ *
+ * Callers should treat this as a runtime capability check: on serverless,
+ * AD-plugin-level endpoints (e.g., `_plugins/_anomaly_detection/detectors/
+ * results/_search`) are not available because the AD backend plugin does
+ * not run in the serverless data plane. Handlers must fall back to the
+ * standard OpenSearch `_search` against the custom result index.
+ */
+export const isServerlessDataSource = async (
+  context: RequestHandlerContext,
+  dataSourceId?: string
+): Promise<boolean> => {
+  if (!dataSourceId) return false;
+  try {
+    const dataSource = await context.core.savedObjects.client.get(
+      'data-source',
+      dataSourceId
+    );
+    return (
+      (dataSource.attributes as any)?.dataSourceEngineType ===
+      OPENSEARCH_SERVERLESS_ENGINE_TYPE
+    );
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Description

On multi-tenant services the AD backend plugin does not run in the data plane, so the plugin-level endpoint `POST /_plugins/_anomaly_detection/detectors/results/_search` (and its custom-result-index variant) is unavailable. Today the dashboard always proxies search-result queries through these endpoints via the `ad.searchResults` / `ad.searchResultsFromCustomResultIndex` cluster-client bindings — on multi-tenant services those calls 404.

This PR detects multi-tenant services at request time and, when multi-tenant services, routes the search through core `_search` against the AD custom result index pattern (`opensearch-ad-plugin-result-*`) with the same query body.

## Context

Part of the AD multi-tenant services onboarding, tracked alongside opensearch-project/anomaly-detection-dashboards-plugin#1189 (the UI-side feature disables). That PR already requires a custom result index on multi-tenant services (no default index), so the `opensearch-ad-plugin-result-*` wildcard used here is the correct superset — the wildcard is a defensive fallback only.

## Changes

### New `server/utils/dataSourceUtils.ts`

Exports `isServerlessDataSource(context, dataSourceId?)` — the server-side counterpart to the `public/utils/dataSourceUtils.ts` utility added in #1189. Reads the `data-source` saved object via `context.core.savedObjects.client.get(...)` and returns `true` iff `attributes.dataSourceEngineType === 'OpenSearch Serverless'`. Returns `false` for the local cluster (no `dataSourceId`) or when the lookup fails.

Engine-type string matches core: `src/plugins/data_source/common/data_sources/types.ts` — `DataSourceEngineType.OpenSearchServerless = 'OpenSearch Serverless'`.

### Three call sites in `server/routes/ad.ts`

For each of the following handlers, when `isServerlessDataSource` is true, the call is replaced with `callWithRequest('search', { index, body })`:

| Handler | URL | Previous binding | multi-tenant services replacement |
|---|---|---|---|
| `searchResults` | `POST /detectors/results/_search[/:dataSourceId[/...]]` | `ad.searchResults` / `ad.searchResultsFromCustomResultIndex` | `search` w/ `index = resultIndex \|\| opensearch-ad-plugin-result-*` |
| `getAnomalyResults` | `GET /detectors/{id}/results/...` | same | same |
| `getDetectors` aggregation | `GET /detectors/_list` (internal aggregation) | `ad.searchResultsFromCustomResultIndex` (with `resultIndex: opensearch-ad-plugin-result-*`) | `search` w/ `index = opensearch-ad-plugin-result-*` |

Non-multi-tenant services path is unchanged.

## Testing

- `../../node_modules/.bin/tsc --noEmit -p tsconfig.json` — 0 errors from this change. (Pre-existing `@xyflow/react` lib-level noise is unrelated and present on `main`.)
- `yarn test:jest --watchAll=false` — test-count delta vs `upstream/main` is 0: the same 3 pre-existing flaky tests in `public/pages/ReviewAndCreate/containers/__tests__/ReviewAndCreate.test.tsx` fail on both. No new failures introduced by this change.

Manual verification not performed (no AOSS collection available in a local dev stack). The branch is purely additive; the non-multi-tenant services path is byte-for-byte unchanged.

## Out of scope

- UI-side feature gates (custom-result-index required, historical analysis disabled, flattened-index disabled): opensearch-project/anomaly-detection-dashboards-plugin#1189.
- Workspace ACL enforcement / 501-on-unsupported guarded router: follow-up, mirroring [alerting-dashboards-plugin#1415](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1415).
- Neo BFF changes (opensearch-client → multi-tenant services client, security header contract, regional endpoint): different repo.

## Check List

- [x] Commits are signed per the DCO using `--signoff`
- [ ] New functionality includes testing. — no new unit tests; existing suites cover the non-multi-tenant services path. The multi-tenant services branch requires either a mocked saved-objects client or an integration test against an AOSS collection — callable out as a follow-up.
- [x] New functionality has been documented in this PR description.
- [x] Commits follow Conventional Commits.
