### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,33 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".html",
+    ".config",
+    ".png",
+    ".svg",
+    ".ico",
+    ".gz",
+    ".lock",
+    ".snap",
+    ".git",
+    ".gitignore",
+    ".prettierrc",
+    ".prettierignore",
+    ".whitesource",
+    "node_modules/",
+    "build/",
+    "dist/",
+    "target/",
+    "**/__snapshots__/",
+    "*.d.ts",
+    "THIRD-PARTY"
+  ]
+}

--- a/global-setup.js
+++ b/global-setup.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export default () => {
   process.env.TZ = 'UTC';
 };

--- a/public/pages/ConfigureForecastModel/components/StorageSettings/StorageSettings.tsx
+++ b/public/pages/ConfigureForecastModel/components/StorageSettings/StorageSettings.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/public/pages/ConfigureForecastModel/index.scss
+++ b/public/pages/ConfigureForecastModel/index.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .unit-badge {
   height:32px;
   line-height: 30px;

--- a/public/pages/ConfigureModel/components/FeatureAccordion/styles.scss
+++ b/public/pages/ConfigureModel/components/FeatureAccordion/styles.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .euiFormAccordion_button {
   padding: 20px 16px 0 0;
 }

--- a/public/pages/ConfigureModel/components/SuppressionRules/__tests__/SuppressionRules.test.tsx
+++ b/public/pages/ConfigureModel/components/SuppressionRules/__tests__/SuppressionRules.test.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/public/pages/ConfigureModel/containers/__tests__/SampleAnomalies.test.tsx
+++ b/public/pages/ConfigureModel/containers/__tests__/SampleAnomalies.test.tsx
@@ -1,4 +1,7 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 import React from 'react';
 import { Provider } from 'react-redux';

--- a/public/pages/DailyInsights/components/__tests__/EnhancedSelectionModal.test.tsx
+++ b/public/pages/DailyInsights/components/__tests__/EnhancedSelectionModal.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/components/__tests__/EventDetailModal.test.tsx
+++ b/public/pages/DailyInsights/components/__tests__/EventDetailModal.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/components/__tests__/IndicesManagement.test.tsx
+++ b/public/pages/DailyInsights/components/__tests__/IndicesManagement.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/hooks/__tests__/useAgentTaskPolling.test.ts
+++ b/public/pages/DailyInsights/hooks/__tests__/useAgentTaskPolling.test.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/hooks/__tests__/useClusterClickHandler.test.ts
+++ b/public/pages/DailyInsights/hooks/__tests__/useClusterClickHandler.test.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/hooks/useAgentTaskPolling.ts
+++ b/public/pages/DailyInsights/hooks/useAgentTaskPolling.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.tsx
+++ b/public/pages/DailyInsights/utils/__tests__/agentTaskStorage.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/utils/__tests__/discoverLink.test.tsx
+++ b/public/pages/DailyInsights/utils/__tests__/discoverLink.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/utils/__tests__/insightCardHelpers.test.tsx
+++ b/public/pages/DailyInsights/utils/__tests__/insightCardHelpers.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/utils/agentTaskStorage.tsx
+++ b/public/pages/DailyInsights/utils/agentTaskStorage.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DailyInsights/utils/discoverLink.ts
+++ b/public/pages/DailyInsights/utils/discoverLink.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * Builds a Discover deep-link URL for a given anomaly.

--- a/public/pages/DailyInsights/utils/insightCardHelpers.ts
+++ b/public/pages/DailyInsights/utils/insightCardHelpers.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/pages/DetectorConfig/containers/__tests__/utils/featureQueries.ts
+++ b/public/pages/DetectorConfig/containers/__tests__/utils/featureQueries.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export const featureQuery1 = {
   featureName: 'value',
   featureEnabled: true,

--- a/public/pages/ForecastDetail/components/ForecastChart/CustomTooltip.tsx
+++ b/public/pages/ForecastDetail/components/ForecastChart/CustomTooltip.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { TooltipValue } from '@elastic/charts';
 import moment from 'moment';
 import React from 'react';

--- a/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
+++ b/public/pages/ForecastDetail/components/ForecastChart/ForecastChart.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/public/pages/ForecastDetail/components/ForecastChart/InitializingText.tsx
+++ b/public/pages/ForecastDetail/components/ForecastChart/InitializingText.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/public/pages/ForecastDetail/index.scss
+++ b/public/pages/ForecastDetail/index.scss
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .display-option-badge {
     height: 40px;
     line-height: 30px;

--- a/public/pages/ReviewAndCreate/components/SuppressionRulesModal/SuppressionRulesModal.tsx
+++ b/public/pages/ReviewAndCreate/components/SuppressionRulesModal/SuppressionRulesModal.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
 import { EuiModal, EuiModalBody, EuiModalHeader, EuiModalHeaderTitle, EuiText, EuiSpacer } from '@elastic/eui';
 

--- a/public/pages/main/__tests__/DailyInsightsMain.test.tsx
+++ b/public/pages/main/__tests__/DailyInsightsMain.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/redux/reducers/__tests__/insights.test.ts
+++ b/public/redux/reducers/__tests__/insights.test.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/redux/reducers/__tests__/ml.test.ts
+++ b/public/redux/reducers/__tests__/ml.test.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/public/redux/reducers/ml.ts
+++ b/public/redux/reducers/ml.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/server/cluster/ad/mlPlugin.ts
+++ b/server/cluster/ad/mlPlugin.ts
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)


### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
