### PR TITLE
Filter AnalyticEngine data sources from AD and Forecasting pickers

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -28,6 +28,7 @@
   "server": true,
   "ui": true,
   "supportedOSDataSourceVersions": ">=2.9.0",
+  "unsupportedOSDataSourceEngineTypes": ["AnalyticEngine"],
   "requiredOSDataSourcePlugins": [
     "opensearch-anomaly-detection"
   ]

--- a/public/pages/utils/__tests__/helpers.test.ts
+++ b/public/pages/utils/__tests__/helpers.test.ts
@@ -19,6 +19,7 @@ import {
 
 jest.mock('../../../../opensearch_dashboards.json', () => ({
   supportedOSDataSourceVersions: '>=2.9.0',
+  unsupportedOSDataSourceEngineTypes: ['AnalyticEngine'],
   requiredOSDataSourcePlugins: ['opensearch-anomaly-detection'],
 }));
 
@@ -219,11 +220,13 @@ describe('helpers', () => {
   describe('isDataSourceCompatible', () => {
     const mockDataSource = (
       version: string,
-      plugins: string[] = ['opensearch-anomaly-detection']
+      plugins: string[] = ['opensearch-anomaly-detection'],
+      dataSourceEngineType?: string
     ) => ({
       attributes: {
         dataSourceVersion: version,
         installedPlugins: plugins,
+        dataSourceEngineType,
       },
     });
 
@@ -251,16 +254,27 @@ describe('helpers', () => {
       const dataSource = mockDataSource('3.1.0', ['some-other-plugin']);
       expect(isDataSourceCompatible(dataSource as any)).toBe(false);
     });
+
+    test('should be incompatible for AnalyticEngine', () => {
+      const dataSource = mockDataSource(
+        '3.1.0',
+        ['opensearch-anomaly-detection'],
+        'AnalyticEngine'
+      );
+      expect(isDataSourceCompatible(dataSource as any)).toBe(false);
+    });
   });
 
   describe('isForecastingDataSourceCompatible', () => {
     const mockDataSource = (
       version: string,
-      plugins: string[] = ['opensearch-anomaly-detection']
+      plugins: string[] = ['opensearch-anomaly-detection'],
+      dataSourceEngineType?: string
     ) => ({
       attributes: {
         dataSourceVersion: version,
         installedPlugins: plugins,
+        dataSourceEngineType,
       },
     });
 
@@ -286,6 +300,15 @@ describe('helpers', () => {
 
     test('should be incompatible if required plugin is missing', () => {
       const dataSource = mockDataSource('3.1.0', ['some-other-plugin']);
+      expect(isForecastingDataSourceCompatible(dataSource as any)).toBe(false);
+    });
+
+    test('should be incompatible for AnalyticEngine', () => {
+      const dataSource = mockDataSource(
+        '3.1.0',
+        ['opensearch-anomaly-detection'],
+        'AnalyticEngine'
+      );
       expect(isForecastingDataSourceCompatible(dataSource as any)).toBe(false);
     });
   });

--- a/public/pages/utils/helpers.ts
+++ b/public/pages/utils/helpers.ts
@@ -287,6 +287,15 @@ export const isDataSourceCompatible = (
   dataSource: SavedObject<DataSourceAttributes>
 ) => {
   if (
+    pluginManifest.hasOwnProperty('unsupportedOSDataSourceEngineTypes') &&
+    pluginManifest.unsupportedOSDataSourceEngineTypes?.includes(
+      dataSource.attributes.dataSourceEngineType ?? ''
+    )
+  ) {
+    return false;
+  }
+
+  if (
     pluginManifest.hasOwnProperty('requiredOSDataSourcePlugins') &&
     !pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
       dataSource.attributes.installedPlugins?.includes(plugin)


### PR DESCRIPTION
### Description

Declares AnalyticEngine as an unsupported data source engine type for this plugin, per the campaign in https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11882 and the reference implementation in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12023.


https://github.com/user-attachments/assets/86e5c7ad-6c9a-4d3a-9318-ffe483237215



### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
