### PR TITLE
Add search tasks route as public API endpoint

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -8,8 +8,8 @@ env:
   TERM: xterm
   # Using main branch which includes React 18 upgrade (OpenSearch-Dashboards#11187)
   OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.5.0'
-  OPENSEARCH_PLUGIN_VERSION: '3.5.0.0'
+  OPENSEARCH_VERSION: '3.6.0'
+  OPENSEARCH_PLUGIN_VERSION: '3.6.0.0'
 
 jobs:
   tests:

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -75,6 +75,12 @@ export function registerADRoutes(apiRouter: Router, adService: AdService) {
   // routes not used in the UI, therefore no data source id
   apiRouter.post('/detectors/_search', adService.searchDetector);
 
+  // search tasks
+  apiRouter.post('/detectors/tasks/_search', adService.searchTasks);
+  apiRouter.post(
+    '/detectors/tasks/_search/{dataSourceId}',
+    adService.searchTasks
+  );
   // post search anomaly results
   apiRouter.post('/detectors/results/_search', adService.searchResults);
   apiRouter.post(
@@ -1003,6 +1009,39 @@ export default class AdService extends MDSEnabledClientService {
           ok: false,
           error: getErrorMessage(err),
         },
+      });
+    }
+  };
+
+  searchTasks = async (
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    try {
+      const { dataSourceId = '' } = request.params as { dataSourceId?: string };
+      const callWithRequest = getClientBasedOnDataSource(
+        context,
+        this.dataSourceEnabled,
+        request,
+        dataSourceId,
+        this.client
+      );
+      const response = await callWithRequest('ad.searchTasks', {
+        body: JSON.stringify(request.body),
+      });
+      return opensearchDashboardsResponse.ok({
+        body: { ok: true, response },
+      });
+    } catch (err) {
+      console.log('Anomaly detector - Unable to search tasks', err);
+      if (isIndexNotFoundError(err)) {
+        return opensearchDashboardsResponse.ok({
+          body: { ok: true, response: { hits: { total: { value: 0 }, hits: [] } } },
+        });
+      }
+      return opensearchDashboardsResponse.ok({
+        body: { ok: false, error: getErrorMessage(err) },
       });
     }
   };

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -1019,6 +1019,13 @@ export default class AdService extends MDSEnabledClientService {
     opensearchDashboardsResponse: OpenSearchDashboardsResponseFactory
   ): Promise<IOpenSearchDashboardsResponse<any>> => {
     try {
+      const aclResponse = await this.enforceWorkspaceAcl(
+        context,
+        request,
+        opensearchDashboardsResponse,
+        ['library_write', 'library_read']
+      );
+      if (aclResponse) return aclResponse;
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
       const callWithRequest = getClientBasedOnDataSource(
         context,

--- a/server/routes/ad.ts
+++ b/server/routes/ad.ts
@@ -1023,7 +1023,7 @@ export default class AdService extends MDSEnabledClientService {
         context,
         request,
         opensearchDashboardsResponse,
-        ['library_write', 'library_read']
+        ['library_read']
       );
       if (aclResponse) return aclResponse;
       const { dataSourceId = '' } = request.params as { dataSourceId?: string };
@@ -1044,7 +1044,10 @@ export default class AdService extends MDSEnabledClientService {
       console.log('Anomaly detector - Unable to search tasks', err);
       if (isIndexNotFoundError(err)) {
         return opensearchDashboardsResponse.ok({
-          body: { ok: true, response: { hits: { total: { value: 0 }, hits: [] } } },
+          body: {
+            ok: true,
+            response: { hits: { total: { value: 0 }, hits: [] } },
+          },
         });
       }
       return opensearchDashboardsResponse.ok({


### PR DESCRIPTION
### Description
Expose `ad.searchTasks` as `POST /api/anomaly_detectors/detectors/tasks/_search` so external callers can query detector task statuses directly. Previously this action was only used internally by `getDetector`/`getDetectors` to stitch task state into responses.

This enables the OpenAPI spec (PR #1197) to accurately document this endpoint.

### Issues Resolved
N/A

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.