### PR TITLE
feat: hide Suggest Anomaly Detector for AnalyticEngine data sources

### DIFF
--- a/public/utils/contextMenu/getActions.tsx
+++ b/public/utils/contextMenu/getActions.tsx
@@ -122,6 +122,8 @@ export const getSuggestAnomalyDetectorAction = () => {
     getIconType: () => ANOMALY_DETECTION_ICON,
     // suggestAD is only compatible with data sources that have certain agents configured
     isCompatible: async (context) => {
+      // Hide for AnalyticEngine data sources
+      if (context.dataSourceType === 'AnalyticEngine') return false;
       if (
         context.datasetId &&
         (context.datasetType === DEFAULT_DATA.SET_TYPES.INDEX_PATTERN ||


### PR DESCRIPTION
### Description
Hide the "Suggest anomaly detector" action when the current data source is AnalyticEngine, which doesn't support OpenSearch DSL.

- Added `context.dataSourceType === 'AnalyticEngine'` check in `getSuggestAnomalyDetectorAction` `isCompatible`

### Issues Resolved
Refs opensearch-project/OpenSearch-Dashboards#11882
Related: opensearch-project/OpenSearch-Dashboards#12083
Depends on: opensearch-project/dashboards-assistant#689

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).