### PR TITLE
Use locked Cypress dependency in remote integration tests

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Install Cypress
         run: |
-          npm install cypress --save-dev
+          npm ci
         shell: bash
         working-directory: opensearch-dashboards-functional-test
 


### PR DESCRIPTION
### Description

Replace `npm install cypress --save-dev` with `npm ci` in the remote integration test workflow. This makes the functional-test checkout use its lockfile-pinned Cypress version instead of installing the latest Cypress release, which no longer supports the tests’ `Cypress.env()` usage.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing. (No new functionality; workflow-only change.)
  - [ ] All tests pass. (The Jest suite could not start locally because `jest-location-mock` is unavailable.)
- [x] New functionality has been documented. (No user-facing functionality.)
- [x] Commits are signed per the DCO using `--signoff`

### Validation

- YAML parse passed
- Prettier check passed
- `git diff --check` passed
- Remote Cypress integration tests were not run locally because they require the external OpenSearch/OpenSearch Dashboards stack

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.