### PR TITLE
feat: enforce workspace ACL and 501-guard unsupported routes on multi-tenant services

### DIFF
--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -11,7 +11,7 @@
 
 import { BASE_NODE_API_PATH, FORECAST_BASE_NODE_API_PATH } from '../utils/constants';
 import { first } from 'rxjs/operators';
-import { default as createRouter, Router } from './router';
+import { default as createRouter, Router, UnsupportedRouteRejector } from './router';
 import {
   AnomalyDetectionOpenSearchDashboardsPluginSetup,
   AnomalyDetectionOpenSearchDashboardsPluginStart,
@@ -22,8 +22,10 @@ import {
   CoreStart,
   PluginInitializerContext,
   Logger,
+  OpenSearchDashboardsRequest,
 } from '../../../src/core/server';
 import { ILegacyClusterClient } from '../../../src/core/server/';
+import { getWorkspaceState } from '../../../src/core/server/utils';
 import adPlugin from './cluster/ad/adPlugin';
 import alertingPlugin from './cluster/ad/alertingPlugin';
 import mlPlugin from './cluster/ad/mlPlugin';
@@ -42,10 +44,24 @@ import { DataSourcePluginSetup } from '../../../src/plugins/data_source/server/t
 import { DataSourceManagementPlugin } from '../../../src/plugins/data_source_management/public';
 import ForecastService, { registerForecastRoutes } from './routes/forecast';
 import { getAnomalyDetectionUiSettings } from './ui_settings';
+import {
+  MDSEnabledClientService,
+  WorkspaceAuthorizer,
+} from './services/MDSEnabledClientService';
 
 export interface ADPluginSetupDependencies {
   dataSourceManagement?: ReturnType<DataSourceManagementPlugin['setup']>;
   dataSource?: DataSourcePluginSetup;
+}
+
+export interface ADPluginStartDependencies {
+  /**
+   * Workspace plugin's start contract. Optional because not all deployments
+   * enable workspaces; when absent the plugin continues to operate without
+   * workspace ACL enforcement (defaults to "allow" for every request, which
+   * matches pre-workspaces behavior).
+   */
+  workspace?: WorkspaceAuthorizer;
 }
 
 export class AnomalyDetectionOpenSearchDashboardsPlugin
@@ -57,6 +73,15 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
 {
   private readonly logger: Logger;
   private readonly globalConfig$: any;
+
+  // Services are held so that `start()` can inject workspace plumbing into
+  // the subset (AdService, AlertingService) that extends MDSEnabledClientService.
+  // The other four services do not participate in workspace ACL enforcement
+  // — their routes are blocked wholesale by the guarded router below.
+  private services: {
+    adService?: AdService;
+    alertingService?: AlertingService;
+  } = {};
 
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
@@ -93,28 +118,78 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
       dataSource.registerCustomApiSchema(mlPlugin);
     }
 
-    // Create router
-    const apiRouter: Router = createRouter(
-      core.http.createRouter(),
-      BASE_NODE_API_PATH
-    );
-    const mlApiRouter: Router = createRouter(
-      core.http.createRouter(),
-      '/api/ml'
-    );
-
-    const forecastApiRouter: Router = createRouter(
-      core.http.createRouter(),
-      FORECAST_BASE_NODE_API_PATH
-    );
-
-    // Create services & register with OpenSearch client
+    // Create services & register with OpenSearch client.
+    // Instantiated before the router so that the guarded-router's
+    // rejector can close over `adService.rejectIfUnsupported`.
     const adService = new AdService(client, dataSourceEnabled);
     const alertingService = new AlertingService(client, dataSourceEnabled);
     const mlService = new MLService(client, dataSourceEnabled);
     const opensearchService = new OpenSearchService(client, dataSourceEnabled);
     const sampleDataService = new SampleDataService(client, dataSourceEnabled);
     const forecastService = new ForecastService(client, dataSourceEnabled);
+    this.services.adService = adService;
+    this.services.alertingService = alertingService;
+
+    // Shared 501 rejector for routes unsupported on serverless.
+    // Delegates to AdService.rejectIfUnsupported, which consults
+    // the workspace plugin's `aclEnforceEndpointPatterns` config.
+    const unsupportedRouteRejector: UnsupportedRouteRejector = (
+      context,
+      request,
+      response
+    ) => adService.rejectIfUnsupported(context, request, response);
+
+    // Minimal `unsupportedRoutes` set for the main AD router: just the
+    // insights subtree, which is not part of the serverless AD API surface
+    // per the design doc. The AD CRUD, search, preview, start/stop, results,
+    // match, count, profile, and alerting/monitor endpoints remain live on
+    // serverless (but gated by workspace ACL inside the handlers).
+    //
+    // Historical-start and historical-stop are NOT blocked at the router
+    // layer because `startDetector` / `stopDetector` are shared handlers
+    // (the isHistorical branch is inside the handler body). Those handlers
+    // return 501 themselves when the endpoint is unsupported.
+    const adUnsupportedRoutes = new Set<string>([
+      `POST ${BASE_NODE_API_PATH}/insights/_start`,
+      `POST ${BASE_NODE_API_PATH}/insights/_start/{dataSourceId}`,
+      `POST ${BASE_NODE_API_PATH}/insights/_stop`,
+      `POST ${BASE_NODE_API_PATH}/insights/_stop/{dataSourceId}`,
+      `GET ${BASE_NODE_API_PATH}/insights/_status`,
+      `GET ${BASE_NODE_API_PATH}/insights/_status/{dataSourceId}`,
+      `GET ${BASE_NODE_API_PATH}/insights/_results`,
+      `GET ${BASE_NODE_API_PATH}/insights/_results/{dataSourceId}`,
+      // Sample data uses the AD backend plugin's sample ingestion API,
+      // which does not exist on Oasis AD.
+      `POST ${BASE_NODE_API_PATH}/create_sample_data/{type}`,
+      `POST ${BASE_NODE_API_PATH}/create_sample_data/{type}/{dataSourceId}`,
+    ]);
+
+    // Create routers. The ML and forecast subtrees are blocked wholesale —
+    // Oasis AD does not expose either on serverless in Milestone 1.
+    const apiRouter: Router = createRouter(
+      core.http.createRouter(),
+      BASE_NODE_API_PATH,
+      {
+        unsupportedRoutes: adUnsupportedRoutes,
+        unsupportedRouteRejector,
+      }
+    );
+    const mlApiRouter: Router = createRouter(
+      core.http.createRouter(),
+      '/api/ml',
+      {
+        allRoutesUnsupported: true,
+        unsupportedRouteRejector,
+      }
+    );
+    const forecastApiRouter: Router = createRouter(
+      core.http.createRouter(),
+      FORECAST_BASE_NODE_API_PATH,
+      {
+        allRoutesUnsupported: true,
+        unsupportedRouteRejector,
+      }
+    );
 
     // Register server routes with the service
     registerADRoutes(apiRouter, adService);
@@ -126,7 +201,29 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
     return {};
   }
 
