### PR TITLE
Filter AnalyticEngine data sources from AD and Forecasting pickers

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -28,6 +28,7 @@
   "server": true,
   "ui": true,
   "supportedOSDataSourceVersions": ">=2.9.0",
+  "unsupportedOSDataSourceEngineTypes": ["AnalyticEngine"],
   "requiredOSDataSourcePlugins": [
     "opensearch-anomaly-detection"
   ]

--- a/public/pages/utils/__tests__/helpers.test.ts
+++ b/public/pages/utils/__tests__/helpers.test.ts
@@ -19,6 +19,7 @@ import {
 
 jest.mock('../../../../opensearch_dashboards.json', () => ({
   supportedOSDataSourceVersions: '>=2.9.0',
+  unsupportedOSDataSourceEngineTypes: ['AnalyticEngine'],
   requiredOSDataSourcePlugins: ['opensearch-anomaly-detection'],
 }));
 
@@ -219,11 +220,13 @@ describe('helpers', () => {
   describe('isDataSourceCompatible', () => {
     const mockDataSource = (
       version: string,
-      plugins: string[] = ['opensearch-anomaly-detection']
+      plugins: string[] = ['opensearch-anomaly-detection'],
+      dataSourceEngineType?: string
     ) => ({
       attributes: {
         dataSourceVersion: version,
         installedPlugins: plugins,
+        dataSourceEngineType,
       },
     });
 
@@ -251,16 +254,27 @@ describe('helpers', () => {
       const dataSource = mockDataSource('3.1.0', ['some-other-plugin']);
       expect(isDataSourceCompatible(dataSource as any)).toBe(false);
     });
+
+    test('should be incompatible for AnalyticEngine', () => {
+      const dataSource = mockDataSource(
+        '3.1.0',
+        ['opensearch-anomaly-detection'],
+        'AnalyticEngine'
+      );
+      expect(isDataSourceCompatible(dataSource as any)).toBe(false);
+    });
   });
 
   describe('isForecastingDataSourceCompatible', () => {
     const mockDataSource = (
       version: string,
-      plugins: string[] = ['opensearch-anomaly-detection']
+      plugins: string[] = ['opensearch-anomaly-detection'],
+      dataSourceEngineType?: string
     ) => ({
       attributes: {
         dataSourceVersion: version,
         installedPlugins: plugins,
+        dataSourceEngineType,
       },
     });
 
@@ -286,6 +300,15 @@ describe('helpers', () => {
 
     test('should be incompatible if required plugin is missing', () => {
       const dataSource = mockDataSource('3.1.0', ['some-other-plugin']);
+      expect(isForecastingDataSourceCompatible(dataSource as any)).toBe(false);
+    });
+
+    test('should be incompatible for AnalyticEngine', () => {
+      const dataSource = mockDataSource(
+        '3.1.0',
+        ['opensearch-anomaly-detection'],
+        'AnalyticEngine'
+      );
       expect(isForecastingDataSourceCompatible(dataSource as any)).toBe(false);
     });
   });

--- a/public/pages/utils/helpers.ts
+++ b/public/pages/utils/helpers.ts
@@ -287,6 +287,15 @@ export const isDataSourceCompatible = (
   dataSource: SavedObject<DataSourceAttributes>
 ) => {
   if (
+    pluginManifest.hasOwnProperty('unsupportedOSDataSourceEngineTypes') &&
+    pluginManifest.unsupportedOSDataSourceEngineTypes?.includes(
+      dataSource.attributes.dataSourceEngineType ?? ''
+    )
+  ) {
+    return false;
+  }
+
+  if (
     pluginManifest.hasOwnProperty('requiredOSDataSourcePlugins') &&
     !pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
       dataSource.attributes.installedPlugins?.includes(plugin)


### PR DESCRIPTION
## Summary
- declare AnalyticEngine as an unsupported engine type for the AD Dashboards plugin
- apply the manifest-driven unsupported engine filter in the shared AD data source compatibility helper
- add AD and Forecasting helper coverage for AnalyticEngine filtering

## Verification
- Confirmed the touched diff/files do not reference `mustang`
- `PATH=/Users/hnyng/.nvm/versions/node/v20.19.4/bin:$PATH yarn test:jest public/pages/utils/__tests__/helpers.test.ts --runInBand`
- Local sanity: created `AnalyticEngine Test Domain` saved object; it appeared in Data Sources management and was hidden from AD and Forecasting data source dropdowns

## Notes
- Left the pre-existing local `yarn.lock` modification unstaged and out of this PR.