### PR TITLE
Match jest-canvas-mock version with core

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -43,7 +43,7 @@ jobs:
           plugin_name: anomaly-detection-dashboards-plugin
           built_plugin_name: anomaly-detection-dashboards
           install_zip: true
-          snapshot: false
+          snapshot: true
 
       - name: Start the binary
         run: | 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Documentation
 ### Maintenance
 - Adopt ESLint 10 / flat config ([#1223](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1223))
+- Match jest-canvas-mock version with core ([#1229](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1229))
 ### Refactoring

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/redux-mock-store": "^1.0.6",
     "babel-polyfill": "^6.26.0",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
-    "jest-canvas-mock": "2.5.1",
+    "jest-canvas-mock": "2.5.8",
     "lint-staged": "^9.2.0",
     "moment": "^2.24.0",
     "redux-mock-store": "^1.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,10 +1045,10 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-jest-canvas-mock@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.5.1.tgz#81509af658ef485e9a1bf39c64e06761517bdbcb"
-  integrity sha512-IVnRiz+v4EYn3ydM/pBo8GW/J+nU/Hg5gHBQQOUQhdRyNfvHnabB8ReqARLO0p+kvQghqr4V0tA92CF3JcUSRg==
+jest-canvas-mock@2.5.8:
+  version "2.5.8"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.5.8.tgz#f9b44e2957dd6be1e2af11f3ce5cccf97bc13993"
+  integrity sha512-RUZRaFHCnLjg0/UAodCai5PTsa7kQI1rUXE5wsQu9f2315dh2YSN7/i3fObTycs7PO09DLSiGXiJTALYIw2yuw==
   dependencies:
     cssfontparser "^1.2.1"
     moo-color "^1.0.2"


### PR DESCRIPTION
### Description
Bumps `jest-canvas-mock` from `2.5.1` to `2.5.8` in `package.json`/`yarn.lock` to match the version pinned in OpenSearch-Dashboards core.

This plugin is built as a workspace under `OpenSearch-Dashboards/plugins/`, and the mismatched exact-pinned version between this plugin and core causes a dependency resolution conflict during `yarn osd bootstrap`, which is currently blocking Dashboards component plugin builds and the opensearch-3.8.0 release candidate creation.

Note: this same conflict was previously fixed in #1202 but has since regressed back to 2.5.1.

### Issues Resolved
Unblocks opensearch-3.8.0 RC creation (Dashboards component plugin build failure due to jest-canvas-mock version conflict).

### Check List
- [x] New functionality includes testing.
  - N/A — dependency version bump only, no functional changes
- [x] All tests pass
- [ ] New functionality has been documented.
  - N/A
- [ ] New functionality has javadoc added
  - N/A
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.