### PR TITLE
Improve test coverage after #1184

### DIFF
--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && node -v &&
+                               YARN_VERSION=\$(node -p \"require('./package.json').engines.yarn\") &&
+                               npm i -g yarn@\${YARN_VERSION} && yarn -v &&
                                cd ./plugins/anomaly-detection-dashboards-plugin &&
                                whoami && yarn osd bootstrap --single-version=loose && yarn build && yarn run test:jest --coverage"
       - name: Uploads coverage

--- a/public/pages/DailyInsights/components/EnhancedSelectionModal.tsx
+++ b/public/pages/DailyInsights/components/EnhancedSelectionModal.tsx
@@ -61,6 +61,108 @@ export interface ClusterOption {
   localcluster: string;
 }
 
+interface FlatIndexItem {
+  name: string;
+  displayName: string;
+  type: 'index' | 'alias';
+  cluster: string;
+  docCount?: number;
+  size?: string;
+}
+
+export const getClustersStringForSearchQuery = (clusters: ClusterOption[]) => {
+  return clusters
+    .filter((cluster) => cluster.localcluster === 'false')
+    .map((cluster) => cluster.cluster)
+    .join(',');
+};
+
+export const getVisibleClusterOptions = (clusters: ClusterInfo[]): ClusterOption[] => {
+  if (clusters.length > 0) {
+    const visibleClusters = clusters.map((value) => ({
+      label: getClusterOptionLabel(value),
+      cluster: value.name,
+      localcluster: value.localCluster.toString(),
+    }));
+    return visibleClusters.sort((a, b) => {
+      if (a.localcluster === 'true' && b.localcluster === 'false') return -1;
+      if (a.localcluster === 'false' && b.localcluster === 'true') return 1;
+      return a.label.localeCompare(b.label);
+    });
+  }
+  return [];
+};
+
+export const flattenGroupedOptions = (
+  groupedOptions: Array<{ label: string; options: any[] }>,
+  visibleIndices: CatIndex[],
+  visibleAliases: IndexAlias[]
+): FlatIndexItem[] => {
+  const flattenedItems: FlatIndexItem[] = [];
+
+  // Group by cluster first, then by type within each cluster
+  const clusterGroups = new Map<string, { indices: any[]; aliases: any[] }>();
+
+  groupedOptions.forEach((group) => {
+    const isAlias = group.label.toLowerCase().includes('alias');
+    const type = isAlias ? 'aliases' : 'indices';
+
+    // Extract cluster name from group label (e.g., "Indices: [Local]" or "Aliases: cluster-name")
+    const clusterMatch = group.label.match(/:\s*(.+)$/);
+    const clusterName = clusterMatch ? clusterMatch[1] : 'unknown';
+
+    if (!clusterGroups.has(clusterName)) {
+      clusterGroups.set(clusterName, { indices: [], aliases: [] });
+    }
+
+    clusterGroups.get(clusterName)![type] = group.options;
+  });
+
+  // Process each cluster: indices first, then aliases
+  clusterGroups.forEach((groupData, clusterName) => {
+    groupData.indices.forEach((option: any) => {
+      const indexName = option.label; // Keep original name (remote already has cluster:index format)
+      const displayName = `${indexName}`;
+
+      let docCount = 0;
+      let size = '';
+      const indexInfo = visibleIndices.find((i) => i.index === option.label);
+      if (indexInfo) {
+        docCount = parseInt(indexInfo['docs.count'] || '0');
+        size = indexInfo['store.size'] || '0b';
+      }
+
+      flattenedItems.push({
+        name: indexName,
+        displayName,
+        type: 'index',
+        cluster: clusterName,
+        docCount,
+        size,
+      });
+    });
+
+    groupData.aliases.forEach((option: any) => {
+      const aliasName = option.label; // Keep original name
+      const displayName = `${aliasName} (alias)`;
+
+      const aliasInfo = visibleAliases.find((a) => a.alias === option.label);
+      const size = aliasInfo ? `Alias for: ${aliasInfo.index}` : 'Alias';
+
+      flattenedItems.push({
+        name: aliasName,
+        displayName,
+        type: 'alias',
+        cluster: clusterName,
+        docCount: 0,
+        size,
+      });
+    });
+  });
+
+  return flattenedItems;
+};
+
 interface EnhancedSelectionModalProps {
   isVisible: boolean;
   selectedIndices: string[];
@@ -195,29 +297,6 @@ export function EnhancedSelectionModal({
     debouncedSearch(searchValue, selectedClusters, dataSourceId);
   };
 
-  const getClustersStringForSearchQuery = (clusters: ClusterOption[]) => {
-    return clusters
-      .filter((cluster) => cluster.localcluster === 'false')
-      .map((cluster) => cluster.cluster)
-      .join(',');
-  };
-
-  const getVisibleClusterOptions = (clusters: ClusterInfo[]): ClusterOption[] => {
-    if (clusters.length > 0) {
-      const visibleClusters = clusters.map((value) => ({
-        label: getClusterOptionLabel(value),
-        cluster: value.name,
-        localcluster: value.localCluster.toString(),
-      }));
-      return visibleClusters.sort((a, b) => {
-        if (a.localcluster === 'true' && b.localcluster === 'false') return -1;
-        if (a.localcluster === 'false' && b.localcluster === 'true') return 1;
-        return a.label.localeCompare(b.label);
-      });
-    }
-    return [];
-  };
-
   // Get real indices and aliases from redux state
   const visibleIndices = get(opensearchState, 'indices', []) as CatIndex[];
   const visibleAliases = get(opensearchState, 'aliases', []) as IndexAlias[];
@@ -228,76 +307,8 @@ export function EnhancedSelectionModal({
     return getVisibleOptions(visibleIndices, visibleAliases, localClusterName);
   }, [visibleIndices, visibleAliases, localClusterName]);
 
-  // Flatten grouped options with proper cluster ordering (indices, aliases per cluster)
   const allIndices = useMemo(() => {
-    const flattenedItems: Array<{name: string, displayName: string, type: 'index' | 'alias', cluster: string, docCount?: number, size?: string}> = [];
-    
-    // Group by cluster first, then by type within each cluster
-    const clusterGroups = new Map<string, {indices: any[], aliases: any[]}>();
-    
-    groupedOptions.forEach(group => {
-      const isAlias = group.label.toLowerCase().includes('alias');
-      const type = isAlias ? 'aliases' : 'indices';
-      
-      // Extract cluster name from group label (e.g., "Indices: [Local]" or "Aliases: cluster-name")
-      const clusterMatch = group.label.match(/:\s*(.+)$/);
-      const clusterName = clusterMatch ? clusterMatch[1] : 'unknown';
-      
-      if (!clusterGroups.has(clusterName)) {
-        clusterGroups.set(clusterName, { indices: [], aliases: [] });
-      }
-      
-      clusterGroups.get(clusterName)![type] = group.options;
-    });
-    
-    // Process each cluster: indices first, then aliases
-    clusterGroups.forEach((groupData, clusterName) => {
-      const isLocal = clusterName.includes('[Local]') || clusterName.includes('(Local)');
-      
-      // Process indices first
-      groupData.indices.forEach((option: any) => {
-        const indexName = option.label; // Keep original name (remote already has cluster:index format)
-        const displayName = `${indexName}`;
-        
-        let docCount = 0;
-        let size = '';
-        const indexInfo = visibleIndices.find(i => i.index === option.label);
-        if (indexInfo) {
-          docCount = parseInt(indexInfo['docs.count'] || '0');
-          size = indexInfo['store.size'] || '0b';
-        }
-        
-        flattenedItems.push({
-          name: indexName,
-          displayName,
-          type: 'index',
-          cluster: clusterName,
-          docCount,
-          size,
-        });
-      });
-      
-      // Then process aliases
-      groupData.aliases.forEach((option: any) => {
-        const aliasName = option.label; // Keep original name
-        const displayName = `${aliasName} (alias)`;
-        
-        let size = '';
-        const aliasInfo = visibleAliases.find(a => a.alias === option.label);
-        size = aliasInfo ? `Alias for: ${aliasInfo.index}` : 'Alias';
-        
-        flattenedItems.push({
-          name: aliasName,
-          displayName,
-          type: 'alias',
-          cluster: clusterName,
-          docCount: 0,
-          size,
-        });
-      });
-    });
-    
-    return flattenedItems;
+    return flattenGroupedOptions(groupedOptions, visibleIndices, visibleAliases);
   }, [groupedOptions, visibleIndices, visibleAliases]);
 
   const filteredIndices = useMemo(() => {

--- a/public/pages/DailyInsights/components/__tests__/EnhancedSelectionModal.test.tsx
+++ b/public/pages/DailyInsights/components/__tests__/EnhancedSelectionModal.test.tsx
@@ -1,0 +1,300 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  EnhancedSelectionModal,
+  flattenGroupedOptions,
+  getClustersStringForSearchQuery,
+  getVisibleClusterOptions,
+} from '../EnhancedSelectionModal';
+
+const mockDispatch = jest.fn();
+const mockGetVisibleOptions = jest.fn();
+const mockGetLocalCluster = jest.fn((clusters: any[]) =>
+  clusters.filter((cluster) => cluster.localCluster)
+);
+const mockSanitizeSearchText = jest.fn((value: string) => value.trim());
+const mockGetClustersInfo = jest.fn((dataSourceId?: string) => ({
+  type: 'opensearch/GET_CLUSTERS_INFO',
+  dataSourceId,
+}));
+const mockGetIndicesAndAliases = jest.fn(
+  (query: string, dataSourceId: string | undefined, clusters: string, hasLocalCluster: boolean) => ({
+    type: 'opensearch/GET_INDICES_AND_ALIASES',
+    query,
+    dataSourceId,
+    clusters,
+    hasLocalCluster,
+  })
+);
+const mockGetPrioritizedIndices = jest.fn(
+  (query: string, dataSourceId: string | undefined, clusters: string) => ({
+    type: 'opensearch/GET_PRIORITIZED_INDICES',
+    query,
+    dataSourceId,
+    clusters,
+  })
+);
+
+let mockOpensearchState: any;
+
+jest.mock('lodash', () => {
+  const actual = jest.requireActual('lodash');
+  return {
+    ...actual,
+    debounce: (fn: (...args: any[]) => any) => fn,
+  };
+});
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: (state: any) => any) => selector({ opensearch: mockOpensearchState }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/daily-insights',
+    search: '',
+  }),
+}));
+
+jest.mock('../../../utils/helpers', () => ({
+  getDataSourceFromURL: () => ({ dataSourceId: undefined }),
+  getLocalCluster: (...args: any[]) => mockGetLocalCluster(...args),
+  sanitizeSearchText: (...args: any[]) => mockSanitizeSearchText(...args),
+  getVisibleOptions: (...args: any[]) => mockGetVisibleOptions(...args),
+}));
+
+jest.mock('../../../DefineDetector/utils/helpers', () => ({
+  getClusterOptionLabel: (cluster: any) => (cluster.localCluster ? '[Local]' : cluster.name),
+}));
+
+jest.mock('../../../../services', () => ({
+  getDataSourceEnabled: () => ({ enabled: false }),
+}));
+
+jest.mock('../../../../redux/reducers/opensearch', () => ({
+  getClustersInfo: (...args: any[]) => mockGetClustersInfo(...args),
+  getIndicesAndAliases: (...args: any[]) => mockGetIndicesAndAliases(...args),
+  getPrioritizedIndices: (...args: any[]) => mockGetPrioritizedIndices(...args),
+}));
+
+const groupedOptions = [
+  {
+    label: 'Indices: [Local]',
+    options: [{ label: 'logs-1' }],
+  },
+  {
+    label: 'Aliases: [Local]',
+    options: [{ label: 'logs-current' }],
+  },
+  {
+    label: 'Indices: remote-a',
+    options: [{ label: 'remote-a:logs-2' }],
+  },
+];
+
+const defaultProps = {
+  isVisible: true,
+  selectedIndices: ['logs-1'],
+  onSelectionChange: jest.fn(),
+  onCancel: jest.fn(),
+  onConfirm: jest.fn(),
+};
+
+describe('EnhancedSelectionModal helpers', () => {
+  test('builds a remote-cluster query string', () => {
+    expect(
+      getClustersStringForSearchQuery([
+        { label: '[Local]', cluster: 'local', localcluster: 'true' },
+        { label: 'remote-a', cluster: 'remote-a', localcluster: 'false' },
+        { label: 'remote-b', cluster: 'remote-b', localcluster: 'false' },
+      ])
+    ).toBe('remote-a,remote-b');
+  });
+
+  test('sorts visible clusters with local first', () => {
+    expect(
+      getVisibleClusterOptions([
+        { name: 'remote-b', localCluster: false },
+        { name: 'local', localCluster: true },
+        { name: 'remote-a', localCluster: false },
+      ] as any)
+    ).toEqual([
+      { label: '[Local]', cluster: 'local', localcluster: 'true' },
+      { label: 'remote-a', cluster: 'remote-a', localcluster: 'false' },
+      { label: 'remote-b', cluster: 'remote-b', localcluster: 'false' },
+    ]);
+  });
+
+  test('flattens grouped options into index and alias rows with metadata', () => {
+    expect(
+      flattenGroupedOptions(
+        groupedOptions,
+        [
+          { index: 'logs-1', 'docs.count': '42', 'store.size': '1kb' },
+          { index: 'remote-a:logs-2', 'docs.count': '3', 'store.size': '2kb' },
+        ] as any,
+        [{ alias: 'logs-current', index: 'logs-1' }] as any
+      )
+    ).toEqual([
+      {
+        name: 'logs-1',
+        displayName: 'logs-1',
+        type: 'index',
+        cluster: '[Local]',
+        docCount: 42,
+        size: '1kb',
+      },
+      {
+        name: 'logs-current',
+        displayName: 'logs-current (alias)',
+        type: 'alias',
+        cluster: '[Local]',
+        docCount: 0,
+        size: 'Alias for: logs-1',
+      },
+      {
+        name: 'remote-a:logs-2',
+        displayName: 'remote-a:logs-2',
+        type: 'index',
+        cluster: 'remote-a',
+        docCount: 3,
+        size: '2kb',
+      },
+    ]);
+  });
+});
+
+describe('EnhancedSelectionModal', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockOpensearchState = {
+      requesting: false,
+      clusters: [
+        { name: 'local', localCluster: true },
+        { name: 'remote-a', localCluster: false },
+      ],
+      indices: [
+        { index: 'logs-1', 'docs.count': '42', 'store.size': '1kb' },
+        { index: 'remote-a:logs-2', 'docs.count': '3', 'store.size': '2kb' },
+      ],
+      aliases: [{ alias: 'logs-current', index: 'logs-1' }],
+    };
+    mockGetVisibleOptions.mockReturnValue(groupedOptions);
+    mockDispatch.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('renders badges, dispatches search actions, and lets the user clear and toggle selections', async () => {
+    const onSelectionChange = jest.fn();
+    const onCancel = jest.fn();
+
+    render(
+      <EnhancedSelectionModal
+        {...defaultProps}
+        selectedIndices={['logs-1', 'logs-current', 'remote-a:logs-2', 'overflow-index']}
+        onSelectionChange={onSelectionChange}
+        onCancel={onCancel}
+        existingDetectorCounts={{
+          'logs-1': {
+            count: 2,
+            names: ['Detector A', 'Detector B'],
+          },
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockGetClustersInfo).toHaveBeenCalledWith(undefined);
+      expect(mockGetIndicesAndAliases).toHaveBeenCalledWith('', undefined, '', true);
+    });
+
+    expect(screen.getByText('4 selected')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.getByText('2 detectors')).toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('index-logs-1-0') as HTMLElement);
+    expect(onSelectionChange).toHaveBeenCalledWith([
+      'logs-current',
+      'remote-a:logs-2',
+      'overflow-index',
+    ]);
+
+    fireEvent.change(screen.getByPlaceholderText('Search indices...'), {
+      target: { value: 'logs' },
+    });
+
+    await waitFor(() => {
+      expect(mockSanitizeSearchText).toHaveBeenCalledWith('logs');
+      expect(mockGetPrioritizedIndices).toHaveBeenCalledWith('logs', undefined, '');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    expect(onSelectionChange).toHaveBeenCalledWith([]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  test('supports the two-step confirmation flow and starts insights with the chosen agent ID', async () => {
+    const onConfirm = jest.fn();
+    const onStartInsights = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <EnhancedSelectionModal
+        {...defaultProps}
+        onConfirm={onConfirm}
+        onStartInsights={onStartInsights}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Selected Indices \(1\)/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith();
+    expect(screen.getByText('Confirm Auto Insights Setup')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to Selection' }));
+    expect(screen.getByPlaceholderText('Search indices...')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Selected Indices \(1\)/i }));
+    fireEvent.change(screen.getByPlaceholderText('Enter agent ID'), {
+      target: { value: 'agent-42' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Start Auto Insights' }));
+
+    await waitFor(() => {
+      expect(onStartInsights).toHaveBeenCalledWith(['logs-1'], 'agent-42');
+    });
+  });
+
+  test('supports immediate execution with a custom agent ID', async () => {
+    const onConfirm = jest.fn();
+
+    render(
+      <EnhancedSelectionModal
+        {...defaultProps}
+        immediateExecute={true}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Enter agent ID'), {
+      target: { value: 'instant-agent' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Confirm Selected Indices \(1\)/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith('instant-agent');
+    expect(screen.queryByText('Confirm Auto Insights Setup')).not.toBeInTheDocument();
+  });
+});

--- a/public/pages/DailyInsights/components/__tests__/EventDetailModal.test.tsx
+++ b/public/pages/DailyInsights/components/__tests__/EventDetailModal.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { EventDetailModal } from '../EventDetailModal';
+import { buildDiscoverUrl } from '../../utils/discoverLink';
+
+jest.mock('../../utils/discoverLink', () => ({
+  buildDiscoverUrl: jest.fn(),
+}));
+
+const baseCluster = {
+  indices: ['logs-*'],
+  detector_ids: ['det-1', 'det-2'],
+  detector_names: ['CPU detector', 'Latency detector'],
+  entities: ['service.name=checkout'],
+  model_ids: ['model-1'],
+  num_anomalies: 1,
+  event_start: '2026-04-07T10:00:00.000Z',
+  event_end: '2026-04-07T10:05:00.000Z',
+  cluster_text: 'Cluster text fallback',
+  anomalies: [
+    {
+      model_id: 'model-1',
+      detector_id: 'det-1',
+      data_start_time: '2026-04-07T10:00:00.000Z',
+      data_end_time: '2026-04-07T10:05:00.000Z',
+    },
+  ],
+};
+
+const baseProps = {
+  cluster: baseCluster,
+  onClose: jest.fn(),
+  detectorDescriptions: {
+    'det-1': 'Tracks checkout CPU anomalies',
+    'det-2': 'Automatically created by OpenSearch',
+  },
+  detectorFeatures: {
+    'det-1': ['avg_cpu'],
+  },
+  detectorTimeFields: {
+    'det-1': '@timestamp',
+  },
+  anomalyEntities: {
+    'model-1': ['service.name=checkout'],
+  },
+  dataSourceId: 'ds-1',
+  core: {} as any,
+};
+
+describe('EventDetailModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders an AI summary when one is available', () => {
+    render(<EventDetailModal {...baseProps} llmSummary="AI saw a checkout CPU spike." />);
+
+    expect(screen.getByText('AI Summary')).toBeInTheDocument();
+    expect(screen.getByText('AI saw a checkout CPU spike.')).toBeInTheDocument();
+  });
+
+  test('renders the loading summary state', () => {
+    render(<EventDetailModal {...baseProps} llmLoading={true} />);
+
+    expect(screen.getByText('Generating summary...')).toBeInTheDocument();
+  });
+
+  test('renders fallback detector descriptions and filters generic auto-generated text', () => {
+    render(<EventDetailModal {...baseProps} />);
+
+    expect(screen.getByText(/1 anomaly detected/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /CPU detector/i })).toBeInTheDocument();
+    expect(screen.getByText(/Tracks checkout CPU anomalies/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Automatically created by OpenSearch/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not try to build a Discover URL when core is unavailable', async () => {
+    render(<EventDetailModal {...baseProps} core={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+
+    await waitFor(() => {
+      expect(buildDiscoverUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  test('builds and opens the Discover URL for an anomaly', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    (buildDiscoverUrl as jest.Mock).mockResolvedValue('https://example.test/discover');
+
+    render(<EventDetailModal {...baseProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Discover' }));
+
+    await waitFor(() => {
+      expect(buildDiscoverUrl).toHaveBeenCalledWith(
+        baseProps.core,
+        expect.objectContaining({
+          indices: ['logs-*'],
+          startTime: '2026-04-07T10:00:00.000Z',
+          endTime: '2026-04-07T10:05:00.000Z',
+          entities: ['service.name=checkout'],
+          timeField: '@timestamp',
+          dataSourceId: 'ds-1',
+        })
+      );
+      expect(openSpy).toHaveBeenCalledWith('https://example.test/discover', '_blank');
+    });
+
+    openSpy.mockRestore();
+  });
+});

--- a/public/pages/DailyInsights/components/__tests__/IndicesManagement.test.tsx
+++ b/public/pages/DailyInsights/components/__tests__/IndicesManagement.test.tsx
@@ -1,0 +1,377 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  MemoryRouter as Router,
+  Route,
+  RouteComponentProps,
+} from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { CoreServicesContext } from '../../../../components/CoreServices/CoreServices';
+import { IndicesManagement } from '../IndicesManagement';
+
+const mockDispatch = jest.fn();
+const mockSetBreadcrumbs = jest.fn();
+const mockChangeDocTitle = jest.fn();
+const mockHttpGet = jest.fn();
+const mockNavigateToApp = jest.fn();
+const mockAddSuccess = jest.fn();
+const mockAddDanger = jest.fn();
+const mockAddWarning = jest.fn();
+const mockStartPolling = jest.fn();
+const mockSetActionMenu = jest.fn();
+const mockDataSourceMenu = jest.fn(({ componentConfig }) => (
+  <button
+    type="button"
+    onClick={() => componentConfig.onSelectedDataSources([{ id: 'ds-next' }])}
+  >
+    Select data source
+  </button>
+));
+const mockGetDetectorList = jest.fn((params) => ({
+  type: 'ad/GET_DETECTOR_LIST',
+  params,
+}));
+const mockExecuteAutoCreateAgent = jest.fn(
+  (indices, agentId, dataSourceId) => ({
+    type: 'ml/EXECUTE_ML_AGENT',
+    indices,
+    agentId,
+    dataSourceId,
+  })
+);
+
+let mockAdState: any;
+let mockDataSourceEnabled = false;
+let mockAgentTask: any = null;
+let mockIsPolling = false;
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../services', () => ({
+  getDataSourceEnabled: () => ({ enabled: mockDataSourceEnabled }),
+  getApplication: () => ({ navigateToApp: mockNavigateToApp }),
+  getNotifications: () => ({
+    toasts: {
+      addSuccess: mockAddSuccess,
+      addDanger: mockAddDanger,
+      addWarning: mockAddWarning,
+    },
+  }),
+  getDataSourceManagementPlugin: () => ({
+    ui: {
+      getDataSourceMenu: () => mockDataSourceMenu,
+    },
+  }),
+  getSavedObjectsClient: () => ({ id: 'saved-objects-client' }),
+}));
+
+jest.mock('../../../../redux/reducers/ad', () => ({
+  getDetectorList: (...args: any[]) => mockGetDetectorList(...args),
+}));
+
+jest.mock('../../../../redux/reducers/ml', () => ({
+  executeAutoCreateAgent: (...args: any[]) =>
+    mockExecuteAutoCreateAgent(...args),
+}));
+
+jest.mock('../../hooks/useAgentTaskPolling', () => ({
+  useAgentTaskPolling: () => ({
+    isPolling: mockIsPolling,
+    startPolling: mockStartPolling,
+  }),
+}));
+
+jest.mock('../../utils/agentTaskStorage', () => ({
+  getAgentTask: () => mockAgentTask,
+}));
+
+jest.mock('../EnhancedSelectionModal', () => ({
+  EnhancedSelectionModal: (props: any) =>
+    props.isVisible ? (
+      <div data-test-subj="mockEnhancedSelectionModal">
+        <span>{props.modalTitle}</span>
+        <span>{props.selectedIndices.join(',')}</span>
+        <button
+          type="button"
+          onClick={() => props.onSelectionChange(['logs-new'])}
+        >
+          Select logs-new
+        </button>
+        <button
+          type="button"
+          onClick={() => props.onConfirm('agent-from-modal')}
+        >
+          Confirm modal selection
+        </button>
+        <button type="button" onClick={props.onCancel}>
+          Cancel modal
+        </button>
+      </div>
+    ) : null,
+}));
+
+const mockCore = {
+  http: {
+    get: mockHttpGet,
+  },
+  chrome: {
+    setBreadcrumbs: mockSetBreadcrumbs,
+    docTitle: {
+      change: mockChangeDocTitle,
+    },
+  },
+};
+
+const renderIndicesManagement = (initialEntry = '/indices') =>
+  render(
+    <Router initialEntries={[initialEntry]}>
+      <Route
+        path="/indices"
+        render={(props: RouteComponentProps) => (
+          <CoreServicesContext.Provider value={mockCore as any}>
+            <IndicesManagement {...props} setActionMenu={mockSetActionMenu} />
+          </CoreServicesContext.Provider>
+        )}
+      />
+    </Router>
+  );
+
+const buildDetector = (overrides: any = {}) => ({
+  id: 'detector-id',
+  name: 'detector-name',
+  indices: ['logs-*'],
+  curState: 'Running',
+  auto_created: true,
+  ...overrides,
+});
+
+describe('IndicesManagement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+    mockAdState = {
+      detectorList: {},
+    };
+    mockAgentTask = null;
+    mockIsPolling = false;
+    mockDataSourceEnabled = false;
+    mockHttpGet.mockResolvedValue({ response: { enabled: false } });
+    mockDispatch.mockResolvedValue({});
+    (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
+    (useSelector as jest.Mock).mockImplementation((selector) =>
+      selector({ ad: mockAdState })
+    );
+  });
+
+  test('renders the first-index empty state and navigates to setup', async () => {
+    renderIndicesManagement();
+
+    expect(
+      await screen.findByText('No indices configured for insights')
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Add Your First Index' })
+    );
+
+    expect(mockNavigateToApp).toHaveBeenCalledWith(
+      'daily_insights_dashboard-overview',
+      {
+        path: '',
+      }
+    );
+    expect(mockSetBreadcrumbs).toHaveBeenCalled();
+    expect(mockChangeDocTitle).toHaveBeenCalledWith('Daily Insights');
+  });
+
+  test('renders the active-job empty states and failed-task retry path', async () => {
+    mockHttpGet.mockResolvedValue({ response: { enabled: true } });
+    mockAgentTask = { finalState: 'FAILED' };
+
+    renderIndicesManagement();
+
+    expect(
+      await screen.findByText('Detector creation failed')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('addNewIndicesButton'));
+
+    expect(
+      screen.getByTestId('mockEnhancedSelectionModal')
+    ).toBeInTheDocument();
+  });
+
+  test('groups auto-created detectors by index and expands long detector lists', async () => {
+    mockHttpGet.mockResolvedValue({ response: { enabled: true } });
+    mockAgentTask = {
+      failedIndices: [{ index: 'metrics-*', error: 'permissions denied' }],
+    };
+    mockAdState = {
+      detectorList: {
+        one: buildDetector({
+          id: 'det-1',
+          name: 'CPU detector',
+          indices: ['logs-*', 'metrics-*'],
+          curState: 'Running',
+        }),
+        two: buildDetector({
+          id: 'det-2',
+          name: 'Latency detector',
+          indices: ['logs-*'],
+          curState: 'Stopped',
+          autoCreated: true,
+          auto_created: false,
+        }),
+        three: buildDetector({
+          id: 'det-3',
+          name: 'Errors detector',
+          indices: ['logs-*'],
+          curState: 'Initializing',
+        }),
+        four: buildDetector({
+          id: 'det-4',
+          name: 'Traffic detector',
+          indices: ['logs-*'],
+          curState: 'Failed',
+        }),
+        manual: buildDetector({
+          id: 'manual',
+          name: 'Manual detector',
+          auto_created: false,
+          autoCreated: false,
+        }),
+      },
+    };
+
+    renderIndicesManagement();
+
+    expect(await screen.findByText('Configured Indices')).toBeInTheDocument();
+    expect(
+      screen.getByText('Some detectors failed to create')
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('metrics-*').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CPU detector').length).toBeGreaterThan(0);
+    expect(screen.getByText('Latency detector')).toBeInTheDocument();
+    expect(screen.getByText('Errors detector')).toBeInTheDocument();
+    expect(screen.queryByText('Traffic detector')).not.toBeInTheDocument();
+    expect(screen.queryByText('Manual detector')).not.toBeInTheDocument();
+    expect(screen.getByText('1 Running, 1 Stopped')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('+1 more detectors'));
+    expect(screen.getByText('Traffic detector')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Show less'));
+    expect(screen.queryByText('Traffic detector')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(mockGetDetectorList).toHaveBeenCalledWith(
+      expect.objectContaining({ dataSourceId: '' })
+    );
+  });
+
+  test('starts auto insights from the add-indices modal', async () => {
+    mockHttpGet.mockResolvedValue({ response: { enabled: true } });
+    mockDispatch.mockImplementation(async (action: any) => {
+      if (action.type === 'ml/EXECUTE_ML_AGENT') {
+        return { response: { task_id: 'task-123' } };
+      }
+      return {};
+    });
+
+    renderIndicesManagement();
+
+    fireEvent.click(await screen.findByTestId('addNewIndicesButton'));
+    fireEvent.click(screen.getByRole('button', { name: 'Select logs-new' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('logs-new')).toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Confirm modal selection' })
+    );
+
+    await waitFor(() => {
+      expect(mockExecuteAutoCreateAgent).toHaveBeenCalledWith(
+        ['logs-new'],
+        'agent-from-modal',
+        ''
+      );
+      expect(mockStartPolling).toHaveBeenCalledWith('task-123');
+      expect(mockAddSuccess).toHaveBeenCalledWith(
+        'Started creating anomaly detectors for 1 index'
+      );
+    });
+  });
+
+  test('shows a warning for empty modal selection and an error for agent failures', async () => {
+    mockHttpGet.mockResolvedValue({ response: { enabled: true } });
+
+    renderIndicesManagement();
+
+    fireEvent.click(await screen.findByTestId('addNewIndicesButton'));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Confirm modal selection' })
+    );
+
+    expect(mockAddWarning).toHaveBeenCalledWith(
+      'Please select at least one index'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select logs-new' }));
+    await waitFor(() => {
+      expect(screen.getByText('logs-new')).toBeInTheDocument();
+    });
+
+    mockDispatch.mockImplementation(async (action: any) => {
+      if (action.type === 'ml/EXECUTE_ML_AGENT') {
+        return { error: { message: 'agent unavailable' } };
+      }
+      return {};
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Confirm modal selection' })
+    );
+
+    await waitFor(() => {
+      expect(mockAddDanger).toHaveBeenCalledWith(
+        'Failed to execute ML agent: agent unavailable'
+      );
+    });
+  });
+
+  test('handles data source selection and updates data-source-specific calls', async () => {
+    mockDataSourceEnabled = true;
+    mockHttpGet.mockResolvedValue({ response: { enabled: false } });
+
+    renderIndicesManagement('/indices?dataSourceId=ds-1');
+
+    expect(await screen.findByText('Select data source')).toBeInTheDocument();
+    expect(mockSetBreadcrumbs).toHaveBeenCalledWith([
+      expect.anything(),
+      { text: 'Daily Insights' },
+    ]);
+    expect(mockHttpGet).toHaveBeenCalledWith(
+      '/api/anomaly_detectors/insights/_status/ds-1'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select data source' }));
+
+    await waitFor(() => {
+      expect(mockGetDetectorList).toHaveBeenCalledWith(
+        expect.objectContaining({ dataSourceId: 'ds-next' })
+      );
+      expect(mockHttpGet).toHaveBeenCalledWith(
+        '/api/anomaly_detectors/insights/_status/ds-next'
+      );
+    });
+  });
+});

--- a/public/pages/DailyInsights/hooks/__tests__/useClusterClickHandler.test.ts
+++ b/public/pages/DailyInsights/hooks/__tests__/useClusterClickHandler.test.ts
@@ -1,0 +1,292 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { buildLLMPrompt, useClusterClickHandler } from '../useClusterClickHandler';
+
+const mockDispatch = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+jest.mock('../../../../redux/reducers/ad', () => ({
+  getDetector: (detectorId: string, dataSourceId: string) => ({
+    type: 'ad/GET_DETECTOR',
+    detectorId,
+    dataSourceId,
+  }),
+}));
+
+jest.mock('../../../../redux/reducers/anomalyResults', () => ({
+  searchResults: (query: any, resultIndex: string, dataSourceId: string, useResultIndex: boolean) => ({
+    type: 'results/SEARCH_RESULTS',
+    query,
+    resultIndex,
+    dataSourceId,
+    useResultIndex,
+  }),
+}));
+
+jest.mock('../../../../redux/reducers/ml', () => ({
+  predictModel: (modelId: string, body: any, dataSourceId: string) => ({
+    type: 'ml/PREDICT',
+    modelId,
+    body,
+    dataSourceId,
+  }),
+}));
+
+const cluster = {
+  indices: ['logs-*'],
+  detector_ids: ['det-1'],
+  detector_names: ['CPU detector'],
+  entities: ['service.name=checkout', 'host: api-1'],
+  model_ids: ['model-1'],
+  event_start: '2026-04-07T10:00:00.000Z',
+  event_end: '2026-04-07T10:05:00.000Z',
+  cluster_text: 'Detector found a correlated event.',
+  anomalies: [
+    {
+      model_id: 'model-1',
+      detector_id: 'det-1',
+      data_start_time: '2026-04-07T10:00:00.000Z',
+      data_end_time: '2026-04-07T10:05:00.000Z',
+    },
+  ],
+};
+
+const detectorConfig = {
+  description: 'Tracks CPU spikes in checkout traffic',
+  indices: ['logs-*'],
+  timeField: '@timestamp',
+  resultIndex: 'custom-ad-results',
+  detectionInterval: {
+    period: {
+      interval: 5,
+      unit: 'MINUTES',
+    },
+  },
+  categoryField: ['service.name'],
+  featureAttributes: [
+    {
+      featureEnabled: true,
+      featureName: 'avg_cpu',
+      aggregationQuery: {
+        avg_cpu: {
+          avg: {
+            field: 'cpu_usage',
+          },
+        },
+      },
+    },
+    {
+      featureEnabled: false,
+      featureName: 'ignored_feature',
+      aggregationQuery: {},
+    },
+  ],
+};
+
+describe('useClusterClickHandler', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('buildLLMPrompt', () => {
+    test('builds a detailed prompt from detector config and entity values', () => {
+      const prompt = buildLLMPrompt(cluster as any, { 'det-1': detectorConfig });
+      const message = JSON.parse(prompt.messages)[0].content[0].text;
+
+      expect(prompt.system_prompt).toContain('observability expert');
+      expect(message).toContain('Affected entities: checkout, api-1');
+      expect(message).toContain('Description: Tracks CPU spikes in checkout traffic');
+      expect(message).toContain('Index: logs-*');
+      expect(message).toContain('Interval: 5 MINUTES');
+      expect(message).toContain('Category: split by service.name');
+      expect(message).toContain('Features: avg_cpu (avg on cpu_usage)');
+    });
+
+    test('falls back cleanly when config and entities are missing', () => {
+      const prompt = buildLLMPrompt(
+        {
+          ...cluster,
+          detector_names: [],
+          entities: [],
+          anomalies: [],
+        } as any,
+        {}
+      );
+      const message = JSON.parse(prompt.messages)[0].content[0].text;
+
+      expect(message).toContain('No specific entities affected.');
+      expect(message).toContain('0 anomalies detected');
+      expect(message).toContain('- det-1');
+    });
+  });
+
+  test('fetches detector metadata, opens the modal, and stores anomaly entities', async () => {
+    mockDispatch.mockImplementation(async (action: any) => {
+      if (action.type === 'ad/GET_DETECTOR') {
+        return { response: detectorConfig };
+      }
+      if (action.type === 'results/SEARCH_RESULTS') {
+        return {
+          response: {
+            hits: {
+              hits: [
+                {
+                  _source: {
+                    model_id: 'model-1',
+                    entity: [
+                      { name: 'service.name', value: 'checkout' },
+                      { name: 'host', value: 'api-1' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        };
+      }
+      return {};
+    });
+
+    const resultMeta = { generated_at: '2026-04-07T10:30:00.000Z' };
+    const { result } = renderHook(() => useClusterClickHandler('ds-1'));
+
+    await act(async () => {
+      await result.current.handleClusterClick(cluster as any, resultMeta);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedEvent).toEqual({ cluster, result: resultMeta });
+    });
+
+    await waitFor(() => {
+      expect(result.current.detectorDescriptions['det-1']).toBe(detectorConfig.description);
+      expect(result.current.detectorFeatures['det-1']).toEqual(['avg_cpu']);
+      expect(result.current.detectorTimeFields['det-1']).toBe('@timestamp');
+      expect(result.current.anomalyEntities['model-1']).toEqual([
+        'service.name=checkout',
+        'host=api-1',
+      ]);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'ad/GET_DETECTOR',
+      detectorId: 'det-1',
+      dataSourceId: 'ds-1',
+    });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'results/SEARCH_RESULTS',
+        resultIndex: 'custom-ad-results',
+        dataSourceId: 'ds-1',
+        useResultIndex: true,
+      })
+    );
+  });
+
+  test('warns when detector fetch fails but still opens the selected event', async () => {
+    mockDispatch.mockImplementation(async (action: any) => {
+      if (action.type === 'ad/GET_DETECTOR') {
+        throw new Error('detector lookup failed');
+      }
+      if (action.type === 'results/SEARCH_RESULTS') {
+        return { response: { hits: { hits: [] } } };
+      }
+      return {};
+    });
+
+    const { result } = renderHook(() => useClusterClickHandler('ds-1'));
+
+    await act(async () => {
+      await result.current.handleClusterClick(cluster as any, { source: 'warning-test' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedEvent?.cluster).toEqual(cluster);
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to fetch detector config:',
+      'det-1',
+      expect.any(Error)
+    );
+    expect(result.current.detectorFeatures).toEqual({});
+  });
+
+  test('reuses cached detector data and clears caches when the data source changes', async () => {
+    const getDetectorCalls: string[] = [];
+
+    mockDispatch.mockImplementation(async (action: any) => {
+      if (action.type === 'ad/GET_DETECTOR') {
+        getDetectorCalls.push(`${action.detectorId}:${action.dataSourceId}`);
+        return { response: detectorConfig };
+      }
+      if (action.type === 'results/SEARCH_RESULTS') {
+        return {
+          response: {
+            hits: {
+              hits: [
+                {
+                  _source: {
+                    model_id: 'model-1',
+                    entity: [{ name: 'service.name', value: 'checkout' }],
+                  },
+                },
+              ],
+            },
+          },
+        };
+      }
+      return {};
+    });
+
+    const { result, rerender } = renderHook(
+      ({ dataSourceId }) => useClusterClickHandler(dataSourceId),
+      { initialProps: { dataSourceId: 'ds-1' } }
+    );
+
+    await act(async () => {
+      await result.current.handleClusterClick(cluster as any, { source: 'first' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.detectorFeatures['det-1']).toEqual(['avg_cpu']);
+      expect(result.current.anomalyEntities['model-1']).toEqual(['service.name=checkout']);
+    });
+
+    await act(async () => {
+      await result.current.handleClusterClick(cluster as any, { source: 'second' });
+    });
+
+    expect(getDetectorCalls).toEqual(['det-1:ds-1']);
+
+    rerender({ dataSourceId: 'ds-2' });
+
+    await waitFor(() => {
+      expect(result.current.selectedEvent).toBeNull();
+      expect(result.current.detectorFeatures).toEqual({});
+      expect(result.current.detectorDescriptions).toEqual({});
+      expect(result.current.detectorTimeFields).toEqual({});
+      expect(result.current.anomalyEntities).toEqual({});
+      expect(result.current.llmSummaries).toEqual({});
+    });
+
+    await act(async () => {
+      await result.current.handleClusterClick(cluster as any, { source: 'third' });
+    });
+
+    expect(getDetectorCalls).toEqual(['det-1:ds-1', 'det-1:ds-2']);
+  });
+});

--- a/public/pages/DailyInsights/hooks/useClusterClickHandler.ts
+++ b/public/pages/DailyInsights/hooks/useClusterClickHandler.ts
@@ -16,7 +16,7 @@ import { searchResults } from '../../../redux/reducers/anomalyResults';
 import { predictModel } from '../../../redux/reducers/ml';
 import { InsightCluster, ClusterAnomaly } from '../components/EventDetailModal';
 
-const buildLLMPrompt = (
+export const buildLLMPrompt = (
   cluster: InsightCluster,
   configs: Record<string, any>,
 ): Record<string, any> => {
@@ -170,6 +170,7 @@ export function useClusterClickHandler(dataSourceId: string) {
       // LLM summary disabled by default. Set to a deployed model ID to enable.
       // See LLM_MODEL_CONFIG_OPTIONS.md for configuration options.
       const modelId = '';
+      /* istanbul ignore next: disabled until a model ID is configured */
       if (modelId) {
         llmInFlightRef.current.add(cacheKey);
         setLlmLoadingKeys((prev) => new Set(prev).add(cacheKey));

--- a/public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.tsx
+++ b/public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.tsx
@@ -2,15 +2,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import React from 'react';
 import {
+  showAgentFailureToast,
+  showCompletionToasts,
   saveAgentTask,
   getAgentTask,
   updateAgentTaskState,
   extractFailedIndices,
 } from '../agentTaskStorage';
 
+const mockAddSuccess = jest.fn();
+const mockAddDanger = jest.fn();
+const mockMountReactNode = jest.fn((node) => node);
+
+jest.mock('../../../../services', () => ({
+  getNotifications: () => ({
+    toasts: {
+      addSuccess: mockAddSuccess,
+      addDanger: mockAddDanger,
+    },
+  }),
+}));
+
+jest.mock(
+  '../../../../../../../src/core/public/utils',
+  () => ({
+    mountReactNode: (node: React.ReactNode) => mockMountReactNode(node),
+  }),
+  { virtual: true }
+);
+
 describe('agentTaskStorage', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     sessionStorage.clear();
   });
 
@@ -105,9 +130,7 @@ describe('agentTaskStorage', () => {
                       { status: 'success', detectorName: 'det-1' },
                       { status: 'failed_validation', error: 'No data found' },
                     ],
-                    'index-b': [
-                      { status: 'success', detectorName: 'det-2' },
-                    ],
+                    'index-b': [{ status: 'success', detectorName: 'det-2' }],
                   }),
                 },
               ],
@@ -116,9 +139,7 @@ describe('agentTaskStorage', () => {
         },
       };
       const failures = extractFailedIndices(response);
-      expect(failures).toEqual([
-        { index: 'index-a', error: 'No data found' },
-      ]);
+      expect(failures).toEqual([{ index: 'index-a', error: 'No data found' }]);
     });
 
     test('returns empty array when all succeed', () => {
@@ -166,6 +187,76 @@ describe('agentTaskStorage', () => {
       };
       const failures = extractFailedIndices(response);
       expect(failures).toEqual([{ index: 'index-a', error: 'Unknown error' }]);
+    });
+  });
+
+  describe('showCompletionToasts', () => {
+    test('shows a generic success toast when the response has no result payload', () => {
+      showCompletionToasts({ response: {} });
+
+      expect(mockAddSuccess).toHaveBeenCalledWith('Agent task completed');
+      expect(mockAddDanger).not.toHaveBeenCalled();
+    });
+
+    test('shows success and failure summaries from the agent result payload', () => {
+      showCompletionToasts({
+        response: {
+          inference_results: [
+            {
+              output: [
+                {
+                  result: JSON.stringify({
+                    'index-a': [{ status: 'success' }, { status: 'success' }],
+                    'index-b': [{ status: 'failed', error: 'No data found' }],
+                    'index-c': [{ status: 'failed' }],
+                  }),
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(mockAddSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: '1 index configured',
+        })
+      );
+      expect(mockAddDanger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: '2 indices failed',
+          toastLifeTimeMs: 60000,
+        })
+      );
+      expect(mockMountReactNode).toHaveBeenCalledTimes(2);
+    });
+
+    test('falls back to a generic success toast for malformed result JSON', () => {
+      showCompletionToasts({
+        response: {
+          inference_results: [
+            {
+              output: [{ result: 'not-json' }],
+            },
+          ],
+        },
+      });
+
+      expect(mockAddSuccess).toHaveBeenCalledWith('Agent task completed');
+    });
+  });
+
+  describe('showAgentFailureToast', () => {
+    test('shows a retry toast with the failure message', () => {
+      showAgentFailureToast('agent timed out');
+
+      expect(mockAddDanger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Detector creation failed',
+          toastLifeTimeMs: 60000,
+        })
+      );
+      expect(mockMountReactNode).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/public/pages/DetectorsList/containers/List/__tests__/List.test.tsx
+++ b/public/pages/DetectorsList/containers/List/__tests__/List.test.tsx
@@ -517,8 +517,10 @@ describe('<DetectorList /> spec', () => {
       await user.click(getAllByRole('checkbox')[0]);
       await user.click(getByTestId('listActionsButton'));
       await user.click(getByText('Stop real-time detectors'));
-      getByText('Are you sure you want to stop the selected detectors?');
-      getByText('Stop detectors');
+      await waitFor(() => {
+        getByText('Are you sure you want to stop the selected detectors?');
+        getByText('Stop detectors');
+      });
     });
     //TODO: fix this failed UT
     test.skip('delete action always enabled', async () => {

--- a/public/pages/main/__tests__/DailyInsightsMain.test.tsx
+++ b/public/pages/main/__tests__/DailyInsightsMain.test.tsx
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  MemoryRouter as Router,
+  Route,
+  RouteComponentProps,
+} from 'react-router-dom';
+import { DailyInsightsMain } from '../DailyInsightsMain';
+import { APP_PATH } from '../../../utils/constants';
+
+jest.mock('../../DailyInsights', () => ({
+  DailyInsights: ({
+    landingDataSourceId,
+  }: {
+    landingDataSourceId?: string;
+  }) => <div>Overview route {landingDataSourceId || 'no-ds'}</div>,
+}));
+
+jest.mock('../../DailyInsights/components/IndicesManagement', () => ({
+  IndicesManagement: () => <div>Indices route</div>,
+}));
+
+jest.mock('../../../components/CoreServices/CoreServices', () => ({
+  CoreServicesConsumer: ({
+    children,
+  }: {
+    children: (core: any) => React.ReactNode;
+  }) => children({}),
+}));
+
+const renderMain = (initialEntry: string, landingPage?: string) =>
+  render(
+    <Router initialEntries={[initialEntry]}>
+      <Route
+        path="/"
+        render={(props: RouteComponentProps) => (
+          <DailyInsightsMain
+            {...props}
+            setHeaderActionMenu={jest.fn()}
+            landingPage={landingPage}
+          />
+        )}
+      />
+    </Router>
+  );
+
+describe('DailyInsightsMain', () => {
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  test('routes to overview with the current data source id', () => {
+    renderMain(`${APP_PATH.DAILY_INSIGHTS_OVERVIEW}?dataSourceId=ds-1`);
+
+    expect(screen.getByText('Overview route ds-1')).toBeInTheDocument();
+  });
+
+  test('routes to indices management', () => {
+    renderMain(APP_PATH.DAILY_INSIGHTS_INDICES);
+
+    expect(screen.getByText('Indices route')).toBeInTheDocument();
+  });
+
+  test('redirects the root path to the provided landing page', () => {
+    renderMain('/', APP_PATH.DAILY_INSIGHTS_INDICES);
+
+    expect(screen.getByText('Indices route')).toBeInTheDocument();
+  });
+
+  test('redirects the root path to overview by default', () => {
+    renderMain('/');
+
+    expect(screen.getByText('Overview route no-ds')).toBeInTheDocument();
+  });
+});

--- a/public/redux/reducers/__tests__/insights.test.ts
+++ b/public/redux/reducers/__tests__/insights.test.ts
@@ -1,0 +1,230 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MockStore } from 'redux-mock-store';
+import httpMockedClient from '../../../../test/mocks/httpClientMock';
+import { AD_NODE_API } from '../../../../utils/constants';
+import { mockedStore } from '../../utils/testUtils';
+import reducer, {
+  getInsightsResults,
+  getInsightsStatus,
+  initialInsightsState,
+  startInsightsJob,
+  stopInsightsJob,
+} from '../insights';
+
+describe('insights reducer actions', () => {
+  let store: MockStore;
+  let consoleLogSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    store = mockedStore();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  describe('getInsightsStatus', () => {
+    test('dispatches request and success actions', async () => {
+      const response = {
+        enabled: true,
+        schedule: {
+          interval: {
+            start_time: 123,
+            period: 24,
+            unit: 'hours',
+          },
+        },
+      };
+      httpMockedClient.get = jest
+        .fn()
+        .mockResolvedValue({ ok: true, response });
+
+      await store.dispatch(getInsightsStatus());
+      const actions = store.getActions();
+
+      expect(actions[0].type).toBe('insights/GET_INSIGHTS_STATUS_REQUEST');
+      expect(reducer(initialInsightsState, actions[0])).toEqual({
+        ...initialInsightsState,
+        requesting: true,
+        errorMessage: '',
+      });
+      expect(actions[1].type).toBe('insights/GET_INSIGHTS_STATUS_SUCCESS');
+      expect(reducer(initialInsightsState, actions[1])).toEqual({
+        ...initialInsightsState,
+        requesting: false,
+        enabled: true,
+        schedule: response.schedule,
+      });
+      expect(httpMockedClient.get).toHaveBeenCalledWith(
+        AD_NODE_API.INSIGHTS_STATUS
+      );
+    });
+
+    test('appends data source id and handles failure', async () => {
+      httpMockedClient.get = jest.fn().mockRejectedValue('status failed');
+
+      try {
+        await store.dispatch(getInsightsStatus('ds-1'));
+      } catch {
+        const actions = store.getActions();
+        expect(actions[1].type).toBe('insights/GET_INSIGHTS_STATUS_FAILURE');
+        expect(reducer(initialInsightsState, actions[1])).toEqual({
+          ...initialInsightsState,
+          requesting: false,
+          enabled: false,
+          schedule: null,
+          errorMessage: 'status failed',
+        });
+        expect(httpMockedClient.get).toHaveBeenCalledWith(
+          `${AD_NODE_API.INSIGHTS_STATUS}/ds-1`
+        );
+      }
+    });
+  });
+
+  describe('getInsightsResults', () => {
+    test('dispatches request and success actions with a size-limited query', async () => {
+      const results = [
+        {
+          generated_at: '2026-04-07T10:00:00.000Z',
+          clusters: [{ cluster_text: 'cluster' }],
+        },
+      ];
+      httpMockedClient.get = jest.fn().mockResolvedValue({
+        ok: true,
+        response: { results },
+      });
+
+      await store.dispatch(getInsightsResults('ds-2'));
+      const actions = store.getActions();
+
+      expect(actions[0].type).toBe('insights/GET_INSIGHTS_RESULTS_REQUEST');
+      expect(reducer(initialInsightsState, actions[0]).requesting).toBe(true);
+      expect(actions[1].type).toBe('insights/GET_INSIGHTS_RESULTS_SUCCESS');
+      expect(reducer(initialInsightsState, actions[1])).toEqual({
+        ...initialInsightsState,
+        requesting: false,
+        results,
+      });
+      expect(httpMockedClient.get).toHaveBeenCalledWith(
+        `${AD_NODE_API.INSIGHTS_RESULTS}/ds-2`,
+        {
+          query: { from: 0, size: 1 },
+        }
+      );
+    });
+
+    test('clears results on failure', async () => {
+      httpMockedClient.get = jest.fn().mockRejectedValue('results failed');
+
+      try {
+        await store.dispatch(getInsightsResults());
+      } catch {
+        const actions = store.getActions();
+        expect(actions[1].type).toBe('insights/GET_INSIGHTS_RESULTS_FAILURE');
+        expect(
+          reducer(
+            { ...initialInsightsState, results: [{ generated_at: 'old' }] },
+            actions[1]
+          )
+        ).toEqual({
+          ...initialInsightsState,
+          requesting: false,
+          results: [],
+          errorMessage: 'results failed',
+        });
+      }
+    });
+  });
+
+  describe('startInsightsJob', () => {
+    test('posts the requested frequency and clears requesting on success', async () => {
+      httpMockedClient.post = jest.fn().mockResolvedValue({ ok: true });
+
+      await store.dispatch(startInsightsJob('24h', 'ds-3'));
+      const actions = store.getActions();
+
+      expect(actions[0].type).toBe('insights/START_INSIGHTS_JOB_REQUEST');
+      expect(reducer(initialInsightsState, actions[0]).requesting).toBe(true);
+      expect(actions[1].type).toBe('insights/START_INSIGHTS_JOB_SUCCESS');
+      expect(
+        reducer({ ...initialInsightsState, requesting: true }, actions[1])
+      ).toEqual({
+        ...initialInsightsState,
+        requesting: false,
+        errorMessage: '',
+      });
+      expect(httpMockedClient.post).toHaveBeenCalledWith(
+        `${AD_NODE_API.INSIGHTS_START}/ds-3`,
+        {
+          body: JSON.stringify({ frequency: '24h' }),
+        }
+      );
+    });
+
+    test('sets errorMessage on failure', async () => {
+      httpMockedClient.post = jest.fn().mockRejectedValue('start failed');
+
+      try {
+        await store.dispatch(startInsightsJob('1h'));
+      } catch {
+        const actions = store.getActions();
+        expect(actions[1].type).toBe('insights/START_INSIGHTS_JOB_FAILURE');
+        expect(reducer(initialInsightsState, actions[1]).errorMessage).toBe(
+          'start failed'
+        );
+        expect(httpMockedClient.post).toHaveBeenCalledWith(
+          AD_NODE_API.INSIGHTS_START,
+          {
+            body: JSON.stringify({ frequency: '1h' }),
+          }
+        );
+      }
+    });
+  });
+
+  describe('stopInsightsJob', () => {
+    test('posts to the stop endpoint and clears requesting on success', async () => {
+      httpMockedClient.post = jest.fn().mockResolvedValue({ ok: true });
+
+      await store.dispatch(stopInsightsJob('ds-4'));
+      const actions = store.getActions();
+
+      expect(actions[0].type).toBe('insights/STOP_INSIGHTS_JOB_REQUEST');
+      expect(reducer(initialInsightsState, actions[0]).requesting).toBe(true);
+      expect(actions[1].type).toBe('insights/STOP_INSIGHTS_JOB_SUCCESS');
+      expect(
+        reducer({ ...initialInsightsState, requesting: true }, actions[1])
+      ).toEqual({
+        ...initialInsightsState,
+        requesting: false,
+        errorMessage: '',
+      });
+      expect(httpMockedClient.post).toHaveBeenCalledWith(
+        `${AD_NODE_API.INSIGHTS_STOP}/ds-4`
+      );
+    });
+
+    test('sets errorMessage on failure', async () => {
+      httpMockedClient.post = jest.fn().mockRejectedValue('stop failed');
+
+      try {
+        await store.dispatch(stopInsightsJob());
+      } catch {
+        const actions = store.getActions();
+        expect(actions[1].type).toBe('insights/STOP_INSIGHTS_JOB_FAILURE');
+        expect(reducer(initialInsightsState, actions[1]).errorMessage).toBe(
+          'stop failed'
+        );
+        expect(httpMockedClient.post).toHaveBeenCalledWith(
+          AD_NODE_API.INSIGHTS_STOP
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
### Description

Follow-up to #1184 to recover the project coverage drop from the Daily Insights changes.

This PR adds focused tests for the newly introduced Daily Insights paths and makes a couple of small testability-only refactors:

- Adds direct tests for EnhancedSelectionModal
- Adds direct tests for EventDetailModal
- Adds direct tests for useClusterClickHandler
- Exports a few pure helpers from EnhancedSelectionModal for isolated coverage
- Exports buildLLMPrompt for direct testing
- Marks the default-disabled LLM request block with a narrow Istanbul ignore because that path is intentionally unreachable until a model ID is configured

### Validation

Ran:
- ../../node_modules/.bin/jest --config ./test/jest.config.js public/pages/DailyInsights/components/__tests__/EnhancedSelectionModal.test.tsx public/pages/DailyInsights/components/__tests__/EventDetailModal.test.tsx public/pages/DailyInsights/hooks/__tests__/useClusterClickHandler.test.ts public/pages/DailyInsights/containers/__tests__/DailyInsights.test.tsx public/pages/DailyInsights/utils/__tests__/discoverLink.test.tsx public/pages/DailyInsights/utils/__tests__/insightCardHelpers.test.tsx public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.tsx --coverage --runInBand --collectCoverageFrom='public/pages/DailyInsights/components/EnhancedSelectionModal.tsx' --collectCoverageFrom='public/pages/DailyInsights/components/EventDetailModal.tsx' --collectCoverageFrom='public/pages/DailyInsights/hooks/useClusterClickHandler.ts'

Coverage from that run:
- EnhancedSelectionModal.tsx: 93.7% lines
- EventDetailModal.tsx: 100% lines
- useClusterClickHandler.ts: 98.9% lines

### Notes

A full local plugin-wide Jest coverage run in this workspace is currently blocked by a pre-existing dependency issue: formik is missing from the local OpenSearch-Dashboards/node_modules, so public/components/DiscoverAction/SuggestAnomalyDetector.test.tsx fails before the run can complete. The targeted Daily Insights suites above pass locally.