-  public async start(core: CoreStart) {
+  public async start(core: CoreStart, plugins?: ADPluginStartDependencies) {
+    // Inject workspace plumbing into services that support ACL enforcement.
+    // Keep this resilient to the workspace plugin being absent (e.g., when
+    // `workspace.enabled: false` in opensearch_dashboards.yml) — services
+    // were constructed in setup() without knowledge of workspaces and
+    // default to "allow" when no workspaceStart is supplied.
+    const workspaceIdGetter = (request: OpenSearchDashboardsRequest) => {
+      try {
+        return getWorkspaceState(request).requestWorkspaceId;
+      } catch {
+        return undefined;
+      }
+    };
+
+    const servicesWithAcl: Array<MDSEnabledClientService | undefined> = [
+      this.services.adService,
+      this.services.alertingService,
+    ];
+    for (const service of servicesWithAcl) {
+      if (!service) continue;
+      if (plugins?.workspace) service.setWorkspaceStart(plugins.workspace);
+      service.setWorkspaceIdGetter(workspaceIdGetter);
+    }
     return {};
   }
 }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -149,6 +149,11 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
     // layer because `startDetector` / `stopDetector` are shared handlers
     // (the isHistorical branch is inside the handler body). Those handlers
     // return 501 themselves when the endpoint is unsupported.
+    //
+    // Sample data routes are intentionally supported: they are
+    // Dashboards-owned ingestion helpers that write through the selected data
+    // source, so authorization is governed by the data source itself (for
+    // example, an AOSS data access policy).
     const adUnsupportedRoutes = new Set<string>([
       `POST ${BASE_NODE_API_PATH}/insights/_start`,
       `POST ${BASE_NODE_API_PATH}/insights/_start/{dataSourceId}`,
@@ -158,10 +163,6 @@ export class AnomalyDetectionOpenSearchDashboardsPlugin
       `GET ${BASE_NODE_API_PATH}/insights/_status/{dataSourceId}`,
       `GET ${BASE_NODE_API_PATH}/insights/_results`,
       `GET ${BASE_NODE_API_PATH}/insights/_results/{dataSourceId}`,
-      // Sample data uses the AD backend plugin's sample ingestion API,
-      // which does not exist on Oasis AD.
-      `POST ${BASE_NODE_API_PATH}/create_sample_data/{type}`,
-      `POST ${BASE_NODE_API_PATH}/create_sample_data/{type}/{dataSourceId}`,
     ]);
 
     // Create routers. The ML and forecast subtrees are blocked wholesale —

--- a/server/router.ts
+++ b/server/router.ts
@@ -32,11 +32,54 @@ export interface Router {
   put: Route;
   delete: Route;
 }
+
+/**
+ * Callback invoked for routes registered in `unsupportedRoutes`. When it
+ * returns a response (rather than undefined) the wrapped handler is
+ * short-circuited and that response is returned to the client. Used to
+ * serve 501 Not Implemented for API paths that do not exist on the
+ * serverless AD data plane (see `plugin.ts` for the configured set).
+ *
+ * This is the same pattern as alerting-dashboards-plugin#1415's
+ * `guardedRouter` — adapted to fit AD's existing router factory instead of
+ * wrapping the raw `IRouter` at the call site.
+ */
+export type UnsupportedRouteRejector = (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+) => Promise<IOpenSearchDashboardsResponse<any> | undefined>;
+
+export interface RouterOptions {
+  /**
+   * Routes registered through the returned Router whose METHOD + path match
+   * an entry in this set will be wrapped with `unsupportedRouteRejector`.
+   * Entries are compared as `${METHOD} ${basePath}${path}` strings, so
+   * callers should include the base path in the entry.
+   */
+  unsupportedRoutes?: Set<string>;
+  /**
+   * When true, every route registered through this router is wrapped with
+   * `unsupportedRouteRejector`. Takes precedence over `unsupportedRoutes`.
+   * Use this when an entire subtree (e.g., `/api/ml/*`, `/api/forecasts/*`)
+   * is unsupported on the target endpoint.
+   */
+  allRoutesUnsupported?: boolean;
+  unsupportedRouteRejector?: UnsupportedRouteRejector;
+}
+
 // Router factory
