### PR TITLE
Adopt ESLint 10 / flat config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# CHANGELOG
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased 3.x](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/compare/main...HEAD)
+### Features
+### Enhancements
+### Bug Fixes
+### Infrastructure
+### Documentation
+### Maintenance
+- Adopt ESLint 10 / flat config ([#1223](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1223))
+### Refactoring

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const osdConfig = require('@elastic/eslint-config-kibana');
+const { eui } = require('@elastic/eslint-config-kibana/extras');
+
+module.exports = [...osdConfig, ...eui];

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "brace": "0.11.1",
     "formik": "^2.2.5",
     "plotly.js-dist": "^2.29.1",
-    "prettier": "^2.1.1",
     "react-plotly.js": "^2.6.0",
     "react-redux": "^8.1.0",
     "reselect": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@types/react-plotly.js": "^2.6.0",
     "@types/redux-mock-store": "^1.0.6",
     "babel-polyfill": "^6.26.0",
-    "eslint-plugin-no-unsanitized": "^3.0.2",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "jest-canvas-mock": "2.5.1",
     "lint-staged": "^9.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,11 +623,6 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
-eslint-plugin-no-unsanitized@^3.0.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-3.2.0.tgz#a74239ae51363a5edbe6920eb34fe09aab925a9c"
-  integrity sha512-92opuXbjWmXcod94EyCKhp36V1QHLM/ArAST2ssgKOojALne0eZvSPfrg4oyr0EwTXvy0RJNe/Tkm33VkDUrKQ==
-
 eslint-plugin-prefer-object-spread@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-object-spread/-/eslint-plugin-prefer-object-spread-1.2.1.tgz#27fb91853690cceb3ae6101d9c8aecc6a67a402c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,11 +1415,6 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
-prettier@^2.1.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
### Description

Adopts ESLint 10 with the new flat config format. Adds a flat `eslint.config.js` that spreads `@elastic/eslint-config-kibana` plus the EUI config, and removes the Prettier 2 pin from `package.json` (Prettier is now inherited from OSD core). This is a config-only change with no source reformatting.

### Issues Resolved

Closes #1222

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
