### PR TITLE
Address dependency CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "resolutions": {
     "minimatch": "^10.2.3",
     "bn.js": "^5.2.3",
-    "brace-expansion": "^5.0.2",
+    "brace-expansion": "^5.0.8",
+    "js-yaml": "^3.15.0",
     "elliptic": "^6.6.1",
     "@babel/runtime": "^7.26.10",
     "**/ansi-regex": "^5.0.1",

--- a/public/pages/Dashboard/Components/__tests__/__snapshots__/AnomaliesLiveCharts.test.tsx.snap
+++ b/public/pages/Dashboard/Components/__tests__/__snapshots__/AnomaliesLiveCharts.test.tsx.snap
@@ -207,23 +207,31 @@ exports[`<AnomaliesLiveChart /> spec AnomaliesLiveChart with Sample anomaly data
             style="height: 200px; width: 100%; opacity: 1;"
           >
             <div
+              aria-roledescription="visualization"
               class="echChart"
+              data-testid="echChart"
+              role="graphics-document"
+              style="width: 100%; height: 100%;"
             >
               <div
-                class="echChartBackground"
-                style="background-color: transparent;"
-              />
-              <div
-                class="echChartStatus"
-                data-ech-render-complete="false"
-                data-ech-render-count="0"
-              />
-              <div
-                class="echChartResizer"
-              />
-              <div
-                class="echContainer"
-              />
+                class="echChartContent"
+              >
+                <div
+                  class="echChartBackground"
+                  style="background-color: transparent;"
+                />
+                <div
+                  class="echChartStatus"
+                  data-ech-render-complete="false"
+                  data-ech-render-count="0"
+                />
+                <div
+                  class="echChartResizer"
+                />
+                <div
+                  class="echContainer"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/public/pages/DetectorsList/containers/List/__tests__/List.test.tsx
+++ b/public/pages/DetectorsList/containers/List/__tests__/List.test.tsx
@@ -144,19 +144,15 @@ describe('<DetectorList /> spec', () => {
       expect(queryByText('index_30')).toBeNull();
 
       // Navigate to next page
-      await waitFor(async () =>
-        await user.click(getAllByTestId('pagination-button-next')[0])
-      );
-      getByText('detector_name_30');
+      await user.click(getAllByTestId('pagination-button-next')[0]);
+      await waitFor(() => getByText('detector_name_30'));
       getByText('index_30');
       expect(queryByText('detector_name_0')).toBeNull();
       expect(queryByText('index_0')).toBeNull();
 
       // Navigate to previous page
-      await waitFor(async () =>
-        await user.click(getAllByTestId('pagination-button-previous')[0])
-      );
-      getByText('detector_name_0');
+      await user.click(getAllByTestId('pagination-button-previous')[0]);
+      await waitFor(() => getByText('detector_name_0'));
       expect(queryByText('detector_name_30')).toBeNull();
     }, 20000);
     test('sorting functionality', async () => {

--- a/test/polyfills.ts
+++ b/test/polyfills.ts
@@ -13,3 +13,21 @@
 import { MutationObserver } from './polyfills/mutationObserver';
 
 Object.defineProperty(window, 'MutationObserver', { value: MutationObserver });
+
+// jsdom does not implement ResizeObserver, but chart components construct one.
+class ResizeObserverMock {
+  observe() {
+    return undefined;
+  }
+
+  unobserve() {
+    return undefined;
+  }
+
+  disconnect() {
+    return undefined;
+  }
+}
+
+Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserverMock });
+Object.defineProperty(globalThis, 'ResizeObserver', { value: ResizeObserverMock });

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,9 +224,9 @@ bn.js@^4.0.0, bn.js@^4.11.9, bn.js@^5.2.1, bn.js@^5.2.2, bn.js@^5.2.3:
   integrity sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==
 
 brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
     balanced-match "^4.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@ bn.js@^4.0.0, bn.js@^4.11.9, bn.js@^5.2.1, bn.js@^5.2.2, bn.js@^5.2.3:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.3.tgz#16a9e409616b23fef3ccbedb8d42f13bff80295e"
   integrity sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==
 
-brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
-  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
+brace-expansion@^5.0.5, brace-expansion@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -1058,10 +1058,10 @@ jest-canvas-mock@2.5.8:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+js-yaml@^3.13.1, js-yaml@^3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Summary
- Updates `brace-expansion` to `5.0.8` to resolve CVE-2026-45149 / GHSA-jxxr-4gwj-5jf2 plus newer brace-expansion advisories CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp and CVE-2026-14257 / GHSA-mh99-v99m-4gvg.
- Adds a Yarn resolution for `js-yaml@3.15.0` to resolve CVE-2026-53550 / GHSA-h67p-54hq-rp68 and CVE-2026-59869 / GHSA-52cp-r559-cp3m through the existing `lint-staged > cosmiconfig` dependency path.
- Adds a shared Jest ResizeObserver mock so chart tests continue to render in jsdom after the current Dashboards test/runtime environment stopped providing that global.
- Updates the affected live-chart snapshot for the current @elastic/charts DOM wrapper once the chart can render again.
- Stabilizes the detector list pagination test by clicking once and waiting for the rendered page state instead of retrying async user interactions inside waitFor.

## Root cause
The original advisory for `brace-expansion@5.0.5` applied the `max` option too late when expanding large numeric ranges, causing avoidable CPU and memory use before truncation.

A follow-up audit on July 24, 2026 found the current advisory feed also flags `brace-expansion@5.0.6` for newer DoS advisories, with `5.0.8` as the patched release, and `js-yaml@3.14.2` for YAML merge-key CPU exhaustion advisories, with `3.15.0` as the compatible patched 3.x release.

The first CI run also exposed a base-environment test issue unrelated to the dependency bump: chart components construct ResizeObserver, but jsdom does not implement ResizeObserver. The Linux and macOS unit jobs failed with `ReferenceError: ResizeObserver is not defined` across chart test suites. After adding the mock, those failures collapsed to one expected snapshot update in `AnomaliesLiveCharts`.

A later macOS run exposed a detector-list pagination test timing issue: the test retried `user.click` inside `waitFor`, which can replay the click and race the pagination state. The test now performs the interaction once and waits on the visible row assertion.

## Validation
- `yarn why brace-expansion` resolves `brace-expansion@5.0.8`
- `yarn why js-yaml` resolves `js-yaml@3.15.0`
- `yarn audit --json` reports 0 vulnerabilities
- `yarn audit --groups dependencies --json` reports 0 vulnerabilities
- `yarn install --ignore-scripts --frozen-lockfile`
- `git diff --check`

Note: targeted Jest commands cannot be run in this standalone checkout because the local path does not include the OpenSearch Dashboards `../../node_modules` layout that CI creates.