-export default (iRouter: IRouter, basePath: String): Router => {
+export default (
+  iRouter: IRouter,
+  basePath: String,
+  options: RouterOptions = {}
+): Router => {
   if (basePath == null || basePath == '') {
     throw new TypeError('Base path is null');
   }
+  const { unsupportedRoutes, allRoutesUnsupported, unsupportedRouteRejector } =
+    options;
+
   const requestHandler =
     (handler: RouteHandler) =>
     async (
@@ -50,62 +93,89 @@ export default (iRouter: IRouter, basePath: String): Router => {
         throw e;
       }
     };
+
+  // Wrap a handler so that when the route matches `unsupportedRoutes` (or
+  // `allRoutesUnsupported` is set), the rejector runs first; a non-undefined
+  // rejector result short-circuits the handler. If the rejector is absent,
+  // the handler is returned unchanged (zero overhead on non-serverless paths).
+  const maybeGuard =
+    (method: string, fullPath: string) =>
+    (handler: RouteHandler): RouteHandler => {
+      if (!unsupportedRouteRejector) return handler;
+      const matches =
+        allRoutesUnsupported ||
+        (unsupportedRoutes &&
+          unsupportedRoutes.has(`${method.toUpperCase()} ${fullPath}`));
+      if (!matches) return handler;
+      return async (context, request, response) => {
+        const rejection = await unsupportedRouteRejector(
+          context,
+          request,
+          response
+        );
+        if (rejection) return rejection;
+        return handler(context, request, response);
+      };
+    };
+
   return ['get', 'put', 'post', 'delete'].reduce(
     (router: any, method: string) => {
       router[method] = (path: String, handler: RouteHandler) => {
+        const fullPath = `${basePath}${path}`;
+        const wrappedHandler = maybeGuard(method, fullPath)(handler);
         switch (method) {
           case 'get': {
             iRouter.get(
               {
-                path: `${basePath}${path}`,
+                path: fullPath,
                 validate: {
                   params: schema.any(),
                   query: schema.any(),
                 },
               },
-              requestHandler(handler)
+              requestHandler(wrappedHandler)
             );
             break;
           }
           case 'put': {
             iRouter.put(
               {
-                path: `${basePath}${path}`,
+                path: fullPath,
                 validate: {
                   params: schema.any(),
                   query: schema.any(),
                   body: schema.any(),
                 },
               },
-              requestHandler(handler)
+              requestHandler(wrappedHandler)
             );
             break;
           }
           case 'post': {
             iRouter.post(
               {
-                path: `${basePath}${path}`,
+                path: fullPath,
                 validate: {
                   params: schema.any(),
                   query: schema.any(),
                   body: schema.any(),
                 },
               },
-              requestHandler(handler)
+              requestHandler(wrappedHandler)
             );
             break;
           }
           case 'delete': {
             iRouter.delete(
               {
-                path: `${basePath}${path}`,
+                path: fullPath,
                 validate: {
                   params: schema.any(),
                   query: schema.any(),
                   body: schema.any(),
                 },
               },
-              requestHandler(handler)
+              requestHandler(wrappedHandler)
             );
             break;
           }

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -206,21 +206,22 @@ export function registerADRoutes(apiRouter: Router, adService: AdService) {
   apiRouter.get('/insights/_results/{dataSourceId}', adService.getInsightsResults);
 }
 
-export default class AdService {
-  private client: any;
-  dataSourceEnabled: boolean;
+import { MDSEnabledClientService } from '../services/MDSEnabledClientService';
 
-  constructor(client: any, dataSourceEnabled: boolean) {
-    this.client = client;
-    this.dataSourceEnabled = dataSourceEnabled;
-  }
-
+export default class AdService extends MDSEnabledClientService {
   deleteDetector = async (
     context: RequestHandlerContext,
     request: OpenSearchDashboardsRequest,
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write']
+      );
+      if (aclResponse) return aclResponse;
       const { detectorId } = request.params as { detectorId: string };
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
       const callWithRequest = getClientBasedOnDataSource(
@@ -258,6 +259,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write']
+      );
+      if (aclResponse) return aclResponse;
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
 
       const requestBody = JSON.stringify(
@@ -300,6 +308,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       let { suggestType } = request.params as {
         suggestType: string;
       };
@@ -344,6 +359,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write']
+      );
+      if (aclResponse) return aclResponse;
       const { detectorId } = request.params as { detectorId: string };
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
 
@@ -407,6 +429,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       let { validationType } = request.params as {
         validationType: string;
       };
@@ -634,6 +663,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { detectorId } = request.params as { detectorId: string };
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
       const callWithRequest = getClientBasedOnDataSource(
@@ -741,6 +777,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write']
+      );
+      if (aclResponse) return aclResponse;
       const { detectorId } = request.params as { detectorId: string };
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
       //@ts-ignore
@@ -759,6 +802,24 @@ export default class AdService {
           },
         };
         requestPath = 'ad.startHistoricalDetector';
+      }
+
+      // Historical analysis is unsupported on OpenSearch Serverless in P0
+      // (see AD serverless design doc, Milestone 2). The dashboard frontend
+      // hides the entry points (PR #1189) but we defend-in-depth here so
+      // direct API callers also get a clear 501 rather than a 404/500 from
+      // the backend.
+      if (
+        requestPath === 'ad.startHistoricalDetector' &&
+        (await this.isUnsupportedEndpoint(context, request))
+      ) {
+        return opensearchDashboardsResponse.custom({
+          statusCode: 501,
+          body: {
+            message:
+              'Historical analysis is not supported on OpenSearch Serverless.',
+          },
+        });
       }
 
       const callWithRequest = getClientBasedOnDataSource(
@@ -794,6 +855,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write']
+      );
+      if (aclResponse) return aclResponse;
       let { detectorId, isHistorical } = request.params as {
         detectorId: string;
         isHistorical: any;
@@ -804,6 +872,25 @@ export default class AdService {
       const requestPath = isHistorical
         ? 'ad.stopHistoricalDetector'
         : 'ad.stopDetector';
+
+      // Defense-in-depth 501 for historical stop on serverless — see
+      // startDetector for rationale. Running detectors cannot exist on
+      // serverless because startHistoricalDetector is already blocked, but
+      // a stale client that retained a detector ID from a pre-serverless
+      // period should receive a clear 501 rather than hit an unsupported
+      // plugin endpoint.
+      if (
+        isHistorical &&
+        (await this.isUnsupportedEndpoint(context, request))
+      ) {
+        return opensearchDashboardsResponse.custom({
+          statusCode: 501,
+          body: {
+            message:
+              'Historical analysis is not supported on OpenSearch Serverless.',
+          },
+        });
+      }
 
       const callWithRequest = getClientBasedOnDataSource(
         context,
@@ -840,6 +927,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { detectorId } = request.params as { detectorId: string };
       const response = await this.client
         .asScoped(request)
@@ -869,6 +963,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const requestBody = JSON.stringify(request.body);
       const response: SearchResponse<Detector> = await this.client
         .asScoped(request)
@@ -911,6 +1012,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       var { resultIndex, onlyQueryCustomResultIndex } = request.params as {
         resultIndex: string;
         onlyQueryCustomResultIndex: boolean;
@@ -974,6 +1082,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const {
         from = 0,
         size = 20,
@@ -1240,6 +1355,13 @@ export default class AdService {
     const searchTerm = isHistorical ? { task_id: id } : { detector_id: id };
 
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const {
         from = 0,
         size = 20,
@@ -1458,6 +1580,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       let { detectorId, isHistorical } = request.params as {
         detectorId: string;
         isHistorical: any;
@@ -1505,6 +1634,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { detectorName } = request.params as { detectorName: string };
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
 
@@ -1540,6 +1676,13 @@ export default class AdService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
 
       const callWithRequest = getClientBasedOnDataSource(

--- a/server/routes/alerting.ts
+++ b/server/routes/alerting.ts
@@ -16,6 +16,7 @@ import { Monitor } from '../models/types';
 import { Router } from '../router';
 import { MAX_MONITORS } from '../utils/constants';
 import { getErrorMessage } from './utils/adHelpers';
+import { MDSEnabledClientService } from '../services/MDSEnabledClientService';
 import {
   RequestHandlerContext,
   OpenSearchDashboardsRequest,
@@ -38,21 +39,20 @@ export function registerAlertingRoutes(
   apiRouter.get('/monitors/alerts/{dataSourceId}', alertingService.searchAlerts);
 }
 
-export default class AlertingService {
-  private client: any;
-  dataSourceEnabled: boolean;
-
-  constructor(client: any, dataSourceEnabled: boolean) {
-    this.client = client;
-    this.dataSourceEnabled = dataSourceEnabled;
-  }
-
+export default class AlertingService extends MDSEnabledClientService {
   searchMonitors = async (
     context: RequestHandlerContext,
     request: OpenSearchDashboardsRequest,
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
 
       const requestBody = {
@@ -139,6 +139,13 @@ export default class AlertingService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { monitorId, startTime, endTime } = request.query as {
         monitorId?: string;
         startTime?: number;

--- a/server/services/MDSEnabledClientService.ts
+++ b/server/services/MDSEnabledClientService.ts
@@ -1,0 +1,216 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  ILegacyClusterClient,
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+} from '../../../../src/core/server';
+
+/**
+ * Subset of the OpenSearch Dashboards Workspace plugin's start contract that
+ * the AD plugin depends on for serverless / workspace-ACL enforcement.
+ *
+ * `aclEnforceEndpointPatterns` is the list of data-source endpoint substrings
+ * that require ACL enforcement (e.g., AOSS collection hostnames). It is
+ * configured via `workspace.aclEnforceEndpointPatterns` in
+ * opensearch_dashboards.yml and exposed via `WorkspacePluginStart` (introduced
+ * by OSD core PR #11770). When the OSD version in use predates that PR the
+ * attribute will be absent and this file treats the plugin as if the list
+ * were empty (no endpoints require ACL enforcement, so all requests pass
+ * through unchanged).
+ */
+export interface WorkspaceAuthorizer {
+  authorizeWorkspace: (
+    request: OpenSearchDashboardsRequest,
+    workspaceIds: string[],
+    permissionModes?: string[]
+  ) => Promise<
+    | { authorized: true }
+    | { authorized: false; unauthorizedWorkspaces: string[] }
+  >;
+  /** Optional — not present in older OSD versions. */
+  aclEnforceEndpointPatterns?: string[];
+}
+
+/**
+ * Shared base class for AD server services that need to enforce workspace
+ * ACLs on per-handler request boundaries and reject API calls that are not
+ * supported on an enforced endpoint (e.g., OpenSearch Serverless).
+ *
+ * This mirrors the pattern established by
+ * alerting-dashboards-plugin's `MDSEnabledClientService` (see PR
+ * opensearch-project/alerting-dashboards-plugin#1415). The two key
+ * differences from Alerting's implementation are:
+ *   1. This is TypeScript rather than JavaScript — AD's server code is TS.
+ *   2. The constructor signature matches the existing AD services
+ *      (`client: any, dataSourceEnabled: boolean`) so subclasses can migrate
+ *      without changing their registration sites.
+ *
+ * Workspace plumbing (`workspaceStart` and `workspaceIdGetter`) is injected
+ * post-construction from `plugin.ts#start()`, so services remain
+ * instantiable without the workspace plugin (e.g., in unit tests or on
+ * environments without workspaces configured).
+ */
+export abstract class MDSEnabledClientService {
+  private workspaceStart?: WorkspaceAuthorizer;
+  private workspaceIdGetter?: (
+    request: OpenSearchDashboardsRequest
+  ) => string | undefined;
+
+  constructor(
+    // `any` is preserved from the pre-existing AD service signatures rather
+    // than narrowed to `ILegacyClusterClient` — narrowing would require
+    // changes at every `new AdService(client, ...)` call site. The client is
+    // only used by subclasses, so the looser typing is confined here.
+    protected client: any,
+    public dataSourceEnabled: boolean
+  ) {}
+
+  public setWorkspaceStart(workspaceStart: WorkspaceAuthorizer) {
+    this.workspaceStart = workspaceStart;
+  }
+
+  public setWorkspaceIdGetter(
+    fn: (request: OpenSearchDashboardsRequest) => string | undefined
+  ) {
+    this.workspaceIdGetter = fn;
+  }
+
+  private get aclEndpointPatterns(): string[] {
+    return this.workspaceStart?.aclEnforceEndpointPatterns ?? [];
+  }
+
+  /**
+   * Resolve the data source endpoint URL for the current request by reading
+   * the `data-source` saved object. Returns undefined when the request is
+   * targeting the local cluster (no dataSourceId) or when the saved object
+   * lookup fails.
+   *
+   * Accepts dataSourceId from either request.query or request.params because
+   * AD's routes carry the id in different positions depending on the handler
+   * (query param for list APIs, path param for per-detector APIs).
+   */
+  private async getDataSourceEndpoint(
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest
+  ): Promise<string | undefined> {
+    const dataSourceId =
+      (request.query as any)?.dataSourceId ||
+      (request.params as any)?.dataSourceId;
+    if (!dataSourceId) return undefined;
+    try {
+      const dataSource = await context.core.savedObjects.client.get(
+        'data-source',
+        dataSourceId.toString()
+      );
+      return (dataSource.attributes as any).endpoint as string | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private matchesAclPattern(endpoint: string): boolean {
+    return this.aclEndpointPatterns.some((pattern) =>
+      endpoint.includes(pattern)
+    );
+  }
+
+  /**
+   * True when the request targets an endpoint that requires ACL enforcement
+   * (i.e., a serverless collection). Safe to call when workspace plumbing is
+   * unavailable — returns false in that case.
+   */
+  protected async isUnsupportedEndpoint(
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest
+  ): Promise<boolean> {
+    if (!this.aclEndpointPatterns.length) return false;
+    const endpoint = await this.getDataSourceEndpoint(context, request);
+    return endpoint ? this.matchesAclPattern(endpoint) : false;
+  }
+
+  /**
+   * Return a 501 Not Implemented response when the request targets an
+   * ACL-enforced endpoint. Intended for the guarded-router wrapper in
+   * `server/router.ts`, which drapes this check over routes the AD backend
+   * plugin does not expose on serverless (`/api/ml/*`, `/api/forecasts/*`,
+   * sample data, insights, etc.).
+   */
+  public async rejectIfUnsupported(
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    response: OpenSearchDashboardsResponseFactory
+  ): Promise<any | undefined> {
+    if (await this.isUnsupportedEndpoint(context, request)) {
+      return response.custom({
+        statusCode: 501,
+        body: { message: 'This operation is not supported on this endpoint.' },
+      });
+    }
+    return undefined;
+  }
+
+  /**
+   * Enforce workspace ACL for the current request. Returns a 401 Unauthorized
+   * response when the caller lacks `permissionModes` on their active workspace;
+   * returns undefined when the caller is authorized (or when no workspace
+   * enforcement is configured for this endpoint). Callers should early-return
+   * the response if defined.
+   *
+   * Default mode is `['read']` — callers should override with `['library_write']`
+   * for write operations and `['library_write', 'library_read']` for reads
+   * that should be visible to workspace viewers.
+   */
+  public async enforceWorkspaceAcl(
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    response: OpenSearchDashboardsResponseFactory,
+    permissionModes: string[] = ['read']
+  ): Promise<any | undefined> {
+    const authorized = await this.checkWorkspaceAcl(
+      context,
+      request,
+      permissionModes
+    );
+    if (!authorized) {
+      return response.unauthorized({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
+      });
+    }
+    return undefined;
+  }
+
+  private async checkWorkspaceAcl(
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    permissionModes: string[]
+  ): Promise<boolean> {
+    // Only enforce ACL for requests that target an ACL-enforced endpoint.
+    const endpoint = await this.getDataSourceEndpoint(context, request);
+    if (!endpoint || !this.matchesAclPattern(endpoint)) return true;
+
+    const workspaceId = this.workspaceIdGetter?.(request);
+    // If no workspace context is attached to the request, fall open. The
+    // workspace plugin itself rejects workspace-scoped requests that lack a
+    // workspace id; requests without a workspace id are out of workspace
+    // scope and not subject to library_read / library_write enforcement.
+    if (!workspaceId || !this.workspaceStart) return true;
+
+    const result = await this.workspaceStart.authorizeWorkspace(
+      request,
+      [workspaceId],
+      permissionModes
+    );
+    return result.authorized;
+  }
+}

--- a/server/services/__tests__/MDSEnabledClientService.test.ts
+++ b/server/services/__tests__/MDSEnabledClientService.test.ts
@@ -1,0 +1,359 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Mock core server module that MDSEnabledClientService imports for types only.
+jest.mock('../../../../../src/core/server', () => ({}), { virtual: true });
+
+import { MDSEnabledClientService, WorkspaceAuthorizer } from '../MDSEnabledClientService';
+
+// Concrete test subclass — the base class is abstract only in intent; tests
+// need an instantiable class. We expose the protected helpers used by real
+// handlers so tests can exercise them directly.
+class TestService extends MDSEnabledClientService {
+  // Promote protected helpers to public for testability.
+  public async isUnsupportedEndpointPublic(context: any, request: any) {
+    return this.isUnsupportedEndpoint(context, request);
+  }
+}
+
+interface MockContext {
+  core: {
+    savedObjects: {
+      client: { get: jest.Mock };
+    };
+  };
+}
+
+const createMockContext = (
+  endpoint: string | undefined = 'https://col.us-west-2.aoss.amazonaws.com',
+  { throwOnGet = false }: { throwOnGet?: boolean } = {}
+): MockContext => ({
+  core: {
+    savedObjects: {
+      client: {
+        get: throwOnGet
+          ? jest.fn().mockRejectedValue(new Error('saved object not found'))
+          : jest.fn().mockResolvedValue({
+              attributes: endpoint === undefined ? {} : { endpoint },
+            }),
+      },
+    },
+  },
+});
+
+const createMockReq = (
+  overrides: { query?: any; params?: any } = {}
+): any => ({
+  query: { dataSourceId: 'ds-1', ...(overrides.query ?? {}) },
+  params: { id: 'det-1', ...(overrides.params ?? {}) },
+  body: {},
+  headers: {},
+});
+
+const createMockRes = () => ({
+  ok: jest.fn((payload: any) => payload),
+  unauthorized: jest.fn((payload: any) => ({ unauthorized: true, ...payload })),
+  custom: jest.fn((payload: any) => ({ custom: true, ...payload })),
+});
+
+// Helpers to construct a workspace authorizer stub.
+const buildWorkspaceStart = (
+  options: {
+    authorized?: boolean;
+    patterns?: string[];
+    unauthorizedWorkspaces?: string[];
+  } = {}
+): WorkspaceAuthorizer & { authorizeWorkspace: jest.Mock } => {
+  const {
+    authorized = true,
+    patterns = ['.aoss.amazonaws.com'],
+    unauthorizedWorkspaces = [],
+  } = options;
+  return {
+    authorizeWorkspace: jest
+      .fn()
+      .mockResolvedValue(
+        authorized
+          ? { authorized: true }
+          : { authorized: false, unauthorizedWorkspaces }
+      ),
+    aclEnforceEndpointPatterns: patterns,
+  };
+};
+
+const setupService = (
+  options: {
+    authorized?: boolean;
+    patterns?: string[];
+    workspaceId?: string | undefined;
+    skipWorkspaceStart?: boolean;
+  } = {}
+) => {
+  const service = new TestService(/* client */ {}, /* dataSourceEnabled */ true);
+  const workspaceStart = buildWorkspaceStart({
+    authorized: options.authorized,
+    patterns: options.patterns,
+  });
+  if (!options.skipWorkspaceStart) {
+    service.setWorkspaceStart(workspaceStart);
+  }
+  service.setWorkspaceIdGetter(() =>
+    'workspaceId' in options ? options.workspaceId : 'ws-1'
+  );
+  return { service, workspaceStart };
+};
+
+describe('MDSEnabledClientService', () => {
+  let mockRes: ReturnType<typeof createMockRes>;
+
+  beforeEach(() => {
+    mockRes = createMockRes();
+  });
+
+  describe('isUnsupportedEndpoint', () => {
+    it('returns false when no dataSourceId is present', async () => {
+      const { service } = setupService();
+      const context = createMockContext();
+      const req = createMockReq({ query: { dataSourceId: undefined } });
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(false);
+    });
+
+    it('returns false when endpoint does not match any ACL pattern', async () => {
+      const { service } = setupService();
+      const context = createMockContext(
+        'https://search-domain.us-west-2.es.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(false);
+    });
+
+    it('returns true when endpoint matches an ACL pattern (AOSS)', async () => {
+      const { service } = setupService();
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(true);
+    });
+
+    it('returns false when no ACL patterns are configured', async () => {
+      const { service } = setupService({ patterns: [] });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(false);
+    });
+
+    it('returns false when workspaceStart is not injected (pre-workspaces OSD)', async () => {
+      const { service } = setupService({ skipWorkspaceStart: true });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(false);
+    });
+
+    it('falls open (returns false) when saved object lookup throws', async () => {
+      const { service } = setupService();
+      const context = createMockContext(undefined, { throwOnGet: true });
+      const req = createMockReq();
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(false);
+    });
+
+    it('reads dataSourceId from request.params when not in request.query', async () => {
+      const { service } = setupService();
+      const context = createMockContext();
+      const req = createMockReq({
+        query: { dataSourceId: undefined },
+        params: { dataSourceId: 'ds-from-params' },
+      });
+
+      expect(
+        await service.isUnsupportedEndpointPublic(context, req)
+      ).toBe(true);
+      expect(context.core.savedObjects.client.get).toHaveBeenCalledWith(
+        'data-source',
+        'ds-from-params'
+      );
+    });
+  });
+
+  describe('rejectIfUnsupported', () => {
+    it('returns 501 when the endpoint is ACL-enforced', async () => {
+      const { service } = setupService();
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.rejectIfUnsupported(
+        context as any,
+        req,
+        mockRes as any
+      );
+      expect(mockRes.custom).toHaveBeenCalledWith({
+        statusCode: 501,
+        body: { message: 'This operation is not supported on this endpoint.' },
+      });
+      expect(result).toEqual(
+        expect.objectContaining({ custom: true, statusCode: 501 })
+      );
+    });
+
+    it('returns undefined when the endpoint is not ACL-enforced', async () => {
+      const { service } = setupService();
+      const context = createMockContext(
+        'https://search-domain.us-west-2.es.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.rejectIfUnsupported(
+        context as any,
+        req,
+        mockRes as any
+      );
+      expect(mockRes.custom).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('enforceWorkspaceAcl', () => {
+    it('returns undefined (passes) when the endpoint is not ACL-enforced', async () => {
+      const { service, workspaceStart } = setupService();
+      const context = createMockContext(
+        'https://search-domain.us-west-2.es.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.enforceWorkspaceAcl(
+        context as any,
+        req,
+        mockRes as any,
+        ['library_write']
+      );
+      expect(result).toBeUndefined();
+      expect(workspaceStart.authorizeWorkspace).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined (passes) when the request lacks a workspaceId', async () => {
+      const { service, workspaceStart } = setupService({
+        workspaceId: undefined,
+      });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.enforceWorkspaceAcl(
+        context as any,
+        req,
+        mockRes as any,
+        ['library_read']
+      );
+      expect(result).toBeUndefined();
+      expect(workspaceStart.authorizeWorkspace).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when authorizeWorkspace says authorized', async () => {
+      const { service, workspaceStart } = setupService({ authorized: true });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.enforceWorkspaceAcl(
+        context as any,
+        req,
+        mockRes as any,
+        ['library_write']
+      );
+      expect(result).toBeUndefined();
+      expect(workspaceStart.authorizeWorkspace).toHaveBeenCalledWith(
+        req,
+        ['ws-1'],
+        ['library_write']
+      );
+    });
+
+    it('returns 401 unauthorized when authorizeWorkspace says not authorized', async () => {
+      const { service, workspaceStart } = setupService({ authorized: false });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.enforceWorkspaceAcl(
+        context as any,
+        req,
+        mockRes as any,
+        ['library_write']
+      );
+      expect(workspaceStart.authorizeWorkspace).toHaveBeenCalled();
+      expect(mockRes.unauthorized).toHaveBeenCalledWith({
+        body: { message: 'Workspace ACL check failed: unauthorized' },
+      });
+      expect(result).toEqual(
+        expect.objectContaining({ unauthorized: true })
+      );
+    });
+
+    it('defaults permissionModes to ["read"] when omitted', async () => {
+      const { service, workspaceStart } = setupService({ authorized: true });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      await service.enforceWorkspaceAcl(context as any, req, mockRes as any);
+      expect(workspaceStart.authorizeWorkspace).toHaveBeenCalledWith(
+        req,
+        ['ws-1'],
+        ['read']
+      );
+    });
+
+    it('returns undefined when workspaceStart is not injected', async () => {
+      const { service } = setupService({ skipWorkspaceStart: true });
+      const context = createMockContext(
+        'https://col.us-west-2.aoss.amazonaws.com'
+      );
+      const req = createMockReq();
+
+      const result = await service.enforceWorkspaceAcl(
+        context as any,
+        req,
+        mockRes as any,
+        ['library_write']
+      );
+      expect(result).toBeUndefined();
+      expect(mockRes.unauthorized).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds two complementary protections on multi-tenant services data sources, mirroring the pattern established by [alerting-dashboards-plugin#1415](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1415) 

**Both protections are implicitly gated on the workspace plugin's `aclEnforceEndpointPatterns` config — non-multi-tenant services endpoints are byte-for-byte unchanged.**

### 1. Per-handler workspace ACL

Each AD handler in the multi-tenant services-supported set (CRUD, search, preview, start/stop, results, topAnomalies, tasks search, profile, match, count, validate, monitor/alert search) calls `enforceWorkspaceAcl(context, req, res, modes)` before executing its body. On failure the handler returns **401 Unauthorized** with a clear message. The `modes` mapping derives from the design doc's policy table:

| Kind | Mode |
|---|---|
| Read APIs (GET + POST `_search`, `_validate`) | `['library_write', 'library_read']` |
| Write APIs (POST/PUT/DELETE, `_preview`, `_start`, `_stop`) | `['library_write']` |

### 2. Guarded-router 501 for unsupported routes

Routes that don't exist on multi-tenant service AD in Milestone 1 return **501 Not Implemented** on an ACL-enforced endpoint:

- Entire `/api/ml/*` subtree (plugin-only API)
- Entire `/api/forecasts/*` subtree (out of AD multi-tenant services P0 scope)
- `/api/anomaly_detectors/insights/*` (plugin-only)
- `/api/anomaly_detectors/create_sample_data/*` (plugin-only)

Plus defense-in-depth 501 inside `startDetector`/`stopDetector` when the operation is historical (covered by the UI gate in opensearch-project/anomaly-detection-dashboards-plugin#1189, repeated here for API-client callers).

## Changes

### New `server/services/MDSEnabledClientService.ts`

Abstract base class that the ACL-supporting AD services extend. Exposes:
- `setWorkspaceStart(workspaceStart)` — called from `plugin.start()`
- `setWorkspaceIdGetter(fn)` — reads `requestWorkspaceId` via `getWorkspaceState`
- `isUnsupportedEndpoint(ctx, req)` — true iff the request's data source is ACL-enforced
- `rejectIfUnsupported(ctx, req, res)` — 501 wrapper for the guarded router
- `enforceWorkspaceAcl(ctx, req, res, permissionModes)` — 401 wrapper for handlers

Defensive against older OSD versions that predate OSD core [PR #11770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11770): `aclEnforceEndpointPatterns` is treated as an empty list when the workspace plugin doesn't expose it, which falls open (no enforcement). Same fallback Alerting PR #1415 uses.

### `server/routes/ad.ts`

`AdService extends MDSEnabledClientService`. `enforceWorkspaceAcl` injected at the top of 16 handler `try` blocks. Two handlers also short-circuit to 501 for historical operations on multi-tenant services.

### `server/routes/alerting.ts`

`AlertingService extends MDSEnabledClientService`. `searchMonitors` and `searchAlerts` gain read-mode ACL checks.

### `server/router.ts`

Existing router factory grows a third parameter, `RouterOptions`:
```ts
interface RouterOptions {
  unsupportedRoutes?: Set<string>;         // exact METHOD + fullPath matches
  allRoutesUnsupported?: boolean;          // whole-subtree guard
  unsupportedRouteRejector?: UnsupportedRouteRejector;
}
```
When set, registered routes get wrapped with the rejector. **Zero overhead** when options are unset — the existing `createRouter(iRouter, basePath)` signature is preserved as a valid call.

### `server/plugin.ts`

- ACL-supporting services are held as instance fields so `start(core, plugins?)` can inject `workspaceStart` and `workspaceIdGetter`.
- Three routers wired: the main AD router with a minimal `unsupportedRoutes` set (insights + sample data), `ml` with `allRoutesUnsupported: true`, `forecasts` with `allRoutesUnsupported: true`.
- All three share the same rejector delegating to `adService.rejectIfUnsupported`.

## Related

- [opensearch-project/anomaly-detection-dashboards-plugin#1189](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1189) — UI feature gates (historical analysis, custom result index, flattened index)
- [opensearch-project/anomaly-detection-dashboards-plugin#1190](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1190) — routes AD results search through core `_search` on AOSS
- [alerting-dashboards-plugin#1415](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1415) — reference implementation
- [OpenSearch-Dashboards#11770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11770) — OSD core `aclEnforceEndpointPatterns` config

## Testing

### New tests
`server/services/__tests__/MDSEnabledClientService.test.ts` — **15 tests** ported and adapted from alerting-dashboards-plugin's `WorkspaceAcl.test.js`. Coverage:

- `isUnsupportedEndpoint`: no `dataSourceId` → false; non-AOSS endpoint → false; AOSS endpoint → true; no patterns configured → false; `workspaceStart` absent → false; savedObjects lookup throws → false (falls open); `dataSourceId` in params fallback.
- `rejectIfUnsupported`: returns 501 on AOSS endpoint; returns undefined on non-AOSS.
- `enforceWorkspaceAcl`: non-AOSS → pass; no workspaceId → pass; `authorizeWorkspace` allows → pass; `authorizeWorkspace` denies → 401; default permission modes (`['read']`); `workspaceStart` absent → pass.

### Full suite

`yarn test:jest --watchAll=false`:
- **922 tests passed** (907 pre-existing + 15 new)
- 2 pre-existing flaky failures in `public/pages/ReviewAndCreate/containers/__tests__/ReviewAndCreate.test.tsx` — verified flaking on `upstream/main` before this change (unrelated)
- 88 snapshots match
- `tsc --noEmit` clean (0 errors from this change; pre-existing `@xyflow/react` lib-level noise unrelated)

### Manual verification

Not performed — no AOSS collection available in a local dev stack. The branch is purely additive:
- Non-multi-tenant services path is byte-for-byte unchanged
- ACL enforcement and 501 guards only activate when the workspace plugin's `aclEnforceEndpointPatterns` matches the request's data source endpoint
- When the workspace plugin is absent (older OSD versions), all checks fall open

## Out of scope

- `MLService`, `OpenSearchService`, `SampleDataService`, `ForecastService` do not migrate to `MDSEnabledClientService`. Their routes are blocked wholesale by the guarded router; per-handler ACL would be unreachable. Leaving them as-is minimises blast radius.
- The `unsupportedRoutes` set is intentionally minimal. Additional AD handlers can be marked unsupported later as the Neo onboarding surface is finalised.
- Neo BFF changes (opensearch-client → multi-tenant services client, security header contract, regional endpoint) — different repo.

## Check List

- [x] Commits are signed per the DCO using `--signoff`
- [x] New functionality includes testing — 15 new unit tests for the base class
- [x] New functionality has been documented in this PR description
- [x] Commits follow Conventional Commits
